### PR TITLE
Revert "test(neuron-wallet): save cached data in neuron-wallet/tests/…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ node_modules
 
 # testing
 /coverage
-userData
 
 # production
 build

--- a/packages/neuron-wallet/src/app.ts
+++ b/packages/neuron-wallet/src/app.ts
@@ -1,9 +1,10 @@
 import path from 'path'
+import os from 'os'
 import { app as electronApp, remote } from 'electron'
 
 const fakeApp = {
   getPath(aPath: string): string {
-    return path.join(__dirname, '../tests', aPath)
+    return path.join(os.tmpdir(), aPath)
   },
   getName(): string {
     return 'Fake App'


### PR DESCRIPTION
…userData"

This reverts commit 9fa6828361d19ac02120a3b6c810189eaefd89e5.

Now we have confirmed network tests' failures are not due to OS temp
folder access, change this back to use temp folder.