### PR TITLE
chore: impl getAll in TransactionsService

### DIFF
--- a/packages/neuron-wallet/src/entities/Input.ts
+++ b/packages/neuron-wallet/src/entities/Input.ts
@@ -30,6 +30,12 @@ export default class Input extends BaseEntity {
   @ManyToOne(_type => Transaction, transaction => transaction.inputs)
   transaction!: Transaction
 
+  @Column({
+    type: 'varchar',
+    nullable: true,
+  })
+  capacity: string | null = null
+
   public previousOutput(): OutPoint {
     return {
       hash: this.outPointHash,

--- a/packages/neuron-wallet/src/entities/Input.ts
+++ b/packages/neuron-wallet/src/entities/Input.ts
@@ -1,6 +1,7 @@
 import { Entity, BaseEntity, PrimaryColumn, Column, ManyToOne } from 'typeorm'
 import { OutPoint } from '../services/cells'
 import Transaction from './Transaction'
+import { Input as InputInterface } from '../services/transactions'
 
 /* eslint @typescript-eslint/no-unused-vars: "warn" */
 @Entity()
@@ -33,6 +34,13 @@ export default class Input extends BaseEntity {
     return {
       hash: this.outPointHash,
       index: this.outPointIndex,
+    }
+  }
+
+  public toInterface(): InputInterface {
+    return {
+      previousOutput: this.previousOutput(),
+      args: this.args,
     }
   }
 }

--- a/packages/neuron-wallet/src/entities/Output.ts
+++ b/packages/neuron-wallet/src/entities/Output.ts
@@ -1,5 +1,5 @@
 import { Entity, BaseEntity, Column, PrimaryColumn, ManyToOne } from 'typeorm'
-import { Script, OutPoint } from '../services/cells'
+import { Script, OutPoint, Cell } from '../services/cells'
 import TransactionEntity from './Transaction'
 
 /* eslint @typescript-eslint/no-unused-vars: "warn" */
@@ -55,4 +55,14 @@ export default class Output extends BaseEntity {
 
   @ManyToOne(_type => TransactionEntity, transaction => transaction.outputs)
   transaction!: TransactionEntity
+
+  public toInterface(): Cell {
+    return {
+      capacity: this.capacity,
+      lock: this.lock,
+      lockHash: this.lockHash,
+      outPoint: this.outPoint(),
+      status: this.status,
+    }
+  }
 }

--- a/packages/neuron-wallet/src/entities/Transaction.ts
+++ b/packages/neuron-wallet/src/entities/Transaction.ts
@@ -39,22 +39,12 @@ export default class Transaction extends BaseEntity {
   @Column({
     type: 'varchar',
   })
-  value!: string
-
-  @Column({
-    type: 'varchar',
-  })
   blockNumber!: string
 
   @Column({
     type: 'varchar',
   })
   blockHash!: string
-
-  @Column({
-    type: 'varchar',
-  })
-  type!: string
 
   @OneToMany(_type => InputEntity, input => input.transaction)
   inputs!: InputEntity[]

--- a/packages/neuron-wallet/src/services/transactions.ts
+++ b/packages/neuron-wallet/src/services/transactions.ts
@@ -114,11 +114,12 @@ export default class TransactionsService {
   public static getAllByAddresses = async (
     params: TransactionsByAddressesParam,
   ): Promise<PaginationResult<Transaction>> => {
-    const lockHashes: string[] = []
-    for (const addr of params.addresses) {
-      const lockHash: string = await TransactionsService.addressToLockHash(addr)
-      lockHashes.push(lockHash)
-    }
+    const lockHashes: string[] = await Promise.all(
+      params.addresses.map(async addr => {
+        const lockHash: string = await TransactionsService.addressToLockHash(addr)
+        return lockHash
+      }),
+    )
 
     return TransactionsService.getAll({
       pageNo: params.pageNo,
@@ -130,12 +131,13 @@ export default class TransactionsService {
   public static getAllByPubkeys = async (
     params: TransactionsByPubkeysParams,
   ): Promise<PaginationResult<Transaction>> => {
-    const lockHashes: string[] = []
-    for (const pubkey of params.pubkeys) {
-      const addr = ckbCore.utils.pubkeyToAddress(pubkey)
-      const lockHash = await TransactionsService.addressToLockHash(addr)
-      lockHashes.push(lockHash)
-    }
+    const lockHashes: string[] = await Promise.all(
+      params.pubkeys.map(async pubkey => {
+        const addr = ckbCore.utils.pubkeyToAddress(pubkey)
+        const lockHash = await TransactionsService.addressToLockHash(addr)
+        return lockHash
+      }),
+    )
 
     return TransactionsService.getAll({
       pageNo: params.pageNo,


### PR DESCRIPTION
1. implement `getAll`, `getAllByAddresses`, `getAllByPubkeys`
2. add static methods `addressToLockScript` and `addressToLockHash` to `TransactionsService`
3. calculate `capacity` and `lockHash` of `InputEntity` when save
4. remove `value` and `type` from `TransactionEntity`
5. calculate `value` and `type` by `params.lockHashes` when in `getAll`, `getAllByAddresses`, `getAllByPubkeys`