### PR TITLE
fix: get locale from electron app

### DIFF
--- a/packages/neuron-wallet/src/main.ts
+++ b/packages/neuron-wallet/src/main.ts
@@ -24,7 +24,7 @@ const initUILayer = (win: BrowserWindow) => {
   dispatch(Command.SetUILocale, {
     window: win,
     extra: {
-      locale: app.getLocale,
+      locale: app.getLocale(),
     },
   })
   sendTransactionHistory(win, 0, 15)


### PR DESCRIPTION
Should call the method to fetch the locale.