### PR TITLE
refactor: Unify singleton usage

### DIFF
--- a/packages/neuron-wallet/src/services/addresses.ts
+++ b/packages/neuron-wallet/src/services/addresses.ts
@@ -1,12 +1,12 @@
 import TransactionsService from './transactions'
 import WalletService from './wallets'
-import { nodeService } from './node'
+import NodeService from './node'
 import HD from '../keys/hd'
 import { KeysData } from '../keys/keystore'
 
 const {
   utils: { AddressPrefix, AddressType: Type, AddressBinIdx, pubkeyToAddress },
-} = nodeService.core
+} = NodeService.getInstance().core
 
 export const MAX_ADDRESS_COUNT = 30
 export const SEARCH_RANGE = 20

--- a/packages/neuron-wallet/src/services/file.ts
+++ b/packages/neuron-wallet/src/services/file.ts
@@ -68,5 +68,3 @@ export default class FileService {
     return fs.unlinkSync(path.join(this.basePath, moduleName, filename))
   }
 }
-
-export const fileService = new FileService()

--- a/packages/neuron-wallet/src/services/networks.ts
+++ b/packages/neuron-wallet/src/services/networks.ts
@@ -10,7 +10,7 @@ import { Channel, ResponseCode } from '../utils/const'
 import i18n from '../utils/i18n'
 
 import { Validate, Required } from '../decorators'
-import { nodeService } from './node'
+import NodeService from './node'
 
 export type NetworkID = string
 export type NetworkName = string
@@ -65,7 +65,7 @@ export default class NetworksService extends Store {
       .subscribe(async ([, newActiveId]) => {
         const network = await this.get(newActiveId)
         if (network) {
-          nodeService.setNetwork(network.remote)
+          NodeService.getInstance().setNetwork(network.remote)
           networkSwitchSubject.next(network)
         }
         windowManage.broadcast(Channel.Networks, 'activeId', {

--- a/packages/neuron-wallet/src/services/node.ts
+++ b/packages/neuron-wallet/src/services/node.ts
@@ -65,6 +65,4 @@ class NodeService {
   }
 }
 
-export const nodeService = NodeService.getInstance()
-
 export default NodeService

--- a/packages/neuron-wallet/src/services/sync-blocks.ts
+++ b/packages/neuron-wallet/src/services/sync-blocks.ts
@@ -6,7 +6,7 @@ import { Script, OutPoint, Cell, Input, Transaction, Block, BlockHeader } from '
 import TransactionsService from './transactions'
 import OutputEntity from '../entities/output'
 import SyncInfoEntity from '../entities/sync-info'
-import { nodeService } from './node'
+import NodeService from './node'
 import LockUtils from '../utils/lock-utils'
 import TypeConvert from '../app-types/type-convert'
 import { NetworkWithID } from './networks'
@@ -17,7 +17,7 @@ const { syncBlockTask } = app
 const { networkSwitchSubject } = syncBlockTask
 
 // FIXME: now have some problem with core, should update every time network switched
-// const { core } = nodeService
+// const { core } = NodeService.getInstance()
 let core: Core
 networkSwitchSubject.subscribe((network: NetworkWithID | undefined) => {
   if (network) {
@@ -48,7 +48,7 @@ export default class SyncBlocksService {
 
   constructor(
     lockHashes: string[],
-    tipNumberSubject: BehaviorSubject<string | undefined> = nodeService.tipNumberSubject,
+    tipNumberSubject: BehaviorSubject<string | undefined> = NodeService.getInstance().tipNumberSubject,
     addressesUsedSubject: Subject<string[]> = AddressesUsedSubject.subject,
   ) {
     this.lockHashList = lockHashes

--- a/packages/neuron-wallet/src/services/transactions.ts
+++ b/packages/neuron-wallet/src/services/transactions.ts
@@ -5,10 +5,10 @@ import CellsService from './cells'
 import InputEntity from '../entities/input'
 import OutputEntity from '../entities/output'
 import TransactionEntity from '../entities/transaction'
-import { nodeService } from './node'
+import NodeService from './node'
 import LockUtils from '../utils/lock-utils'
 
-const { core } = nodeService
+const { core } = NodeService.getInstance()
 
 export interface TransactionsByAddressesParam {
   pageNo: number

--- a/packages/neuron-wallet/src/services/wallets.ts
+++ b/packages/neuron-wallet/src/services/wallets.ts
@@ -5,15 +5,16 @@ import TransactionsService from './transactions'
 import Key, { Addresses } from '../keys/key'
 import { Keystore } from '../keys/keystore'
 import Store from '../utils/store'
-import { nodeService } from './node'
-import { fileService } from './file'
+import NodeService from './node'
+import FileService from './file'
 import LockUtils from '../utils/lock-utils'
 import env from '../env'
 import i18n from '../utils/i18n'
 import windowManage from '../utils/window-manage'
 import { Channel, ResponseCode } from '../utils/const'
 
-const { core } = nodeService
+const { core } = NodeService.getInstance()
+const fileService = FileService.getInstance()
 
 const hrp = `01${Buffer.from('P2PH').toString('hex')}`
 

--- a/packages/neuron-wallet/src/startup/init-app.ts
+++ b/packages/neuron-wallet/src/startup/init-app.ts
@@ -2,11 +2,12 @@ import { distinctUntilChanged } from 'rxjs/operators'
 import controllers from '../controllers'
 import windowManage from '../utils/window-manage'
 import Router from '../router'
-import { nodeService } from '../services/node'
+import NodeService from '../services/node'
 import { Channel } from '../utils/const'
 import logger from '../utils/logger'
 import app from '../app'
 
+const nodeService = NodeService.getInstance()
 const { NetworksController } = controllers
 
 const syncConnectStatus = () => {

--- a/packages/neuron-wallet/src/startup/sync-block-task/create.ts
+++ b/packages/neuron-wallet/src/startup/sync-block-task/create.ts
@@ -3,7 +3,7 @@ import { Subject } from 'rxjs'
 import path from 'path'
 import { networkSwitchSubject, NetworkWithID } from '../../services/networks'
 import app from '../../app'
-import { nodeService } from '../../services/node'
+import NodeService from '../../services/node'
 import env from '../../env'
 import initConnection from '../../typeorm'
 import { AddressesUsedSubject } from '../../subjects/addresses-used-subject'
@@ -16,6 +16,7 @@ networkSwitchSubject.subscribe(async (network: NetworkWithID | undefined) => {
 
 // TODO: mock as an address subject
 export const addressChangeSubject = new Subject()
+const nodeService = NodeService.getInstance()
 
 const loadURL = `file://${path.join(__dirname, 'index.html')}`
 

--- a/packages/neuron-wallet/src/utils/lock-utils.ts
+++ b/packages/neuron-wallet/src/utils/lock-utils.ts
@@ -1,7 +1,7 @@
-import { nodeService } from '../services/node'
+import NodeService from '../services/node'
 import { CellOutPoint, OutPoint, Script } from '../app-types/types'
 
-const { core } = nodeService
+const { core } = NodeService.getInstance()
 
 export default class LockUtils {
   static systemScriptInfo: { codeHash: string; outPoint: OutPoint } | undefined

--- a/packages/neuron-wallet/src/utils/store.ts
+++ b/packages/neuron-wallet/src/utils/store.ts
@@ -1,12 +1,12 @@
 import EventEmitter from 'events'
-import { fileService } from '../services/file'
+import FileService from '../services/file'
 import logger from './logger'
 
 class Store extends EventEmitter {
   public moduleName: string
   public filename: string
   public defaultValue: string
-  public service = fileService
+  public service = FileService.getInstance()
 
   constructor(moduleName: string, filename: string, defaultValue: string = '{}') {
     super()

--- a/packages/neuron-wallet/tests/services/address.test.ts
+++ b/packages/neuron-wallet/tests/services/address.test.ts
@@ -1,7 +1,7 @@
 import Addresses from '../../src/services/addresses'
-import { nodeService } from '../../src/services/node'
+import NodeService from '../../src/services/node'
 
-const { utils } = nodeService.core
+const { utils } = NodeService.getInstance().core
 
 describe('Key tests', () => {
   const { AddressPrefix } = utils


### PR DESCRIPTION
Use `XxxService.getInstance()` instead of exposing a singleton constant.