### PR TITLE
feat(neuron-ui): add stateless dialog

### DIFF
--- a/packages/neuron-ui/src/components/Dialog/index.tsx
+++ b/packages/neuron-ui/src/components/Dialog/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { createPortal } from 'react-dom'
+import styled from 'styled-components'
+
+const Dialog = styled.dialog.attrs({
+  open: true,
+})`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.7);
+`
+
+export default ({
+  children,
+  open,
+}: {
+  children?: React.ReactNode | string
+  open?: boolean
+}) => {
+  if (open && children) {
+    return createPortal(<Dialog>{children}</Dialog>, document.querySelector(
+      '.modal',
+    ) as HTMLElement)
+  }
+  return null
+}


### PR DESCRIPTION
This dialog could be used in this method:

```javascript
<Dialog open>
    <div>My Dialog Content</div>
</Dialog>
```

And this is a rough one, we should add more interaction like `backdrop` click or sth on it.
