### PR TITLE
feat(neuron-ui): make sidebar invisible when wallets.length === 0

### DIFF
--- a/packages/neuron-ui/src/containers/Sidebar/index.tsx
+++ b/packages/neuron-ui/src/containers/Sidebar/index.tsx
@@ -17,6 +17,8 @@ import { Routes } from 'utils/const'
 
 const SidebarAside = styled.nav`
   display: flex;
+  width: 240px;
+  box-sizing: border-box;
   flex-direction: column;
   margin: 40px 0 0 0;
   padding: 0 32px;
@@ -44,10 +46,11 @@ const menuItems = [
 const Sidebar = () => {
   const {
     wallet: { name },
+    settings: { wallets },
   } = useNeuronWallet()
   const [t] = useTranslation()
 
-  return (
+  return wallets.length ? (
     <SidebarAside>
       {menuItems.map(menuItem => (
         <NavLink
@@ -65,7 +68,7 @@ const Sidebar = () => {
         </NavLink>
       ))}
     </SidebarAside>
-  )
+  ) : null
 }
 
 const Container = (props: any) => createPortal(<Sidebar {...props} />, document.querySelector('aside') as HTMLElement)

--- a/packages/neuron-ui/src/styles/layout.scss
+++ b/packages/neuron-ui/src/styles/layout.scss
@@ -7,7 +7,7 @@ body {
     'sidebar notification notification notification' auto
     'sidebar content content content' 1fr
     'sidebar content content content' 1fr /
-    240px 1fr 1fr 340px;
+    auto 1fr 1fr 340px;
   column-gap: $column-gap;
 
   height: 100vh;


### PR DESCRIPTION
Hide the sidebar when wallets.length ===0

This behavior differs from the launch screen and wizard, which hide both of header bar and sidebar.