### PR TITLE
feat: rescanning and expanding addresses when one type used out

### DIFF
--- a/packages/neuron-wallet/src/database/address/dao.ts
+++ b/packages/neuron-wallet/src/database/address/dao.ts
@@ -154,4 +154,27 @@ export default class AddressDao {
 
     return addressEntity
   }
+
+  public static maxAddressIndex = async (
+    walletId: string,
+    addressType: AddressType,
+    version: AddressVersion
+  ): Promise<AddressEntity | undefined> => {
+    const addressEntity = await getConnection()
+      .getRepository(AddressEntity)
+      .createQueryBuilder('address')
+      .where({
+        walletId,
+        addressType,
+        version,
+      })
+      .orderBy('address.addressIndex', 'DESC')
+      .getOne()
+
+    if (!addressEntity) {
+      return undefined
+    }
+
+    return addressEntity
+  }
 }

--- a/packages/neuron-wallet/src/listener/address.ts
+++ b/packages/neuron-wallet/src/listener/address.ts
@@ -1,0 +1,21 @@
+import AddressesUsedSubject from '../models/subjects/addresses-used-subject'
+import AddressService from '../services/addresses'
+import WalletService from '../services/wallets'
+import { AccountExtendedPublicKey } from '../models/keys/key'
+
+// update txCount when addresses used
+export const register = () => {
+  AddressesUsedSubject.getSubject().subscribe(async (addresses: string[]) => {
+    const addrs = await AddressService.updateTxCountAndBalances(addresses)
+    const walletIds: string[] = addrs.map(addr => addr.walletId).filter((value, idx, a) => a.indexOf(value) === idx)
+    await Promise.all(
+      walletIds.map(async id => {
+        const wallet = WalletService.getInstance().get(id)
+        const accountExtendedPublicKey: AccountExtendedPublicKey = wallet.accountExtendedPublicKey()
+        await AddressService.checkAndGenerateSave(id, accountExtendedPublicKey, 20, 10)
+      })
+    )
+  })
+}
+
+export default register

--- a/packages/neuron-wallet/src/main.ts
+++ b/packages/neuron-wallet/src/main.ts
@@ -9,6 +9,10 @@ import createMainWindow from './startup/create-main-window'
 import createSyncBlockTask from './startup/sync-block-task/create'
 import initConnection from './database/address/ormconfig'
 import WalletsService from './services/wallets'
+import { register as registerAddressListener } from './listener/address'
+
+// register to listen address updates
+registerAddressListener()
 
 const walletsService = WalletsService.getInstance()
 

--- a/packages/neuron-wallet/src/services/addresses.ts
+++ b/packages/neuron-wallet/src/services/addresses.ts
@@ -4,8 +4,7 @@ import Address, { AddressType } from '../models/keys/address'
 import LockUtils from '../utils/lock-utils'
 import AddressDao, { Address as AddressInterface } from '../database/address/dao'
 import env from '../env'
-import { AddressVersion } from '../database/address/entities/address'
-import AddressesUsedSubject from '../models/subjects/addresses-used-subject'
+import AddressEntity, { AddressVersion } from '../database/address/entities/address'
 
 const MAX_ADDRESS_COUNT = 30
 
@@ -25,10 +24,19 @@ export default class AddressService {
   public static generateAndSave = async (
     walletId: string,
     extendedKey: AccountExtendedPublicKey,
+    receivingStartIndex: number,
+    changeStartIndex: number,
     receivingAddressCount: number = 20,
     changeAddressCount: number = 10
   ) => {
-    const addresses = AddressService.generateAddresses(walletId, extendedKey, receivingAddressCount, changeAddressCount)
+    const addresses = AddressService.generateAddresses(
+      walletId,
+      extendedKey,
+      receivingStartIndex,
+      changeStartIndex,
+      receivingAddressCount,
+      changeAddressCount
+    )
     const allAddresses = [
       ...addresses.testnetReceiving,
       ...addresses.mainnetReceiving,
@@ -38,18 +46,52 @@ export default class AddressService {
     await AddressDao.create(allAddresses)
   }
 
+  public static checkAndGenerateSave = async (
+    walletId: string,
+    extendedKey: AccountExtendedPublicKey,
+    receivingAddressCount: number = 20,
+    changeAddressCount: number = 10
+  ) => {
+    const addressVersion = AddressService.getAddressVersion()
+    const maxIndexReceivingAddress = await AddressDao.maxAddressIndex(walletId, AddressType.Receiving, addressVersion)
+    const maxIndexChangeAddress = await AddressDao.maxAddressIndex(walletId, AddressType.Change, addressVersion)
+    if (
+      maxIndexReceivingAddress !== undefined &&
+      maxIndexReceivingAddress.txCount === 0 &&
+      maxIndexChangeAddress !== undefined &&
+      maxIndexChangeAddress.txCount === 0
+    ) {
+      return undefined
+    }
+    const nextReceivingIndex = maxIndexReceivingAddress === undefined ? 0 : maxIndexReceivingAddress.addressIndex + 1
+    const nextChangeIndex = maxIndexChangeAddress === undefined ? 0 : maxIndexChangeAddress.addressIndex + 1
+    return AddressService.generateAndSave(
+      walletId,
+      extendedKey,
+      nextReceivingIndex,
+      nextChangeIndex,
+      receivingAddressCount,
+      changeAddressCount
+    )
+  }
+
   /* eslint no-await-in-loop: "off" */
   /* eslint no-restricted-syntax: "off" */
   public static updateTxCountAndBalances = async (addresses: string[]) => {
+    let addrs: AddressEntity[] = []
     for (const address of addresses) {
-      await AddressDao.updateTxCountAndBalance(address)
+      const ads = await AddressDao.updateTxCountAndBalance(address)
+      addrs = addrs.concat(ads)
     }
+    return addrs
   }
 
   // Generate both receiving and change addresses.
   public static generateAddresses = (
     walletId: string,
     extendedKey: AccountExtendedPublicKey,
+    receivingStartIndex: number,
+    changeStartIndex: number,
     receivingAddressCount: number = 20,
     changeAddressCount: number = 10
   ) => {
@@ -63,7 +105,7 @@ export default class AddressService {
       const addressMetaInfo: AddressMetaInfo = {
         walletId,
         addressType: AddressType.Receiving,
-        addressIndex: idx,
+        addressIndex: idx + receivingStartIndex,
         accountExtendedPublicKey: extendedKey,
       }
       return AddressService.toAddress(addressMetaInfo)
@@ -75,7 +117,7 @@ export default class AddressService {
       const addressMetaInfo: AddressMetaInfo = {
         walletId,
         addressType: AddressType.Change,
-        addressIndex: idx,
+        addressIndex: idx + changeStartIndex,
         accountExtendedPublicKey: extendedKey,
       }
       return AddressService.toAddress(addressMetaInfo)
@@ -173,9 +215,3 @@ export default class AddressService {
     return env.testnet ? AddressVersion.Testnet : AddressVersion.Mainnet
   }
 }
-
-// update txCount when addresses used
-const addressUsedSubject = AddressesUsedSubject.getSubject()
-addressUsedSubject.subscribe(async (addresses: string[]) => {
-  await AddressService.updateTxCountAndBalances(addresses)
-})

--- a/packages/neuron-wallet/src/services/wallets.ts
+++ b/packages/neuron-wallet/src/services/wallets.ts
@@ -216,7 +216,7 @@ export default class WalletService {
   ) => {
     const wallet: Wallet = this.get(id)
     const accountExtendedPublicKey: AccountExtendedPublicKey = wallet.accountExtendedPublicKey()
-    await AddressService.generateAndSave(id, accountExtendedPublicKey, receivingAddressCount, changeAddressCount)
+    await AddressService.checkAndGenerateSave(id, accountExtendedPublicKey, receivingAddressCount, changeAddressCount)
   }
 
   public generateCurrentWalletAddresses = async (

--- a/packages/neuron-wallet/tests/services/address.test.ts
+++ b/packages/neuron-wallet/tests/services/address.test.ts
@@ -13,7 +13,7 @@ const extendedKey = new AccountExtendedPublicKey(
 
 describe('Key tests', () => {
   it('Generate addresses from extended public key', () => {
-    const addresses = AddressService.generateAddresses('1', extendedKey, 2, 2)
+    const addresses = AddressService.generateAddresses('1', extendedKey, 0, 0, 2, 2)
 
     expect(2).toBe(addresses.testnetReceiving.length)
     expect("m/44'/309'/0'/0/0").toBe(addresses.testnetReceiving[0].path)
@@ -94,7 +94,11 @@ describe('Key tests with db', () => {
   })
 
   const generate = async (id: string = walletId) => {
-    await AddressService.generateAndSave(id, extendedKey, 2, 1)
+    await AddressService.generateAndSave(id, extendedKey, 0, 0, 2, 1)
+  }
+
+  const checkAndGenerate = async (id: string = walletId) => {
+    await AddressService.checkAndGenerateSave(id, extendedKey, 2, 1)
   }
 
   it('generateAndSave', async () => {
@@ -106,6 +110,33 @@ describe('Key tests with db', () => {
       .getMany()
 
     expect(all.length).toEqual((2 + 1) * 2)
+  })
+
+  it('checkAndGenerateSave', async () => {
+    await generate()
+
+    const all = await getConnection()
+      .getRepository(AddressEntity)
+      .createQueryBuilder('address')
+      .getMany()
+
+    const usedAll = all
+      .filter(one => one.addressType === AddressType.Receiving)
+      .map(one => {
+        const entity = one
+        entity.txCount = 1
+        return entity
+      })
+    await getConnection().manager.save(usedAll)
+
+    await checkAndGenerate()
+
+    const final = await getConnection()
+      .getRepository(AddressEntity)
+      .createQueryBuilder('address')
+      .getMany()
+
+    expect(final.length).toEqual((2 + 1) * 2 * 2)
   })
 
   it('generateAndSave with two wallet', async () => {


### PR DESCRIPTION
It will generate new addresses when addresses used out.
When `address` used, will broadcast a `addressUsedSubject` subject and subscribe this subject, when listened an address used, check the max `addressIndex` is used or not, if do, generate new addresses.