### PR TITLE
chore(ci): Add Node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,13 @@ os:
   - linux
   - osx
 
-osx_image: xcode10.1
+osx_image: xcode10.2
 
 language: node_js
 
 node_js:
-  - '11.10'
+  - '11'
+  - '12'
 
 cache:
   - npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,18 @@
 language: node_js
 
-matrix:
-  include:
-    - name: Test on Linux
-      os: linux
-      dist: xenial
-      node_js:
-        - '11'
-        - '12'
-    - name: Test on macOS
-      os: osx
-      osx_image: xcode10.2
-      node_js:
-        - '11'
-        - '12'
+os:
+  - linux
+  - osx
+
+dist: xenial
+osx_image: xcode10.2
 
 services:
   - xvfb
+
+node_js:
+  - '11'
+  - '12'
 
 cache:
   - npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,22 @@
+language: node_js
+
 matrix:
   include:
     - name: Test on Linux
       os: linux
       dist: xenial
+      node_js:
+        - '11'
+        - '12'
     - name: Test on macOS
       os: osx
       osx_image: xcode10.2
+      node_js:
+        - '11'
+        - '12'
 
 services:
   - xvfb
-
-language: node_js
-
-node_js:
-  - '11'
-  - '12'
 
 cache:
   - npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 matrix:
   include:
-    - os: linux
+    - name: Test on Linux
+      os: linux
       dist: xenial
-    - os: osx
+    - name: Test on macOS
+      os: osx
       osx_image: xcode10.2
 
-addons:
-   apt:
-     packages:
-       - xvfb
+services:
+  - xvfb
 
 language: node_js
 
@@ -27,11 +27,6 @@ before_install:
 install:
   - travis_retry yarn install
   - travis_retry yarn lerna bootstrap
-
-before_script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sleep 3; fi
 
 script:
   - git diff --exit-code yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ matrix:
     - os: osx
       osx_image: xcode10.2
 
+addons:
+   apt:
+     packages:
+       - xvfb
+
 language: node_js
 
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
-os:
-  - linux
-  - osx
-
-osx_image: xcode10.2
+matrix:
+  include:
+    - os: linux
+      dist: xenial
+    - os: osx
+      osx_image: xcode10.2
 
 language: node_js
 


### PR DESCRIPTION
Configure Travis to run Node 11/12 on Ubuntu 16.04/macOS. (4 jobs)