### PR TITLE
fix: move `electron-window-state` back to dependencies

### DIFF
--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -40,7 +40,8 @@
     "@nervosnetwork/ckb-sdk-core": "^0.0.1-alpha.3",
     "electron-store": "^2.0.0",
     "i18next": "^15.0.5",
-    "rxjs": "^6.4.0"
+    "rxjs": "^6.4.0",
+    "electron-window-state": "^5.0.3"
   },
   "devDependencies": {
     "@nervosnetwork/ckb-types": "^0.0.1-alpha.3",
@@ -54,7 +55,6 @@
     "electron-devtools-installer": "^2.2.4",
     "spectron": "^5.0.0",
     "tslint": "^5.12.1",
-    "electron-window-state": "^5.0.3",
     "execa": "^1.0.0",
     "ava": "^1.3.1"
   }


### PR DESCRIPTION
"electron-window-state" should be a runtime dependency.