### PR TITLE
chore: delete .env.example file

### DIFF
--- a/packages/neuron-ui/.env.example
+++ b/packages/neuron-ui/.env.example
@@ -1,1 +1,0 @@
-REACT_APP_NETWORKS=[{"name":"Testnet","remote":"http://localhost:8114"},{"name":"Localhost","remote":"http://localhost:8114"}]


### PR DESCRIPTION
@Keith-CY I guess we no longer use this?