### PR TITLE
refactor: update sending status of ui via neuron-wallet's messages

### DIFF
--- a/packages/neuron-ui/src/components/Send/index.tsx
+++ b/packages/neuron-ui/src/components/Send/index.tsx
@@ -6,9 +6,11 @@ import { useTranslation } from 'react-i18next'
 import TransactionFeePanel from 'components/TransactionFeePanel'
 import QRScanner from 'widgets/QRScanner'
 import InlineInputWithDropdown from 'widgets/InlineInput/InlineInputWithDropdown'
+import { Spinner } from 'widgets/Loading'
 
 import { ContentProps } from 'containers/MainContent'
 import { PlaceHolders } from 'utils/const'
+import { useNeuronWallet } from 'utils/hooks'
 
 import { useInitialize } from './hooks'
 
@@ -22,6 +24,9 @@ const Send = ({
   },
 }: React.PropsWithoutRef<ContentProps & RouteComponentProps<{ address: string }>>) => {
   const { t } = useTranslation()
+  const {
+    wallet: { sending },
+  } = useNeuronWallet()
   const {
     id,
     updateTransactionOutput,
@@ -47,6 +52,7 @@ const Send = ({
                   <Col sm={10}>
                     <InputGroup>
                       <Form.Control
+                        disabled={sending}
                         value={item.address || ''}
                         onChange={onItemChange('address', idx)}
                         placeholder={PlaceHolders.send.Address}
@@ -72,6 +78,7 @@ const Send = ({
                   value={item.amount}
                   placeholder={PlaceHolders.send.Amount}
                   onChange={onItemChange('amount', idx)}
+                  disabled={sending}
                   dropDown={{
                     title: item.unit,
                     items: dropdownItems(idx),
@@ -91,8 +98,15 @@ const Send = ({
             ))}
           </Form>
           <TransactionFeePanel fee="10" cycles="10" price={send.price} onPriceChange={updateTransactionPrice} />
-          <Button type="submit" variant="primary" size="lg" block onClick={onSubmit(id, send.outputs)}>
-            {t('send.send')}
+          <Button
+            type="submit"
+            variant="primary"
+            size="lg"
+            block
+            onClick={onSubmit(id, send.outputs)}
+            disabled={sending}
+          >
+            {sending ? <Spinner /> : t('send.send')}
           </Button>
         </Card.Body>
       </Card>

--- a/packages/neuron-ui/src/containers/Providers/hooks.ts
+++ b/packages/neuron-ui/src/containers/Providers/hooks.ts
@@ -168,6 +168,15 @@ export const useChannelListeners = (i18n: any, chain: any, dispatch: React.Dispa
             history.push(`${Routes.Transaction}/${args.result}`)
             break
           }
+          case WalletsMethod.SendingStatus: {
+            dispatch({
+              type: ProviderActions.Wallet,
+              payload: {
+                sending: args.result,
+              },
+            })
+            break
+          }
           default: {
             break
           }

--- a/packages/neuron-ui/src/contexts/NeuronWallet/wallet.ts
+++ b/packages/neuron-ui/src/contexts/NeuronWallet/wallet.ts
@@ -7,6 +7,7 @@ export interface Wallet extends WalletIdentity {
   addresses: Addresses
   publicKey: Uint8Array
   message: string
+  sending: boolean
 }
 
 export interface Addresses {
@@ -21,6 +22,7 @@ export const walletState: Wallet = {
   addresses: { receiving: [], change: [] },
   publicKey: new Uint8Array(0),
   message: '',
+  sending: false,
 }
 
 export default walletState

--- a/packages/neuron-ui/src/services/UILayer.ts
+++ b/packages/neuron-ui/src/services/UILayer.ts
@@ -33,6 +33,7 @@ export enum WalletsMethod {
   Activate = 'activate',
   Backup = 'backup',
   SendCapacity = 'sendCapacity',
+  SendingStatus = 'sendingStatus',
 }
 
 export enum NetworksMethod {

--- a/packages/neuron-wallet/src/controllers/wallets/index.ts
+++ b/packages/neuron-wallet/src/controllers/wallets/index.ts
@@ -18,6 +18,7 @@ import {
 } from '../../exceptions'
 import prompt from '../../utils/prompt'
 import i18n from '../../utils/i18n'
+import windowManage from '../../utils/window-manage'
 
 const walletsService = WalletsService.getInstance()
 
@@ -277,11 +278,21 @@ export default class WalletsController {
     if (!params) throw new IsRequired('Parameters')
     try {
       const hash = await walletsService.sendCapacity(params.items, password)
+
+      // TODO: tell neuron-ui when to set sending to false, usually at the time the tx hash returns
+      windowManage.broadcast(Channel.Wallets, 'sendingStatus' as any, {
+        status: ResponseCode.Success,
+        result: true,
+      })
       return {
         status: ResponseCode.Success,
         result: hash,
       }
     } catch (err) {
+      windowManage.broadcast(Channel.Wallets, 'sendingStatus' as any, {
+        status: ResponseCode.Success,
+        result: false,
+      })
       return {
         status: ResponseCode.Fail,
         msg: {


### PR DESCRIPTION
the sending state should be set after verification of password, which happens in neuron-wallet, so a
message is required to display the loading view.