### PR TITLE
Manage window properties/state

### DIFF
--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -20,7 +20,9 @@
     "package-mac": "electron-builder --mac --project ../../ -c packages/neuron-wallet/electron-builder.yml -c.extraMetadata.main=packages/neuron-wallet/dist/main.js",
     "package-linux": "electron-builder --linux --project ../../ -c packages/neuron-wallet/electron-builder.yml -c.extraMetadata.main=packages/neuron-wallet/dist/main.js"
   },
-  "dependencies": {},
+  "dependencies": {
+    "electron-window-state": "^5.0.3"
+  },
   "devDependencies": {
     "@types/electron": "^1.6.10",
     "electron": "^4.0.1",

--- a/packages/neuron-wallet/src/main.ts
+++ b/packages/neuron-wallet/src/main.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, Menu } from 'electron'
+import windowStateKeeper from 'electron-window-state'
 import * as path from 'path'
 import listenToChannel from './IPCChannel'
 import menuTemplate from './utils/menuTemplate'
@@ -14,9 +15,16 @@ const ENTRY = {
 
 listenToChannel()
 function createWindow() {
+  const windowState = windowStateKeeper({
+    defaultWidth: 1366,
+    defaultHeight: 768,
+  })
+
   mainWindow = new BrowserWindow({
-    width: 800,
-    height: 600,
+    x: windowState.x,
+    y: windowState.y,
+    width: windowState.width,
+    height: windowState.height,
     minWidth: 800,
     minHeight: 600,
     show: false,
@@ -24,6 +32,8 @@ function createWindow() {
       devTools: NODE_ENV === 'development',
     },
   })
+
+  windowState.manage(mainWindow)
 
   Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate))
 

--- a/packages/neuron-wallet/src/main.ts
+++ b/packages/neuron-wallet/src/main.ts
@@ -51,6 +51,12 @@ function createWindow() {
 
 app.on('ready', createWindow)
 
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit()
+  }
+})
+
 app.on('activate', () => {
   if (mainWindow === null) {
     createWindow()

--- a/packages/neuron-wallet/src/main.ts
+++ b/packages/neuron-wallet/src/main.ts
@@ -19,6 +19,7 @@ function createWindow() {
     height: 600,
     minWidth: 800,
     minHeight: 600,
+    show: false,
     webPreferences: {
       devTools: NODE_ENV === 'development',
     },
@@ -30,6 +31,11 @@ function createWindow() {
 
   mainWindow.on('closed', () => {
     mainWindow = null
+  })
+
+  mainWindow.on('ready-to-show', () => {
+    mainWindow!.show()
+    mainWindow!.focus()
   })
 }
 


### PR DESCRIPTION
* Remember and restore window position and size.
* Set default window size to 1366x768, which covers most desktop computers.
* Hook `window-all-closed` event though we don't have multiple windows.