### PR TITLE
[ᚬrc/v0.1.0] refactor(neuron-wallet): remove slash before the transaction detail url

### DIFF
--- a/packages/neuron-wallet/src/controllers/app/index.ts
+++ b/packages/neuron-wallet/src/controllers/app/index.ts
@@ -202,7 +202,7 @@ export default class AppController {
         preload: path.join(__dirname, '../../startup/preload.js'),
       },
     })
-    win.loadURL(`${env.mainURL}/#/transaction/${hash}`)
+    win.loadURL(`${env.mainURL}#/transaction/${hash}`)
     win.on('ready-to-show', () => {
       win.show()
       win.focus()


### PR DESCRIPTION
fix the path to transaction detail dialog