### PR TITLE
Refactor sync blocks

### DIFF
--- a/packages/neuron-wallet/src/services/cells.ts
+++ b/packages/neuron-wallet/src/services/cells.ts
@@ -11,7 +11,7 @@ export interface OutPoint {
 
 export interface Script {
   args?: string[]
-  binaryHash?: string | null
+  codeHash?: string | null
 }
 
 // FIXME: should update capacity to string

--- a/packages/neuron-wallet/src/services/networks.ts
+++ b/packages/neuron-wallet/src/services/networks.ts
@@ -1,4 +1,6 @@
 import { v4 as uuid } from 'uuid'
+import { BehaviorSubject } from 'rxjs'
+
 import Store from '../utils/store'
 import env from '../env'
 
@@ -27,6 +29,9 @@ export interface Network {
 export interface NetworkWithID extends Network {
   id: NetworkID
 }
+
+export const networkSwitchSubject = new BehaviorSubject<undefined | NetworkWithID>(undefined)
+
 export default class NetworksService extends Store {
   constructor(pathname: string, filename: string) {
     super(pathname, filename)
@@ -54,6 +59,7 @@ export default class NetworksService extends Store {
       const network = await this.get(newActiveId)
       if (network) {
         nodeService.setNetwork(network.remote)
+        networkSwitchSubject.next(network)
       }
       windowManage.broadcast(Channel.Networks, NetworksMethod.ActiveId, {
         status: ResponseCode.Success,

--- a/packages/neuron-wallet/src/services/node.ts
+++ b/packages/neuron-wallet/src/services/node.ts
@@ -5,7 +5,7 @@ import { distinctUntilChanged, flatMap, retry, filter } from 'rxjs/operators'
 class NodeService {
   tick = interval(1000)
 
-  tipNumberSubject = new Subject()
+  tipNumberSubject = new Subject<string | undefined>()
 
   core: Core = new Core('')
 

--- a/packages/neuron-wallet/src/services/node.ts
+++ b/packages/neuron-wallet/src/services/node.ts
@@ -1,11 +1,11 @@
 import Core from '@nervosnetwork/ckb-sdk-core'
-import { interval, Subject } from 'rxjs'
+import { interval, BehaviorSubject } from 'rxjs'
 import { distinctUntilChanged, flatMap, retry, filter } from 'rxjs/operators'
 
 class NodeService {
   tick = interval(1000)
 
-  tipNumberSubject = new Subject<string | undefined>()
+  tipNumberSubject = new BehaviorSubject<string | undefined>(undefined)
 
   core: Core = new Core('')
 

--- a/packages/neuron-wallet/src/services/syncBlocks.ts
+++ b/packages/neuron-wallet/src/services/syncBlocks.ts
@@ -8,7 +8,7 @@ import SyncInfoEntity from '../entities/SyncInfo'
 import nodeService from '../startup/nodeService'
 import { networkSwitchSubject } from './networks'
 
-// FIXME: now have some problem with core, should should update every time network switched
+// FIXME: now have some problem with core, should update every time network switched
 // const { core } = nodeService
 let core: Core
 networkSwitchSubject.subscribe(network => {

--- a/packages/neuron-wallet/src/services/syncBlocks.ts
+++ b/packages/neuron-wallet/src/services/syncBlocks.ts
@@ -37,16 +37,11 @@ export const addressesUsedSubject = new Subject()
 /* eslint no-restricted-syntax: "warn" */
 export default class SyncBlocksService {
   private lockHashList: string[]
-
   private fetchSize = 128
-
   private minFetchSize = 16
-
   // TODO: it should depends on CKB
   private sizeForCheck = 12
-
   private tryTime = 0
-
   private stopFlag = false
 
   // cache the blocks for check fork

--- a/packages/neuron-wallet/src/services/transactions.ts
+++ b/packages/neuron-wallet/src/services/transactions.ts
@@ -11,7 +11,7 @@ const { core } = nodeService
 export interface Input {
   previousOutput: OutPoint
   args: string[]
-  validSince?: string
+  since?: string
   capacity?: string | null
   lockHash?: string | null
 }
@@ -196,7 +196,7 @@ export default class TransactionsService {
     const contractInfo = await TransactionsService.contractInfo()
 
     const lock: Script = {
-      binaryHash: contractInfo.binaryHash,
+      codeHash: contractInfo.codeHash,
       args: [blake160],
     }
     const lockHash: string = TransactionsService.lockScriptToHash(lock)
@@ -440,20 +440,20 @@ export default class TransactionsService {
       // if Uint8Array
       blake2b.update(data)
     }
-    const binaryHash: string = blake2b.digest('hex')
+    const codeHash: string = blake2b.digest('hex')
     const outPoint: OutPoint = {
       txHash: systemScriptTx.hash,
       index: 0,
     }
     return {
-      binaryHash,
+      codeHash,
       outPoint,
     }
   }
 
   // lockHashes for each inputs
   public static generateTx = async (lockHashes: string[], targetOutputs: TargetOutput[], changeAddress: string) => {
-    const { binaryHash, outPoint } = await TransactionsService.contractInfo()
+    const { codeHash, outPoint } = await TransactionsService.contractInfo()
 
     const needCapacities: bigint = targetOutputs
       .map(o => BigInt(o.capacity))
@@ -470,7 +470,7 @@ export default class TransactionsService {
         capacity,
         data: '0x',
         lock: {
-          binaryHash,
+          codeHash,
           args: [blake160],
         },
       }
@@ -490,7 +490,7 @@ export default class TransactionsService {
         capacity: `${BigInt(capacities) - needCapacities}`,
         data: '0x',
         lock: {
-          binaryHash,
+          codeHash,
           args: [changeBlake160],
         },
       }
@@ -509,10 +509,10 @@ export default class TransactionsService {
   // TODO: check this algorithm
   // use SDK lockScriptToHash
   public static lockScriptToHash = (lock: Script) => {
-    const binaryHash: string = lock!.binaryHash!
+    const codeHash: string = lock!.codeHash!
     const args: string[] = lock.args!
     const lockHash: string = core.utils.lockScriptToHash({
-      binaryHash,
+      binaryHash: codeHash,
       args,
     })
 
@@ -528,7 +528,7 @@ export default class TransactionsService {
     const contractInfo = await TransactionsService.contractInfo()
 
     const lock: Script = {
-      binaryHash: contractInfo.binaryHash,
+      codeHash: contractInfo.codeHash,
       args: [blake160],
     }
     return lock

--- a/packages/neuron-wallet/src/startup/loopTask/create.ts
+++ b/packages/neuron-wallet/src/startup/loopTask/create.ts
@@ -1,10 +1,11 @@
 import { BrowserWindow } from 'electron'
 import path from 'path'
-import { Subject, BehaviorSubject } from 'rxjs'
+import { Subject } from 'rxjs'
 import SyncBlocksService from '../../services/syncBlocks'
 import initConnection from '../../typeorm'
 import Address from '../../services/addresses'
 import TransactionsService from '../../services/transactions'
+import { networkSwitchSubject } from '../../services/networks'
 
 const loadURL = `file://${path.join(__dirname, 'index.html')}`
 
@@ -12,11 +13,6 @@ const stopLoopSubject = new Subject()
 
 // TODO: mock as an address subject
 const addressChangeSubject = new Subject()
-
-// TODO: mock as an network init or change subject
-// init-message means network not initialized
-const networkChangeSubject = new BehaviorSubject('init-message')
-networkChangeSubject.next('testnet')
 
 // maybe should call this every time when new address generated
 // load all addresses and convert to lockHashes
@@ -72,9 +68,9 @@ const createLoopTask = () => {
     loopWindow!.hide()
 
     // TODO: add an event on networkId for when it init and changed, it should broadcast a message with networkId
-    networkChangeSubject.subscribe(async (networkId: string) => {
-      if (networkId !== 'init-message') {
-        await switchNetwork(networkId)
+    networkSwitchSubject.subscribe(async network => {
+      if (network) {
+        await switchNetwork(network.name)
       }
     })
   })


### PR DESCRIPTION
1. cache `blockHeaderForCheck`
2. cache `currentBlockNumber`
3. listen `tipBlockNumber` by `nodeService` to replace monitor by self
4. listen to network switch
5. reduce fetch size when failed 3 times in a row