### PR TITLE
feat(neuron-ui): pass content props from MainContent container to spe…

### DIFF
--- a/packages/neuron-ui/src/components/Router/RoutesWithProps.tsx
+++ b/packages/neuron-ui/src/components/Router/RoutesWithProps.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Route } from 'react-router-dom'
+import { CustomRoute } from '.'
+
+/**
+ * @name RoutesWithProps
+ * @description with this Component, props from parent will be passed to component in Route
+ */
+const RoutesWithProps = ({ contents, ...rest }: { contents: CustomRoute[] }) => (
+  <>
+    {contents.map(({ component: Component, ...restContent }) => {
+      return (
+        <Route
+          key={restContent.name}
+          {...restContent}
+          render={(routeProps: any) => <Component {...routeProps} {...rest} />}
+        />
+      )
+    })}
+  </>
+)
+
+export default RoutesWithProps

--- a/packages/neuron-ui/src/components/Router/index.tsx
+++ b/packages/neuron-ui/src/components/Router/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
-import { BrowserRouter as Router, Route } from 'react-router-dom'
+import { BrowserRouter as Router } from 'react-router-dom'
 import { Routes } from '../../utils/const'
+
+import RoutesWithProps from './RoutesWithProps'
 import MainContent from '../../containers/MainContent'
 import Notification from '../../containers/Notification'
 import Sidebar from '../../containers/Sidebar'
@@ -14,7 +16,7 @@ import Addresses from '../Addresses'
 import Settings from '../Settings'
 import WalletWizard, { ImportWallet, CreateWallet } from '../WalletWizard'
 
-interface CustomRoute {
+export interface CustomRoute {
   path: string
   name: string
   exact?: boolean
@@ -105,14 +107,12 @@ export const mainContents: CustomRoute[] = [
   },
 ]
 
-const renderComp = (route: CustomRoute) => <Route key={route.name} {...route} />
-
 const CustomRouter = () => (
   <Router>
     <>
-      {containers.map(renderComp)}
+      <RoutesWithProps contents={containers} />
       <MainContent>
-        <>{mainContents.map(renderComp)}</>
+        <RoutesWithProps contents={mainContents} />
       </MainContent>
     </>
   </Router>

--- a/packages/neuron-ui/src/components/WalletDetail/index.tsx
+++ b/packages/neuron-ui/src/components/WalletDetail/index.tsx
@@ -1,7 +1,8 @@
 import React, { useContext } from 'react'
 import WalletContext from '../../contexts/Wallet'
+import { ContentProps } from '../../containers/MainContent'
 
-const WalletDetail = () => {
+const WalletDetail: React.SFC<{ children?: React.ReactNode } & Partial<ContentProps>> = () => {
   const wallet = useContext(WalletContext)
 
   return wallet.name ? (

--- a/packages/neuron-ui/src/containers/MainContent/index.tsx
+++ b/packages/neuron-ui/src/containers/MainContent/index.tsx
@@ -1,6 +1,21 @@
 import React from 'react'
+import ipc from '../../utils/ipc'
 
-const MainContent = ({ children }: { children?: React.ReactNode }) => <main>{children}</main>
+export interface ContentProps {
+  sendCapacity: (address: string, capacity: string) => void
+}
+
+const MainContent = ({ children }: { children?: any }) => {
+  // content props passed to main contents
+  const contentProps = {
+    sendCapacity: (address: string, capacity: string) => {
+      // TODO: verify address
+      // TODO: verify capacity
+      ipc.sendCapacity(address, capacity)
+    },
+  }
+  return <main>{React.Children.map(children, child => child && React.cloneElement(child, contentProps))}</main>
+}
 
 MainContent.displayName = 'MainContent'
 


### PR DESCRIPTION
…cified main content components

For example, sendCapacity in MainContent could be used in Wallet Detail.