### PR TITLE
chore(deps): require node 11.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - '10.15'
+  - '11.10'
 
 cache:
   - npm

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">= 10.15",
+    "node": ">= 11.10",
     "yarn": ">= 1.12"
   },
   "workspaces": [


### PR DESCRIPTION
Which fixes tiny-secp256k1 symbol not found issue on macOS.

Fix #77.