### PR TITLE
Bump TypeScript to 3.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "nodemon": "1.18.11",
     "prettier": "1.17.0",
     "ts-jest": "24.0.2",
-    "typescript": "3.4.1",
+    "typescript": "3.4.5",
     "wait-on": "3.2.0"
   },
   "dependencies": {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -14361,10 +14361,10 @@ typeorm@0.2.17:
     yargonaut "^1.1.2"
     yargs "^13.2.1"
 
-typescript@3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.1.tgz#b6691be11a881ffa9a05765a205cb7383f3b63c6"
-  integrity sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==
+typescript@3.4.5:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
We should soon consider 3.5.0 RC too, as it claims to fix regression brought by 3.4.