### PR TITLE
feat(neuron-wallet): remove useless notification

### DIFF
--- a/packages/neuron-wallet/src/channel/index.ts
+++ b/packages/neuron-wallet/src/channel/index.ts
@@ -10,8 +10,6 @@ enum ResponseStatus {
   Success,
 }
 
-const NOTIFICATION_FADE_TIME = 3000
-
 export class Listeners {
   static start = (
     methods: string[] = [
@@ -61,12 +59,6 @@ export class Listeners {
    */
   static createWallet = () => {
     return ipcMain.on(Channel.CreateWallet, (e: Electron.Event, wallet: Wallet) => {
-      const notification = new Notification({
-        title: 'Create Wallet',
-        body: JSON.stringify(wallet),
-      })
-      notification.show()
-      setTimeout(notification.close, NOTIFICATION_FADE_TIME)
       e.sender.send(Channel.CreateWallet, {
         status: ResponseStatus.Success,
         result: {
@@ -85,12 +77,6 @@ export class Listeners {
    */
   static deleteWallet = () => {
     return ipcMain.on(Channel.DeleteWallet, (e: Electron.Event, address: string) => {
-      const notification = new Notification({
-        title: 'Delete Wallet',
-        body: address,
-      })
-      notification.show()
-      setTimeout(notification.close, NOTIFICATION_FADE_TIME)
       e.sender.send(Channel.DeleteWallet, {
         status: ResponseStatus.Success,
         reult: `wallet of ${address} deleted`,
@@ -104,13 +90,7 @@ export class Listeners {
    * @description channel to import a wallet
    */
   static importWallet = () => {
-    return ipcMain.on(Channel.ImportWallet, (e: Electron.Event, wallet: Wallet) => {
-      const notification = new Notification({
-        title: 'Import Wallet',
-        body: JSON.stringify(wallet),
-      })
-      notification.show()
-      setTimeout(notification.close, NOTIFICATION_FADE_TIME)
+    return ipcMain.on(Channel.ImportWallet, (e: Electron.Event) => {
       e.sender.send(Channel.ImportWallet, {
         status: ResponseStatus.Success,
         result: `wallet imported`,
@@ -125,12 +105,6 @@ export class Listeners {
    */
   static exportWallet = () => {
     return ipcMain.on(Channel.ExportWallet, (e: Electron.Event) => {
-      const notification = new Notification({
-        title: 'Export Wallet',
-        body: '',
-      })
-      notification.show()
-      setTimeout(notification.close, NOTIFICATION_FADE_TIME)
       e.sender.send(Channel.ExportWallet, {
         status: ResponseStatus.Success,
         result: `wallet exported`,

--- a/packages/neuron-wallet/src/monitor.ts
+++ b/packages/neuron-wallet/src/monitor.ts
@@ -26,6 +26,7 @@ const monitorChain = (webContents: Electron.WebContents) => {
     )
     .subscribe(
       result => {
+        if (!webContents) return
         webContents.send(Channel.GetNetwork, {
           status: 1,
           result,


### PR DESCRIPTION
the auto-dismiss leads [this problem](https://github.com/nervosnetwork/neuron/issues/152), notification objects cleaned before the callbacks.