### PR TITLE
chore: remove ckb-sdk from neuron-ui cuz it's not used now, update @n…

### DIFF
--- a/packages/neuron-ui/package.json
+++ b/packages/neuron-ui/package.json
@@ -33,7 +33,6 @@
   },
   "browserslist": ["last 2 chrome versions"],
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-core": "0.12.0",
     "@types/node": "11.13.5",
     "@types/react": "16.8.13",
     "@types/react-dom": "16.8.4",
@@ -54,7 +53,6 @@
     "styled-components": "4.2.0"
   },
   "devDependencies": {
-    "@nervosnetwork/ckb-types": "0.11.0",
     "@types/enzyme": "3.1.16",
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/qrcode.react": "0.8.2",

--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -68,7 +68,7 @@
     "winston": "3.2.1"
   },
   "devDependencies": {
-    "@nervosnetwork/ckb-types": "0.11.0",
+    "@nervosnetwork/ckb-types": "0.12.0",
     "@nervosnetwork/neuron-ui": "0.1.0",
     "@types/bip39": "2.4.2",
     "@types/electron-devtools-installer": "2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2025,11 +2025,6 @@
     blake2b-wasm "1.1.7"
     elliptic "^6.4.1"
 
-"@nervosnetwork/ckb-types@0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@nervosnetwork/ckb-types/-/ckb-types-0.11.0.tgz#571a6c33def973fd8b10b35c3cf8166770942fb8"
-  integrity sha512-mM99hw3xt1Ct1Jbmtn9l5kg3hbcxkKNFjjieXlSJOBeW4FpDUotvtQEQaPtlPeN0+uRC32XGzcqcFe4bMDQlOw==
-
 "@nervosnetwork/ckb-types@0.12.0":
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/@nervosnetwork/ckb-types/-/ckb-types-0.12.0.tgz#f9c5ac446b3667cdf9dbea7b86434e73114d506e"


### PR DESCRIPTION
…ervosnetwork/ckb-types to 0.12.

1. remove the sdk from neuron-ui, because it's not used now
2. update @nervosnetwork/ckb-types to 0.12.0