### PR TITLE
refactor(neuron-wallet): fix cannot find neuron dir on creating netwo…

### DIFF
--- a/packages/neuron-wallet/src/utils/store.ts
+++ b/packages/neuron-wallet/src/utils/store.ts
@@ -1,8 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import EventEmitter from 'events'
-
-import console = require('console')
+import Logger from './logger'
 
 class Store extends EventEmitter {
   public readonly location: string
@@ -15,10 +14,17 @@ class Store extends EventEmitter {
 
   constructor(pathname: string, filename: string) {
     super()
+    if (!fs.existsSync(pathname)) {
+      fs.mkdirSync(pathname, { recursive: true })
+    }
     this.location = path.resolve(pathname, filename)
     const exist = fs.existsSync(this.location)
     if (!exist) {
-      fs.writeFileSync(this.location, '{}', this.config)
+      try {
+        fs.writeFileSync(this.location, this.defaultValue, this.config)
+      } catch (err) {
+        Logger.log({ level: 'error', message: err.message })
+      }
     }
   }
 


### PR DESCRIPTION
…rks.json

check the directory on creating networks.json for quick fix, should check the initializing progress to make sure the networks.json will be created after the neuron dir created.