### PR TITLE
Revert "refactor(neuron-wallet): slice '0x' in privateToPublic"

### DIFF
--- a/packages/neuron-wallet/src/keys/keychain.ts
+++ b/packages/neuron-wallet/src/keys/keychain.ts
@@ -5,10 +5,7 @@ import BN from 'bn.js'
 const ec = new EC('secp256k1')
 
 export const privateToPublic = (privateKey: Buffer) => {
-  return Buffer.from(
-    ec.keyFromPrivate(privateKey.length === 66 ? privateKey.slice(2) : privateKey).getPublic(true, 'hex') as string,
-    'hex'
-  )
+  return Buffer.from(ec.keyFromPrivate(privateKey).getPublic(true, 'hex') as string, 'hex')
 }
 
 const EMPTY_BUFFER = Buffer.from('')

--- a/packages/neuron-wallet/src/keys/keychain.ts
+++ b/packages/neuron-wallet/src/keys/keychain.ts
@@ -5,6 +5,9 @@ import BN from 'bn.js'
 const ec = new EC('secp256k1')
 
 export const privateToPublic = (privateKey: Buffer) => {
+  if (privateKey.length !== 32) {
+    throw new Error('Private key must be 32 bytes')
+  }
   return Buffer.from(ec.keyFromPrivate(privateKey).getPublic(true, 'hex') as string, 'hex')
 }
 

--- a/packages/neuron-wallet/tests/keys/keychain.test.ts
+++ b/packages/neuron-wallet/tests/keys/keychain.test.ts
@@ -174,4 +174,14 @@ describe('private to public', () => {
     const publicKey = Buffer.from('03e5b310636a0f6e7dcdfffa98f28d7ed70df858bb47acf13db830bfde3510b3f3', 'hex')
     expect(privateToPublic(privateKey)).toEqual(publicKey)
   })
+
+  it('derive public key from private key wrong length', () => {
+    expect(() => privateToPublic(Buffer.from(''))).toThrowError()
+    expect(() =>
+      privateToPublic(Buffer.from('39d218506b30ca69b0f3112427877d983dd3cd2cabc742ab723e2964d98016', 'hex'))
+    ).toThrowError()
+    expect(() =>
+      privateToPublic(Buffer.from('0xbb39d218506b30ca69b0f3112427877d983dd3cd2cabc742ab723e2964d98016', 'hex'))
+    ).toThrowError()
+  })
 })


### PR DESCRIPTION
This reverts commit 61a0e1491d7150c0e7092591ff9bdfe8af2797f7.

1. Buffer.from never accepts string with 0x prefixed hex string (as I observed).
2. 66 is length of string key, not buffer.

Let's keep stripping the 0x outside.

Original PR: https://github.com/nervosnetwork/neuron/pull/493