### PR TITLE
Move all extended tsconfig settings to react-app

### DIFF
--- a/packages/react-app/tsconfig.json
+++ b/packages/react-app/tsconfig.json
@@ -1,20 +1,37 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "lib": [
       "dom",
       "dom.iterable",
       "esnext"
     ],
+    "target": "es6",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
-    "moduleResolution": "node",
     "resolveJsonModule": true,
-    "isolatedModules": false,
+    "isolatedModules": true,
     "noEmit": true,
+    "alwaysStrict": true,
+    "experimentalDecorators": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noUnusedParameters": true,
+    "noUnusedLocals": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "removeComments": true,
+    "preserveConstEnums": true,
+    "allowJs": false,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
     "jsx": "preserve",
-    "typeRoots": ["./types", "node_modules/@types"]
+    "typeRoots": [
+      "./types",
+      "node_modules/@types"
+    ]
   },
   "include": [
     "src"


### PR DESCRIPTION
Note this might be a temporary workaround.

Reason: CRA automatically updates `tsconfig.json` and forces `isolatedModules: true` config. (see https://github.com/facebook/create-react-app/issues/5508)

We have the react app's tsconfig extend our base sdk config, which has `"declaration": true` set. That couldn't co-exist with `isolatedModules`.

This has resulted: 1, TypeScript would complain about the config. 2, if we remove `isolatedModules` CRA adds it back and changes the tsconfig file every time we run the app.

Until we have a more elegant tsconfig setup let have all compiler options in the tsconfig.json file (some of them might be the same to default value but I didn't bother double checking them).