### PR TITLE
Refactor Keystore

### DIFF
--- a/packages/neuron-wallet/src/keys/key.ts
+++ b/packages/neuron-wallet/src/keys/key.ts
@@ -192,7 +192,7 @@ export default class Key {
       .toString('hex')
       .replace('0x', '')
     return {
-      version: 0,
+      version: 3,
       id: uuid(),
       crypto: {
         ciphertext: ciphertext.toString('hex'),

--- a/packages/neuron-wallet/tests/services/wallets.test.ts
+++ b/packages/neuron-wallet/tests/services/wallets.test.ts
@@ -6,7 +6,7 @@ describe('wallet service', () => {
   const wallet1 = {
     name: 'wallet1',
     keystore: {
-      version: 0,
+      version: 3,
       id: '0',
       crypto: {
         cipher: 'wallet1',
@@ -58,7 +58,7 @@ describe('wallet service', () => {
   const wallet2 = {
     name: 'wallet2',
     keystore: {
-      version: 0,
+      version: 3,
       id: '1',
       crypto: {
         cipher: 'wallet2',
@@ -109,7 +109,7 @@ describe('wallet service', () => {
   const wallet3 = {
     name: 'wallet3',
     keystore: {
-      version: 0,
+      version: 3,
       id: '1',
       crypto: {
         cipher: 'wallet3',


### PR DESCRIPTION
* Fix version to `3`, altough we don't guarantee the compatibility with V3 Keystore format used by Ethereum and some other implementations.