### PR TITLE
feat: add package naming conventions

### DIFF
--- a/packages/neuron-wallet/electron-builder.yml
+++ b/packages/neuron-wallet/electron-builder.yml
@@ -1,7 +1,7 @@
 appId: com.nervos.neuron
 copyright: Copyright (C) 2019 Nervos Foundation. All rights reserved
 productName: Neuron
-artifactName: "${productName}-${version}.${ext}"
+
 
 asar: false
 
@@ -15,14 +15,20 @@ files:
   - packages/neuron-wallet/dist/
 
 win:
-  target: nsis
+  artifactName: "${productName}-${version}-${os}-${arch}.${ext}"
   icon: packages/neuron-wallet/assets/images/icon.ico
+  target:
+    - target: nsis
+      arch:
+        - x64
 
 mac:
+  artifactName: "${productName}-${version}-${os}.${ext}"
   category: blockchain_wallet
   icon: packages/neuron-wallet/assets/images/icon.icns
 
 linux:
+  artifactName: "${productName}-${version}-${os}-${arch}.${ext}"
   category: Development
   icon: packages/neuron-wallet/assets/images/icon.png
   target:

--- a/packages/neuron-wallet/electron-builder.yml
+++ b/packages/neuron-wallet/electron-builder.yml
@@ -1,6 +1,7 @@
 appId: com.nervos.neuron
 copyright: Copyright (C) 2019 Nervos Foundation. All rights reserved
 productName: Neuron
+artifactName: "${productName}-${version}.${ext}"
 
 asar: false
 


### PR DESCRIPTION
Generally, electron-builder set default naming conventions on three platforms and different from each other.
And I'm not found common naming conventions, like `* ${productName}-${version}.${ext}` `${productName}-Setup-${version}-${arch}.${ext}`  and so on.
So, I think we can decide what we should custom package name.