### PR TITLE
fix: fileBasePath and logger bugs

### DIFF
--- a/packages/neuron-wallet/src/env.ts
+++ b/packages/neuron-wallet/src/env.ts
@@ -7,11 +7,11 @@ const { NODE_ENV } = process.env
 const isDevMode = !app.isPackaged
 
 const fileBase = (() => {
-  if (NODE_ENV === 'prod') {
-    return ''
-  }
   if (NODE_ENV === 'test') {
     return 'test/'
+  }
+  if (!isDevMode) {
+    return ''
   }
   return 'dev/'
 })()

--- a/packages/neuron-wallet/src/utils/logger.ts
+++ b/packages/neuron-wallet/src/utils/logger.ts
@@ -1,7 +1,7 @@
-import { app } from 'electron'
 import winston, { format } from 'winston'
 import path from 'path'
 import env from '../env'
+import app from '../app'
 
 const { isDevMode } = env
 const basePath = isDevMode ? './' : `${app.getPath('logs')}`


### PR DESCRIPTION
fileBasePath pointer to `dev` when packaged, logger only works in main process