### PR TITLE
chore: disable electron app node integration (WIP)

### DIFF
--- a/packages/neuron-wallet/src/main.ts
+++ b/packages/neuron-wallet/src/main.ts
@@ -24,6 +24,7 @@ function createWindow() {
     show: false,
     webPreferences: {
       devTools: env.isDevMode,
+      nodeIntegration: false,
     },
   })
 


### PR DESCRIPTION
Disable `nodeIntegration` for a more secure setup (note Electron 5 will set this to false as default).