### PR TITLE
chore(lint): Do not require trailing comma for function parameters

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "trailingComma": "all",
+  "trailingComma": "es5",
   "semi": false,
   "singleQuote": true
 }

--- a/packages/neuron-ui/src/components/Addresses/index.tsx
+++ b/packages/neuron-ui/src/components/Addresses/index.tsx
@@ -47,7 +47,7 @@ const Addresses = () => {
         transactions: '0',
         key: address,
       })),
-    [receiving],
+    [receiving]
   )
 
   const changeAddresses = useMemo(
@@ -59,7 +59,7 @@ const Addresses = () => {
         transactions: '0',
         key: address,
       })),
-    [change],
+    [change]
   )
 
   const count = useMemo(() => receiving.length + change.length, [receiving, change])

--- a/packages/neuron-ui/src/components/History/hooks.ts
+++ b/packages/neuron-ui/src/components/History/hooks.ts
@@ -32,7 +32,7 @@ export const useOnChangePage = (search: string, pathname: string, history: Histo
       const newQuery = queryFormatter(params)
       history.push(`${pathname}?${newQuery.toString()}`)
     },
-    [search, pathname, history, queryFormatter],
+    [search, pathname, history, queryFormatter]
   )
 }
 
@@ -44,7 +44,7 @@ export const useOnAddressRemove = (search: string, pathname: string, history: Hi
       const newQuery = queryFormatter(params)
       history.push(`${pathname}?${newQuery.toString()}`)
     },
-    [search, pathname, history, queryFormatter],
+    [search, pathname, history, queryFormatter]
   )
 }
 

--- a/packages/neuron-ui/src/components/NetworkEditor/hooks.ts
+++ b/packages/neuron-ui/src/components/NetworkEditor/hooks.ts
@@ -17,7 +17,7 @@ export const useNetworkEditor = (
   { currentName, currentRemote }: { currentName: string; currentRemote: string } = {
     currentName: '',
     currentRemote: '',
-  },
+  }
 ) => {
   const [name, setName] = useState(currentName)
   const [remote, setRemote] = useState(currentRemote)
@@ -26,7 +26,7 @@ export const useNetworkEditor = (
       setName(initName)
       setRemote(initRemote)
     },
-    [setName, setRemote],
+    [setName, setRemote]
   )
 
   return {
@@ -94,7 +94,7 @@ export const useInputs = (editor: EditorType) => {
         placeholder: PlaceHolder.Name,
       },
     ],
-    [editor.remote, editor.name],
+    [editor.remote, editor.name]
   )
 }
 
@@ -106,7 +106,7 @@ export const useIsInputsValid = (editor: EditorType, cachedNetwork: Network | un
 
   const notModified = useMemo(
     () => cachedNetwork && (cachedNetwork.name === editor.name.value && cachedNetwork.remote === editor.remote.value),
-    [cachedNetwork, editor.name.value, editor.remote.value],
+    [cachedNetwork, editor.name.value, editor.remote.value]
   )
   return { invalidParams, notModified }
 }
@@ -116,7 +116,7 @@ export const useHandleSubmit = (
   name: string,
   remote: string,
   networks: Network[],
-  dispatch: DispatchType,
+  dispatch: DispatchType
 ) =>
   useCallback(() => {
     dispatch(actionCreators.createOrUpdateNetwork({ id, name, remote }, networks))

--- a/packages/neuron-ui/src/components/TransactionList/index.tsx
+++ b/packages/neuron-ui/src/components/TransactionList/index.tsx
@@ -65,7 +65,7 @@ const TransactionList = ({ items }: { items: Transaction[] }) => {
                     </MetaData>
                   ) : (
                     <td key={header.key}>{historyItem[header.key as keyof Transaction]}</td>
-                  ),
+                  )
                 )}
               </tr>
             ))}

--- a/packages/neuron-ui/src/components/Transfer/hooks.ts
+++ b/packages/neuron-ui/src/components/Transfer/hooks.ts
@@ -18,7 +18,7 @@ export const useUpdateTransferItem = (dispatch: React.Dispatch<any>) =>
         },
       })
     },
-    [dispatch],
+    [dispatch]
   )
 
 export const useOnSubmit = (dispatch: React.Dispatch<any>) =>
@@ -26,7 +26,7 @@ export const useOnSubmit = (dispatch: React.Dispatch<any>) =>
     (items: TransferItem[]) => () => {
       dispatch(actionCreators.submitTransfer(items))
     },
-    [dispatch],
+    [dispatch]
   )
 
 export const useOnPasswordChange = (dispatch: React.Dispatch<any>) =>
@@ -37,7 +37,7 @@ export const useOnPasswordChange = (dispatch: React.Dispatch<any>) =>
         payload: e.currentTarget.value,
       })
     },
-    [dispatch],
+    [dispatch]
   )
 
 export const useOnConfirm = (dispatch: React.Dispatch<any>, setLoading: Function) =>
@@ -60,15 +60,15 @@ export const useOnConfirm = (dispatch: React.Dispatch<any>, setLoading: Function
             id,
             items,
             password: pwd,
-          }),
+          })
         )
       }, 10)
     },
-    [dispatch, setLoading],
+    [dispatch, setLoading]
   )
 
 export const useOnItemChange = (updateTransferItem: Function) => (field: string, idx: number) => (
-  e: React.FormEvent<{ value: string }>,
+  e: React.FormEvent<{ value: string }>
 ) => {
   updateTransferItem(field)(idx)(e.currentTarget.value)
 }
@@ -83,14 +83,14 @@ export const useDropdownItems = (updateTransferItem: Function) =>
           key: unit,
           onClick: () => updateTransferItem('unit')(idx)(unit),
         })),
-    [updateTransferItem],
+    [updateTransferItem]
   )
 
 export const useInitialize = (
   address: string,
   dispatch: React.Dispatch<any>,
   history: History,
-  updateTransferItem: Function,
+  updateTransferItem: Function
 ) =>
   useEffect(() => {
     if (address) {

--- a/packages/neuron-ui/src/components/WalletEditor/hooks.ts
+++ b/packages/neuron-ui/src/components/WalletEditor/hooks.ts
@@ -8,7 +8,7 @@ export const useWalletEditor = () => {
     (initName: string = '') => {
       setName(initName)
     },
-    [setName],
+    [setName]
   )
   return {
     initialize,
@@ -29,7 +29,7 @@ export const useInputs = ({ name }: ReturnType<typeof useWalletEditor>) => {
         maxLength: 20,
       },
     ],
-    [name],
+    [name]
   )
 }
 
@@ -49,7 +49,7 @@ export const useToggleDialog = (dispatch: React.Dispatch<any>) =>
         },
       })
     },
-    [dispatch],
+    [dispatch]
   )
 
 export default {

--- a/packages/neuron-ui/src/components/WalletEditor/index.tsx
+++ b/packages/neuron-ui/src/components/WalletEditor/index.tsx
@@ -51,7 +51,7 @@ export default ({
       actionCreators.updateWallet({
         id: wallet.id,
         name: editor.name.value,
-      }),
+      })
     )
   }, [editor.name.value, wallet.id, dispatch, toggleDialog])
 

--- a/packages/neuron-ui/src/components/WalletSetting/hooks.ts
+++ b/packages/neuron-ui/src/components/WalletSetting/hooks.ts
@@ -12,7 +12,7 @@ export const useToggleDialog = (dispatch: React.Dispatch<any>) =>
         },
       })
     },
-    [dispatch],
+    [dispatch]
   )
 
 export const useDeleteWallet = () => {
@@ -38,7 +38,7 @@ export const useWalletToDelete = (deleteId: string, wallets: WalletIdentity[]) =
 export const useHandleConfirm = (
   deleteWallet: ReturnType<typeof useDeleteWallet>,
   toggleDialog: ReturnType<typeof useToggleDialog>,
-  dispatch: React.Dispatch<any>,
+  dispatch: React.Dispatch<any>
 ) =>
   useCallback(() => {
     toggleDialog(false)
@@ -46,7 +46,7 @@ export const useHandleConfirm = (
       actionCreators.deleteWallet({
         id: deleteWallet.id.value,
         password: deleteWallet.password.value,
-      }),
+      })
     )
   }, [deleteWallet, toggleDialog, dispatch])
 

--- a/packages/neuron-ui/src/components/WalletWizard/index.tsx
+++ b/packages/neuron-ui/src/components/WalletWizard/index.tsx
@@ -39,7 +39,7 @@ const Welcome = ({ rootPath }: { rootPath: string }) => {
       { label: 'wizard.create-new-wallet', href: `${rootPath}${WalletWizardPath.Mnemonic}/${MnemonicAction.Create}` },
       { label: 'wizard.import-wallet', href: `${rootPath}${WalletWizardPath.Mnemonic}/${MnemonicAction.Import}` },
     ],
-    [rootPath],
+    [rootPath]
   )
 
   return (
@@ -103,7 +103,7 @@ const Mnemonic = ({
         payload: e.target.value,
       })
     },
-    [dispatch],
+    [dispatch]
   )
   const onNext = useCallback(() => {
     if (isCreate) {
@@ -187,7 +187,7 @@ const Submission = ({
         })
       }
     },
-    [dispatch],
+    [dispatch]
   )
 
   const onNext = useCallback(() => {

--- a/packages/neuron-ui/src/components/withWizard/index.tsx
+++ b/packages/neuron-ui/src/components/withWizard/index.tsx
@@ -35,7 +35,7 @@ const reducer = (
   }: {
     type: string
     payload: string
-  },
+  }
 ) => {
   switch (type) {
     default: {

--- a/packages/neuron-ui/src/containers/MainContent/actionCreators/transfer.ts
+++ b/packages/neuron-ui/src/containers/MainContent/actionCreators/transfer.ts
@@ -27,7 +27,7 @@ export default {
           return true
         }
         return false
-      },
+      }
     )
     if (invalid) {
       return errorAction

--- a/packages/neuron-ui/src/containers/MainContent/index.tsx
+++ b/packages/neuron-ui/src/containers/MainContent/index.tsx
@@ -53,7 +53,7 @@ const MainContent = ({
             ...state,
             providerDispatch,
             dispatch,
-          }),
+          })
       )}
     </Main>
   )

--- a/packages/neuron-ui/src/containers/Providers/hooks.ts
+++ b/packages/neuron-ui/src/containers/Providers/hooks.ts
@@ -19,7 +19,7 @@ export const useChannelListeners = (i18n: any, chain: any, dispatch: React.Dispa
           activeWallet: any
           transactions: any
           locale: string
-        }>,
+        }>
       ) => {
         if (args.status) {
           const {
@@ -53,7 +53,7 @@ export const useChannelListeners = (i18n: any, chain: any, dispatch: React.Dispa
           /* eslint-enable no-alert */
           window.close()
         }
-      },
+      }
     )
 
     UILayer.on(Channel.App, (_e: Event, method: AppMethod, args: ChannelResponse<any>) => {

--- a/packages/neuron-ui/src/containers/Providers/index.tsx
+++ b/packages/neuron-ui/src/containers/Providers/index.tsx
@@ -5,7 +5,7 @@ import { initProviders, ProviderDispatch, reducer } from './reducer'
 import { useChannelListeners } from './hooks'
 
 const withProviders = (Comp: React.ComponentType<{ providerDispatch: ProviderDispatch }>) => (
-  props: React.Props<any>,
+  props: React.Props<any>
 ) => {
   const [providers, dispatch] = useReducer(reducer, initProviders)
   const { chain } = providers

--- a/packages/neuron-ui/src/serviceWorker.ts
+++ b/packages/neuron-ui/src/serviceWorker.ts
@@ -28,7 +28,7 @@ function registerValidSW(swUrl: string, config?: Config) {
               // content until all client tabs are closed.
               console.info(
                 'New content is available and will be used when all ' +
-                  'tabs for this page are closed. See http://bit.ly/CRA-PWA.',
+                  'tabs for this page are closed. See http://bit.ly/CRA-PWA.'
               )
 
               // Execute callback
@@ -83,7 +83,7 @@ const isLocalhost = Boolean(
     // [::1] is the IPv6 localhost address.
     window.location.hostname === '[::1]' ||
     // 127.0.0.1/8 is considered localhost for IPv4.
-    window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/),
+    window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)
 )
 
 type Config = {
@@ -114,7 +114,7 @@ export function register(config?: Config) {
         navigator.serviceWorker.ready.then(() => {
           console.info(
             'This web app is being served cache-first by a service ' +
-              'worker. To learn more, visit http://bit.ly/CRA-PWA',
+              'worker. To learn more, visit http://bit.ly/CRA-PWA'
           )
         })
       } else {

--- a/packages/neuron-ui/src/services/UILayer.ts
+++ b/packages/neuron-ui/src/services/UILayer.ts
@@ -130,7 +130,7 @@ export const wallets = (
     | { keystore: string; password: string }
     | { mnemonic: string; password: string }
     | { id: string; password: string }
-    | { id: string; name?: string; password: string; newPassword?: string },
+    | { id: string; name?: string; password: string; newPassword?: string }
 ) => {
   UILayer.send(Channel.Wallets, method, params)
 }

--- a/packages/neuron-ui/src/utils/formatters.ts
+++ b/packages/neuron-ui/src/utils/formatters.ts
@@ -30,7 +30,7 @@ export type currencyCode = 'CKB' | 'CNY' | 'USD'
 export const currencyFormatter = (
   shannons: string,
   unit: currencyCode = 'CKB',
-  exchange: string = '0.000000001',
+  exchange: string = '0.000000001'
 ): string => {
   const [integer, decimal] = numberParser(shannons, exchange)
   const dot = '.'

--- a/packages/neuron-ui/src/widgets/BannerMessages/index.tsx
+++ b/packages/neuron-ui/src/widgets/BannerMessages/index.tsx
@@ -55,7 +55,7 @@ const BannerMessages = ({ messages, style = {} }: { messages: Message[]; style?:
                 <button key={label} type="button" className={`btn btn-outline-${category}`} onClick={action}>
                   {label}
                 </button>
-              ),
+              )
             )}
           </ActionZone>
         </AlertItem>

--- a/packages/neuron-wallet/src/controllers/app/index.ts
+++ b/packages/neuron-wallet/src/controllers/app/index.ts
@@ -48,7 +48,7 @@ export default class AppController {
 
   public static showMessageBox(
     options: MessageBoxOptions,
-    callback: (response: number, checkboxChecked: boolean) => void = () => {},
+    callback: (response: number, checkboxChecked: boolean) => void = () => {}
   ) {
     dialog.showMessageBox(options, callback)
   }

--- a/packages/neuron-wallet/src/controllers/app/options.ts
+++ b/packages/neuron-wallet/src/controllers/app/options.ts
@@ -79,7 +79,7 @@ export const contextMenuTemplate: {
                   })
                 }
               }
-            },
+            }
           )
         },
       },
@@ -121,7 +121,7 @@ export const contextMenuTemplate: {
                   if (filename) {
                     fs.writeFileSync(filename, JSON.stringify(keystore))
                   }
-                },
+                }
               )
             })
             .catch((err: Error) => {

--- a/packages/neuron-wallet/src/controllers/transactions.ts
+++ b/packages/neuron-wallet/src/controllers/transactions.ts
@@ -21,7 +21,7 @@ import { KeyHasNoData, TransactionNotFound, CurrentWalletNotSet, ServiceHasNoRes
 export default class TransactionsController {
   @CatchControllerError
   public static async getAll(
-    params: TransactionsByLockHashesParam,
+    params: TransactionsByLockHashesParam
   ): Promise<Controller.Response<PaginationResult<Transaction>>> {
     const transactions = await TransactionsService.getAll(params)
 
@@ -35,7 +35,7 @@ export default class TransactionsController {
 
   @CatchControllerError
   public static async getAllByAddresses(
-    params: TransactionsByAddressesParam,
+    params: TransactionsByAddressesParam
   ): Promise<Controller.Response<PaginationResult<Transaction> & TransactionsByAddressesParam>> {
     const { pageNo, pageSize, addresses } = params
 

--- a/packages/neuron-wallet/src/keys/key.ts
+++ b/packages/neuron-wallet/src/keys/key.ts
@@ -53,7 +53,7 @@ export default class Key {
     @Required keystore: string,
     @Password password: string,
     receivingAddressNumber = DefaultAddressNumber.Receiving,
-    changeAddressNumber = DefaultAddressNumber.Change,
+    changeAddressNumber = DefaultAddressNumber.Change
   ) {
     const keystoreObject: Keystore = JSON.parse(keystore)
     const key = new Key()
@@ -70,7 +70,7 @@ export default class Key {
         N: kdfparams.n,
         r: kdfparams.r,
         p: kdfparams.p,
-      },
+      }
     )
     const ciphertext = Buffer.from(keystoreObject.crypto.ciphertext, 'hex')
     const hash = new SHA3(256)
@@ -85,7 +85,7 @@ export default class Key {
     const decipher = crypto.createDecipheriv(
       keystoreObject.crypto.cipher,
       derivedKey.slice(0, 16),
-      Buffer.from(keystoreObject.crypto.cipherparams.iv, 'hex'),
+      Buffer.from(keystoreObject.crypto.cipherparams.iv, 'hex')
     )
     const seed = `0x${Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('hex')}`
     const keysData = Buffer.from(seed.replace('0x', ''), 'hex').toString()
@@ -99,7 +99,7 @@ export default class Key {
     @Required mnemonic: string,
     @Password password: string,
     receivingAddressNumber = DefaultAddressNumber.Receiving,
-    changeAddressNumber = DefaultAddressNumber.Change,
+    changeAddressNumber = DefaultAddressNumber.Change
   ) {
     if (!bip39.validateMnemonic(mnemonic)) {
       throw new InvalidMnemonic()
@@ -128,7 +128,7 @@ export default class Key {
         N: kdfparams.n,
         r: kdfparams.r,
         p: kdfparams.p,
-      },
+      }
     )
     const ciphertext = Buffer.from(this.keystore.crypto.ciphertext, 'hex')
     const hash = new SHA3(256)

--- a/packages/neuron-wallet/src/services/addresses.ts
+++ b/packages/neuron-wallet/src/services/addresses.ts
@@ -44,7 +44,7 @@ class Address {
   public static generateAddresses = (
     keysData: KeysData,
     receivingAddressCount: number = 20,
-    changeAddressCount: number = 10,
+    changeAddressCount: number = 10
   ) => {
     if (receivingAddressCount < 1 || changeAddressCount < 1) {
       throw new Error('Address number error.')
@@ -90,7 +90,7 @@ class Address {
     startIndex = 0,
     maxUsedIndex = 0,
     minUnusedIndex = 100,
-    depth = 0,
+    depth = 0
   ): any => {
     if (depth >= 10) return maxUsedIndex + 1
     if (!Address.isAddressUsed(Address.addressFromHDIndex(keysData, startIndex))) {
@@ -102,7 +102,7 @@ class Address {
         Math.floor((startIndex - maxUsedIndex) / 2 + maxUsedIndex),
         maxUsedIndex,
         Math.min(minUnusedIndex, startIndex),
-        depth + 1,
+        depth + 1
       )
     }
     if (!Address.isAddressUsed(Address.addressFromHDIndex(keysData, startIndex + 1))) {
@@ -113,7 +113,7 @@ class Address {
       Math.round((minUnusedIndex - startIndex) / 2 + startIndex),
       Math.max(maxUsedIndex, startIndex),
       minUnusedIndex,
-      depth + 1,
+      depth + 1
     )
   }
 }

--- a/packages/neuron-wallet/src/services/cells.ts
+++ b/packages/neuron-wallet/src/services/cells.ts
@@ -50,7 +50,7 @@ export default class CellsService {
   // gather inputs for generateTx
   public static gatherInputs = async (
     capacity: string,
-    lockHashes: string[],
+    lockHashes: string[]
   ): Promise<{
     inputs: CKBComponents.CellInput[]
     capacities: string

--- a/packages/neuron-wallet/src/services/networks.ts
+++ b/packages/neuron-wallet/src/services/networks.ts
@@ -111,7 +111,7 @@ export default class NetworksService extends Store {
   public async create(
     @Required name: NetworkName,
     @Required remote: NetworkRemote,
-    type: NetworkType = NetworkType.Normal,
+    type: NetworkType = NetworkType.Normal
   ) {
     const list = await this.getAll()
     if (list.some(item => item.name === name)) {

--- a/packages/neuron-wallet/src/services/node.ts
+++ b/packages/neuron-wallet/src/services/node.ts
@@ -72,7 +72,7 @@ class NodeService {
             })
         }),
         retry(3),
-        distinctUntilChanged(),
+        distinctUntilChanged()
       )
       .subscribe(
         tipNumber => {
@@ -86,7 +86,7 @@ class NodeService {
           this.tipNumberSubject.next(undefined)
           const { unsubscribe } = this.tipNumber()
           this.stop = unsubscribe
-        },
+        }
       )
   }
 }

--- a/packages/neuron-wallet/src/services/sync-blocks.ts
+++ b/packages/neuron-wallet/src/services/sync-blocks.ts
@@ -49,7 +49,7 @@ export default class SyncBlocksService {
   constructor(
     lockHashes: string[],
     tipNumberSubject: BehaviorSubject<string | undefined> = NodeService.getInstance().tipNumberSubject,
-    addressesUsedSubject: Subject<string[]> = AddressesUsedSubject.subject,
+    addressesUsedSubject: Subject<string[]> = AddressesUsedSubject.subject
   ) {
     this.lockHashList = lockHashes
     this.addressesUsedSubject = addressesUsedSubject
@@ -155,7 +155,7 @@ export default class SyncBlocksService {
   // delete all transactions where blockNumber >= checkResult.blockHeader!.number
   async deleteTxs(sinceBlockNumber: string) {
     const blockNumbers: number[] = Array.from({ length: this.sizeForCheck + 2 }).map(
-      (_a, i) => i + parseInt(sinceBlockNumber, 10),
+      (_a, i) => i + parseInt(sinceBlockNumber, 10)
     )
     await TransactionsService.deleteByBlockNumbers(blockNumbers.map(n => n.toString()))
   }
@@ -213,13 +213,13 @@ export default class SyncBlocksService {
       blockNumbers.map(async num => {
         const block = await core.rpc.getBlockByNumber(num.toString())
         return TypeConvert.toBlock(block)
-      }),
+      })
     )
     return blocks
   }
 
   checkBlockRange(
-    blockHeaders: BlockHeader[],
+    blockHeaders: BlockHeader[]
   ): {
     success: boolean
     index?: number
@@ -266,7 +266,7 @@ export default class SyncBlocksService {
     await Promise.all(
       blocks.map(async block => {
         await this.resolveBlock(block)
-      }),
+      })
     )
   }
 

--- a/packages/neuron-wallet/src/services/sync/block-listener.ts
+++ b/packages/neuron-wallet/src/services/sync/block-listener.ts
@@ -15,7 +15,7 @@ export default class BlockListener {
 
   constructor(
     lockHashes: string[],
-    tipNumberSubject: BehaviorSubject<string | undefined> = NodeService.getInstance().tipNumberSubject,
+    tipNumberSubject: BehaviorSubject<string | undefined> = NodeService.getInstance().tipNumberSubject
   ) {
     this.lockHashes = lockHashes
     this.currentBlockNumber = new BlockNumber()
@@ -96,7 +96,7 @@ export default class BlockListener {
       startBlockNumber,
       endBlockNumber,
       this.currentBlockNumber,
-      this.rangeForCheck,
+      this.rangeForCheck
     )
 
     this.queue.get().drain(() => {

--- a/packages/neuron-wallet/src/services/sync/check-and-save/index.ts
+++ b/packages/neuron-wallet/src/services/sync/check-and-save/index.ts
@@ -16,7 +16,7 @@ export default class CheckAndSave {
       txs.map(async tx => {
         const checkTx = new CheckTx(tx)
         return checkTx.checkAndSave(this.lockHashes)
-      }),
+      })
     )
   }
 }

--- a/packages/neuron-wallet/src/services/sync/get-blocks.ts
+++ b/packages/neuron-wallet/src/services/sync/get-blocks.ts
@@ -29,7 +29,7 @@ export default class GetBlocks {
     const blocks: Block[] = await Promise.all(
       blockNumbers.map(async num => {
         return this.retryGetBlock(num)
-      }),
+      })
     )
 
     return blocks

--- a/packages/neuron-wallet/src/services/sync/queue.ts
+++ b/packages/neuron-wallet/src/services/sync/queue.ts
@@ -23,7 +23,7 @@ export default class Queue {
     startBlockNumber: string,
     endBlockNumber: string,
     currentBlockNumber: BlockNumber = new BlockNumber(),
-    rangeForCheck: RangeForCheck = new RangeForCheck(),
+    rangeForCheck: RangeForCheck = new RangeForCheck()
   ) {
     this.generateQueue()
     this.lockHashes = lockHashes

--- a/packages/neuron-wallet/src/services/sync/renderer-params.ts
+++ b/packages/neuron-wallet/src/services/sync/renderer-params.ts
@@ -1,5 +1,5 @@
 import { remote } from 'electron'
 
 export const { networkSwitchSubject, nodeService, addressChangeSubject, addressesUsedSubject } = remote.require(
-  './startup/sync-block-task/params',
+  './startup/sync-block-task/params'
 )

--- a/packages/neuron-wallet/src/services/transactions.ts
+++ b/packages/neuron-wallet/src/services/transactions.ts
@@ -106,13 +106,13 @@ export default class TransactionsService {
   }
 
   public static getAllByAddresses = async (
-    params: TransactionsByAddressesParam,
+    params: TransactionsByAddressesParam
   ): Promise<PaginationResult<Transaction>> => {
     const lockHashes: string[] = await Promise.all(
       params.addresses.map(async addr => {
         const lockHash: string = await LockUtils.addressToLockHash(addr)
         return lockHash
-      }),
+      })
     )
 
     return TransactionsService.getAll({
@@ -123,14 +123,14 @@ export default class TransactionsService {
   }
 
   public static getAllByPubkeys = async (
-    params: TransactionsByPubkeysParams,
+    params: TransactionsByPubkeysParams
   ): Promise<PaginationResult<Transaction>> => {
     const lockHashes: string[] = await Promise.all(
       params.pubkeys.map(async pubkey => {
         const addr = core.utils.pubkeyToAddress(pubkey)
         const lockHash = await LockUtils.addressToLockHash(addr)
         return lockHash
-      }),
+      })
     )
 
     return TransactionsService.getAll({
@@ -209,7 +209,7 @@ export default class TransactionsService {
           const output = o
           output.status = OutputStatus.Live
           return output
-        }),
+        })
       )
 
       const previousOutputsWithUndefined: Array<OutputEntity | undefined> = await Promise.all(
@@ -228,7 +228,7 @@ export default class TransactionsService {
             return outputEntity
           }
           return undefined
-        }),
+        })
       )
 
       const previousOutputs: OutputEntity[] = previousOutputsWithUndefined.filter(o => !!o) as OutputEntity[]
@@ -244,7 +244,7 @@ export default class TransactionsService {
   public static create = async (
     transaction: Transaction,
     outputStatus: OutputStatus,
-    inputStatus: OutputStatus,
+    inputStatus: OutputStatus
   ): Promise<TransactionEntity> => {
     const connection = getConnection()
     const tx = new TransactionEntity()
@@ -298,7 +298,7 @@ export default class TransactionsService {
         output.transaction = tx
         output.status = outputStatus
         return output
-      }),
+      })
     )
 
     await connection.manager.save([tx, ...inputs, ...previousOutputs, ...outputs])
@@ -323,7 +323,7 @@ export default class TransactionsService {
   // when fetch a transaction, use TxSaveType.Fetch
   public static convertTransactionAndSave = async (
     transaction: Transaction,
-    saveType: TxSaveType,
+    saveType: TxSaveType
   ): Promise<TransactionEntity> => {
     const tx: Transaction = transaction
     tx.outputs = tx.outputs!.map(o => {
@@ -350,7 +350,7 @@ export default class TransactionsService {
           }
         }
         return input
-      }),
+      })
     )
     let txEntity: TransactionEntity
     if (saveType === TxSaveType.Sent) {
@@ -366,14 +366,14 @@ export default class TransactionsService {
   public static saveFetchTx = async (transaction: Transaction): Promise<TransactionEntity> => {
     const txEntity: TransactionEntity = await TransactionsService.convertTransactionAndSave(
       transaction,
-      TxSaveType.Fetch,
+      TxSaveType.Fetch
     )
     return txEntity
   }
 
   public static saveSentTx = async (
     transaction: TransactionWithoutHash,
-    txHash: string,
+    txHash: string
   ): Promise<TransactionEntity> => {
     const tx: Transaction = {
       hash: txHash,
@@ -387,7 +387,7 @@ export default class TransactionsService {
   public static generateTx = async (
     lockHashes: string[],
     targetOutputs: TargetOutput[],
-    changeAddress: string,
+    changeAddress: string
   ): Promise<CKBComponents.RawTransaction> => {
     const { codeHash, outPoint } = await LockUtils.systemScript()
 
@@ -419,7 +419,7 @@ export default class TransactionsService {
       const changeBlake160: string = core.utils.parseAddress(
         changeAddress,
         core.utils.AddressPrefix.Testnet,
-        'hex',
+        'hex'
       ) as string
 
       const output: CKBComponents.CellOutput = {

--- a/packages/neuron-wallet/src/services/wallets.ts
+++ b/packages/neuron-wallet/src/services/wallets.ts
@@ -279,7 +279,7 @@ export default class WalletService {
       capacity: CKBComponents.Capacity
       unit: 'byte' | 'shannon'
     }[],
-    password: string,
+    password: string
   ) => {
     const wallet = await this.getCurrent()
     if (!wallet) throw new CurrentWalletNotSet()
@@ -304,7 +304,7 @@ export default class WalletService {
       const identifier = core.utils.parseAddress(
         address,
         env.testnet ? core.utils.AddressPrefix.Testnet : core.utils.AddressPrefix.Mainnet,
-        'hex',
+        'hex'
       ) as string
       if (!identifier.startsWith(hrp)) throw new InvalidAddress(address)
       return core.utils.lockScriptToHash({
@@ -333,7 +333,7 @@ export default class WalletService {
       {
         length: rawTransaction.inputs.length,
       },
-      () => witness,
+      () => witness
     )
     rawTransaction.witnesses = witnesses
     const realTxHash = await core.rpc.sendTransaction(rawTransaction)

--- a/packages/neuron-wallet/src/startup/sync-block-task/task.ts
+++ b/packages/neuron-wallet/src/startup/sync-block-task/task.ts
@@ -8,7 +8,7 @@ import BlockListener from '../../services/sync/block-listener'
 import { NetworkWithID } from '../../services/networks'
 
 const { networkSwitchSubject, nodeService, addressChangeSubject, addressesUsedSubject } = remote.require(
-  './startup/sync-block-task/params',
+  './startup/sync-block-task/params'
 )
 
 // pass to task a main process subject
@@ -23,7 +23,7 @@ export const loadAddressesAndConvert = async (): Promise<string[]> => {
   const lockHashes: string[] = await Promise.all(
     addresses.map(async addr => {
       return LockUtils.addressToLockHash(addr)
-    }),
+    })
   )
   return lockHashes
 }

--- a/packages/neuron-wallet/tests/keys/hd.test.ts
+++ b/packages/neuron-wallet/tests/keys/hd.test.ts
@@ -5,13 +5,13 @@ describe('BIP32 Keychain tests', () => {
   const shortSeed = Buffer.from('000102030405060708090a0b0c0d0e0f', 'hex')
   const longSeed = Buffer.from(
     'fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542',
-    'hex',
+    'hex'
   )
 
   it('create master keychain from seed', () => {
     const master = Keychain.fromSeed(shortSeed)
     expect(master.privateKey.toString('hex')).toEqual(
-      'e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35',
+      'e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35'
     )
     expect(master.identifier.toString('hex')).toEqual('3442193e1bb70916e914552172cd4e2dbc9df811')
     expect(master.fingerprint).toEqual(876747070)
@@ -35,7 +35,7 @@ describe('BIP32 Keychain tests', () => {
   it('derive path', () => {
     const master = Keychain.fromSeed(shortSeed)
     expect(master.derivePath(`m/0'`).privateKey.toString('hex')).toEqual(
-      'edb2e14f9ee77d26dd93b4ecede8d16ed408ce149b6cd80b0715a2d911a0afea',
+      'edb2e14f9ee77d26dd93b4ecede8d16ed408ce149b6cd80b0715a2d911a0afea'
     )
 
     const child = master.derivePath(`m/0'/1/2'`)
@@ -50,7 +50,7 @@ describe('BIP32 Keychain tests', () => {
   it('create master keychain from long seed', () => {
     const master = Keychain.fromSeed(longSeed)
     expect(master.privateKey.toString('hex')).toEqual(
-      '4b03d6fc340455b363f51020ad3ecca4f0850280cf436c70c727923f6db46c3e',
+      '4b03d6fc340455b363f51020ad3ecca4f0850280cf436c70c727923f6db46c3e'
     )
     expect(master.identifier.toString('hex')).toEqual('bd16bee53961a47d6ad888e29545434a89bdfe95')
     expect(master.fingerprint).toEqual(3172384485)
@@ -63,7 +63,7 @@ describe('BIP32 Keychain tests', () => {
   it('derive path large index', () => {
     const master = Keychain.fromSeed(longSeed)
     expect(master.derivePath(`m`).privateKey.toString('hex')).toEqual(
-      '4b03d6fc340455b363f51020ad3ecca4f0850280cf436c70c727923f6db46c3e',
+      '4b03d6fc340455b363f51020ad3ecca4f0850280cf436c70c727923f6db46c3e'
     )
 
     let child = master.derivePath(`0/2147483647'`)
@@ -106,7 +106,7 @@ describe('BIP32 Keychain tests', () => {
     const child = Keychain.fromPublicKey(
       Buffer.from('0357bfe1e341d01c69fe5654309956cbea516822fba8a601743a012a7896ee8dc2', 'hex'),
       Buffer.from('04466b9cc8e161e966409ca52986c584f07e9dc81f735db683c3ff6ec7b1503f', 'hex'),
-      `m/0'/1/2'`,
+      `m/0'/1/2'`
     )
     expect(child.identifier.toString('hex')).toEqual('ee7ab90cde56a8c0e2bb086ac49748b8db9dce72')
     expect(child.fingerprint).toEqual(4001020172)
@@ -115,10 +115,10 @@ describe('BIP32 Keychain tests', () => {
 
     const grandchild = child.deriveChild(2, false)
     expect(grandchild.publicKey.toString('hex')).toEqual(
-      '02e8445082a72f29b75ca48748a914df60622a609cacfce8ed0e35804560741d29',
+      '02e8445082a72f29b75ca48748a914df60622a609cacfce8ed0e35804560741d29'
     )
     expect(grandchild.chainCode.toString('hex')).toEqual(
-      'cfb71883f01676f587d023cc53a35bc7f88f724b1f8c2892ac1275ac822a3edd',
+      'cfb71883f01676f587d023cc53a35bc7f88f724b1f8c2892ac1275ac822a3edd'
     )
     expect(grandchild.identifier.toString('hex')).toEqual('d880d7d893848509a62d8fb74e32148dac68412f')
     expect(grandchild.fingerprint).toEqual(3632322520)
@@ -129,7 +129,7 @@ describe('BIP32 Keychain tests', () => {
   it('private key add', () => {
     const k = new Keychain(
       Buffer.from('9e919c96ac5a4caea7ba0ea1f7dd7bca5dca8a11e66ed633690c71e483a6e3c9', 'hex'),
-      Buffer.from('36e92e33659808bf06c3e4302b657f39ca285f6bb5393019bb4e2f7b96e3f914', 'hex'),
+      Buffer.from('36e92e33659808bf06c3e4302b657f39ca285f6bb5393019bb4e2f7b96e3f914', 'hex')
     )
     const t = k.privateKeyAdd(k.privateKey, k.chainCode)
     expect(t.toString('hex')).toEqual('d57acaca11f2556dae7df2d22342fb0427f2e97d9ba8064d245aa1601a8adcdd')
@@ -138,10 +138,10 @@ describe('BIP32 Keychain tests', () => {
   it('public key add', () => {
     const k = new Keychain(
       Buffer.from('56788dc69315bf1b10c1ae232176de9dd57e83bf07f9bc33f64f9da9eb31f13b', 'hex'),
-      Buffer.from('953fd6b91b51605d32a28ab478f39ab53c90103b93bd688330b118c460e9c667', 'hex'),
+      Buffer.from('953fd6b91b51605d32a28ab478f39ab53c90103b93bd688330b118c460e9c667', 'hex')
     )
     expect(k.publicKey).toEqual(
-      Buffer.from('03556b2c7e03b12845a973a6555b49fe44b0836fbf3587709fa73bb040ba181b21', 'hex'),
+      Buffer.from('03556b2c7e03b12845a973a6555b49fe44b0836fbf3587709fa73bb040ba181b21', 'hex')
     )
     const t = k.publicKeyAdd(k.publicKey, k.chainCode)
     expect(t.toString('hex')).toEqual('03db6eab66f918e434bae0e24fd73de1a2b293a2af9bd3ad53123996fa94494f37')

--- a/packages/neuron-wallet/tests/utils/validators.test.ts
+++ b/packages/neuron-wallet/tests/utils/validators.test.ts
@@ -8,7 +8,7 @@ describe('validators', () => {
     expect(verifyPasswordComplexity('1234ABbaa3'))
     expect(verifyPasswordComplexity('1234AB!@'))
     expect(() => verifyPasswordComplexity('12abAC.')).toThrow(
-      i18n.t('messages.wallet-password-less-than-min-length', { minPasswordLength: MIN_PASSWORD_LENGTH }),
+      i18n.t('messages.wallet-password-less-than-min-length', { minPasswordLength: MIN_PASSWORD_LENGTH })
     )
     expect(() => verifyPasswordComplexity('1234567a')).toThrow(i18n.t('messages.wallet-password-letter-complexity'))
     expect(() => verifyPasswordComplexity('1234ABAAA')).toThrow(i18n.t('messages.wallet-password-letter-complexity'))


### PR DESCRIPTION
## Purpose

Do not require trailing comma for function parameters.

## Issue

Prettier's `trailingComma` - `all` option takes over `eslint` - `comma-dangle` - `"functions": "ignore"`.

## Solution

Change `trailingComma` to `es5`.