### PR TITLE
fix(neuron-ui): display icons of sidebar items

### DIFF
--- a/packages/neuron-ui/src/containers/Sidebar/index.tsx
+++ b/packages/neuron-ui/src/containers/Sidebar/index.tsx
@@ -64,6 +64,7 @@ const Sidebar = () => {
             fontWeight: 'bolder',
           }}
         >
+          {<menuItem.icon size="20px" style={{ paddingRight: '5px' }} />}
           {menuItem.name === menuItems[0].name ? name : t(menuItem.name)}
         </NavLink>
       ))}


### PR DESCRIPTION
They are lost in the refactoring of https://github.com/nervosnetwork/neuron/commit/1a6afb5c05c529dc0bd38e3d3d5d50d4bb247d93#diff-4bbaf8c600de7dee442ac266d55cbda7R64