### PR TITLE
chore: Skip neuron-wallet test on commit

### DIFF
--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -21,7 +21,7 @@
     "test": "jest --color",
     "lint": "eslint 'src/**/*.{js,ts}'",
     "package": "./script/package.sh",
-    "precommit": "lint-staged && yarn test",
+    "precommit": "lint-staged",
     "rebuild:nativemodules": "electron-builder install-app-deps"
   },
   "husky": {


### PR DESCRIPTION
Some tests (e.g., HD key derivation) are very slow which makes the pre commit check take too long. Remove that; we always run tests locally frequently and let's delegate that to CI to catch if we miss the green before committing.