### PR TITLE
test: Update jest config to run only neuron-wallet tests automatically inside vscode

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+jest.config.js

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,6 @@ module.exports = {
   bail: 1,
   verbose: true,
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
-  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$"],
   projects: [
     "<rootDir>/packages/neuron-wallet"
   ]

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  testRegex: "(/tests/.*.(test|spec))\\.(ts?|js?)$",
+  transform: {
+    "^.+\\.ts?$": "ts-jest"
+  },
+  bail: 1,
+  verbose: true,
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$"],
+  projects: [
+    "<rootDir>/packages/neuron-wallet"
+  ]
+};

--- a/packages/neuron-ui/package.json
+++ b/packages/neuron-ui/package.json
@@ -30,6 +30,9 @@
       "git add"
     ]
   },
+  "jest": {
+    "displayName": "Neuron UI"
+  },
   "browserslist": ["last 2 chrome versions"],
   "dependencies": {
     "bootstrap": "4.3.1",

--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -31,7 +31,7 @@
     ]
   },
   "jest": {
-    "displayName": "electron",
+    "displayName": "Neuron Wallet",
     "testRegex": "(/tests/.*.(test|spec))\\.(ts?|js?)$",
     "transform": {
       "^.+\\.ts?$": "ts-jest"


### PR DESCRIPTION
Jest couldn't pick up neuron-ui tests as RCA has its own jest settings.

Note this doesn't affect our running `yarn test` manually. Only affects the vscode jest extension behavior.