### PR TITLE
feat: listen tx and update when failed

### DIFF
--- a/packages/neuron-wallet/src/listener/tx-status.ts
+++ b/packages/neuron-wallet/src/listener/tx-status.ts
@@ -1,0 +1,48 @@
+import { interval } from 'rxjs'
+import TransactionsService from '../services/transactions'
+import NodeService from '../services/node'
+import { TransactionStatus } from '../types/cell-types'
+
+const getTransactionStatus = async (hash: string) => {
+  const { core } = NodeService.getInstance()
+  // getTransaction function return type seems error
+  const tx = (await core.rpc.getTransaction(hash)) as any
+  if (!tx) {
+    return TransactionStatus.Failed
+  }
+  if (tx.txStatus.status === 'committed') {
+    return TransactionStatus.Success
+  }
+  return TransactionStatus.Pending
+}
+
+const trackingStatus = async () => {
+  const pendingTransactions = await TransactionsService.pendings()
+  if (!pendingTransactions.length) {
+    return
+  }
+  const pendingHashes = pendingTransactions.map(tx => tx.hash)
+  const txs = await Promise.all(
+    pendingHashes.map(async hash => {
+      const status = await getTransactionStatus(hash)
+      return {
+        hash,
+        status,
+      }
+    })
+  )
+  const failedTxs = txs.filter(tx => tx.status === TransactionStatus.Failed)
+  if (!failedTxs.length) {
+    return
+  }
+  await TransactionsService.updateFailedTxs(failedTxs.map(tx => tx.hash))
+}
+
+export const register = () => {
+  // every 5 seconds
+  interval(5000).subscribe(async () => {
+    await trackingStatus()
+  })
+}
+
+export default register

--- a/packages/neuron-wallet/src/startup/sync-block-task/task.ts
+++ b/packages/neuron-wallet/src/startup/sync-block-task/task.ts
@@ -7,6 +7,7 @@ import AddressesUsedSubject from '../../models/subjects/addresses-used-subject'
 import BlockListener from '../../services/sync/block-listener'
 import { NetworkWithID } from '../../services/networks'
 import { initDatabase } from './init-database'
+import { register as registerTxStatusListener } from '../../listener/tx-status'
 
 const { nodeService, addressDbChangedSubject, addressesUsedSubject, databaseInitSubject } = remote.require(
   './startup/sync-block-task/params'
@@ -63,6 +64,7 @@ export const run = async () => {
       await switchNetwork()
     }
   })
+  registerTxStatusListener()
 }
 
 run()


### PR DESCRIPTION
Load `pending` transactions and using RPC `getTransaction` to get new status, then update status to `failed` if return null, sync task will resolve `committed` transactions, do just kill these.
Will do this every 5 seconds. (May too short or too long ?)
Do this inside sync renderer process.