### PR TITLE
fix(neuron-ui): update interface ContentProps cause actionCreators no…

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,10 +49,9 @@ module.exports = {
       }
     }],
     "no-plusplus": [0],
-    // disabled until test recovered
-    // "no-console": [2, {
-    //   "allow": ["warn", "error"]
-    // }]
+    "no-console": [2, {
+      "allow": ["warn", "error"]
+    }]
   },
   "env": {
     "jest": true,

--- a/packages/neuron-ui/src/components/Network/index.tsx
+++ b/packages/neuron-ui/src/components/Network/index.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import Dropdown from '../../widgets/Dropdown'
 import { NetworkStatus, Routes } from '../../utils/const'
 import ChainContext, { Network } from '../../contexts/Chain'
-import { HeaderActionsCreators, HeaderActions, actionCreators } from '../../containers/Header'
+import { HeaderActions, actionCreators } from '../../containers/Header/reducer'
 
 const Status = styled.div`
   width: 8px;
@@ -41,7 +41,6 @@ const NetworkStatusHeader = ({
   networks: Network[]
   dispatch: React.Dispatch<{ type: HeaderActions; payload?: any }>
   navTo: Function
-  actionCreators: HeaderActionsCreators
 }) => {
   const chain = useContext(ChainContext)
 

--- a/packages/neuron-ui/src/containers/Header/index.tsx
+++ b/packages/neuron-ui/src/containers/Header/index.tsx
@@ -3,10 +3,9 @@ import { createPortal } from 'react-dom'
 import { RouteComponentProps } from 'react-router-dom'
 import styled from 'styled-components'
 
-import { setNetwork } from '../../services/UILayer'
 import NetworkStatusHeader from '../../components/Network'
-import { Network } from '../../contexts/Chain'
 import SettingsContext from '../../contexts/Settings'
+import { initState, reducer, HeaderActions } from './reducer'
 
 const AppHeader = styled.div`
   height: 100%;
@@ -15,41 +14,11 @@ const AppHeader = styled.div`
   justify-content: flex-end;
 `
 
-export enum HeaderActions {
-  SetNetwork,
-}
-
-const reducer = (state: any, action: { type: HeaderActions; payload?: any }) => {
-  switch (action.type) {
-    case HeaderActions.SetNetwork: {
-      return {
-        ...state,
-        netowrk: action.payload,
-      }
-    }
-    default: {
-      return state
-    }
-  }
-}
-
-export const actionCreators = {
-  setNetwork: (network: Network) => {
-    setNetwork(network)
-    return {
-      type: HeaderActions.SetNetwork,
-      payload: network,
-    }
-  },
-}
-
-export type HeaderActionsCreators = typeof actionCreators
-export type HeaderDispatch = React.Dispatch<{ type: string; payload?: any }>
-
 const Header = (props: React.PropsWithoutRef<RouteComponentProps>) => {
   const settings = useContext(SettingsContext)
 
   const [header, dispatch] = useReducer(reducer, {
+    ...initState,
     networks: settings.networks,
   })
 
@@ -76,12 +45,7 @@ const Header = (props: React.PropsWithoutRef<RouteComponentProps>) => {
 
   return (
     <AppHeader>
-      <NetworkStatusHeader
-        networks={settings.networks}
-        navTo={navTo}
-        dispatch={dispatch}
-        actionCreators={actionCreators}
-      />
+      <NetworkStatusHeader networks={settings.networks} navTo={navTo} dispatch={dispatch} />
     </AppHeader>
   )
 }

--- a/packages/neuron-ui/src/containers/Header/reducer.ts
+++ b/packages/neuron-ui/src/containers/Header/reducer.ts
@@ -1,0 +1,40 @@
+import { setNetwork } from '../../services/UILayer'
+import { Network } from '../../contexts/Chain'
+
+export enum HeaderActions {
+  SetNetwork,
+}
+
+export interface InitState {
+  networks: Network[]
+}
+export const initState: InitState = {
+  networks: [],
+}
+
+export const reducer = (state: any, action: { type: HeaderActions; payload?: any }) => {
+  switch (action.type) {
+    case HeaderActions.SetNetwork: {
+      return {
+        ...state,
+        netowrk: action.payload,
+      }
+    }
+    default: {
+      return state
+    }
+  }
+}
+
+export const actionCreators = {
+  setNetwork: (network: Network) => {
+    setNetwork(network)
+    return {
+      type: HeaderActions.SetNetwork,
+      payload: network,
+    }
+  },
+}
+
+export type HeaderActionsCreators = typeof actionCreators
+export type HeaderDispatch = React.Dispatch<{ type: string; payload?: any }>

--- a/packages/neuron-ui/src/containers/MainContent/index.tsx
+++ b/packages/neuron-ui/src/containers/MainContent/index.tsx
@@ -2,7 +2,7 @@ import React, { useReducer } from 'react'
 import styled from 'styled-components'
 
 import Dialog from '../../widgets/Dialog'
-import { MainDispatch, InitState, initState, reducer, actionCreators, MainActions } from './reducer'
+import { initState, reducer, MainDispatch, InitState, MainActions } from './reducer'
 
 const Main = styled.main`
   height: 100%;
@@ -11,7 +11,6 @@ const Main = styled.main`
 
 export interface ContentProps extends InitState {
   dispatch: MainDispatch
-  actionCreators: typeof actionCreators
 }
 
 const MainContent = ({ children }: React.PropsWithoutRef<{ children?: any }>) => {

--- a/packages/neuron-ui/src/containers/MainContent/reducer.ts
+++ b/packages/neuron-ui/src/containers/MainContent/reducer.ts
@@ -190,4 +190,6 @@ export const reducer = (state: typeof initState, action: { type: MainActions; pa
     }
   }
 }
+
+export type MainActionCreators = typeof actionCreators
 export type MainDispatch = React.Dispatch<{ type: MainActions; payload?: any }>


### PR DESCRIPTION
…t passed to children, separate reducer of Header into an independent module