### PR TITLE
feat: update lockHashes when new address generated

### DIFF
--- a/packages/neuron-wallet/src/startup/sync-block-task/create.ts
+++ b/packages/neuron-wallet/src/startup/sync-block-task/create.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow } from 'electron'
-import { Subject, ReplaySubject } from 'rxjs'
+import { ReplaySubject } from 'rxjs'
 import path from 'path'
 import { networkSwitchSubject, NetworkWithID } from '../../services/networks'
 import env from '../../env'
@@ -27,9 +27,6 @@ networkSwitchSubject.subscribe(async (network: NetworkWithID | undefined) => {
     await updateAllAddressesTxCount()
   }
 })
-
-// TODO: mock as an address subject
-export const addressChangeSubject = new Subject()
 
 const loadURL = `file://${path.join(__dirname, 'index.html')}`
 

--- a/packages/neuron-wallet/src/startup/sync-block-task/params.ts
+++ b/packages/neuron-wallet/src/startup/sync-block-task/params.ts
@@ -1,10 +1,12 @@
 import NodeService from '../../services/node'
 import { AddressesUsedSubject } from '../../models/subjects/addresses-used-subject'
+import AddressDbChangedSubject from '../../models/subjects/address-db-changed-subject'
 
 export { networkSwitchSubject } from '../../services/networks'
 
-export { addressChangeSubject, genesisBlockHash } from './create'
+export { genesisBlockHash } from './create'
 export { databaseInitSubject } from './create'
 
 export const nodeService = NodeService.getInstance()
 export const addressesUsedSubject = AddressesUsedSubject.getSubject()
+export const addressDbChangedSubject = AddressDbChangedSubject.getSubject()

--- a/packages/neuron-wallet/src/startup/sync-block-task/task.ts
+++ b/packages/neuron-wallet/src/startup/sync-block-task/task.ts
@@ -8,7 +8,7 @@ import BlockListener from '../../services/sync/block-listener'
 import { NetworkWithID } from '../../services/networks'
 import { initDatabase } from './init-database'
 
-const { nodeService, addressChangeSubject, addressesUsedSubject, databaseInitSubject } = remote.require(
+const { nodeService, addressDbChangedSubject, addressesUsedSubject, databaseInitSubject } = remote.require(
   './startup/sync-block-task/params'
 )
 
@@ -41,9 +41,12 @@ export const switchNetwork = async () => {
   // start sync blocks service
   const blockListener = new BlockListener(lockHashes, nodeService.tipNumberSubject)
 
-  addressChangeSubject.subscribe(async () => {
-    const hashes: string[] = await loadAddressesAndConvert()
-    blockListener.setLockHashes(hashes)
+  addressDbChangedSubject.subscribe(async (event: string) => {
+    // ignore update and remove
+    if (event === 'AfterInsert') {
+      const hashes: string[] = await loadAddressesAndConvert()
+      blockListener.setLockHashes(hashes)
+    }
   })
 
   stopLoopSubject.subscribe(() => {


### PR DESCRIPTION
Should listen new addresses saved, create wallet and insert addresses will happen after sync start, so will not include those until you restart now.