### PR TITLE
chore(ci): Add lerna globally when running travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ cache:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
   - export PATH=$HOME/.yarn/bin:$PATH
+  - yarn global add lerna
 
 install:
-  - travis_retry yarn install
-  - travis_retry yarn lerna bootstrap
+  - travis_retry yarn bootstrap
 
 script:
   - git diff --exit-code yarn.lock


### PR DESCRIPTION
To apply a more proper use of learn and avoid installing deps twice.