### PR TITLE
chore: enable BigInt as a global variable

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,6 +55,9 @@ module.exports = {
       "allow": ["warn", "error", "info"]
     }]
   },
+  "globals": {
+    "BigInt": "readonly"
+  },
   "env": {
     "jest": true,
     "browser": true,


### PR DESCRIPTION
eslint will take it as a global function once it's on staging 4