### PR TITLE
chore(ci): Expect Travis to have yarn > 1.13 pre-installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ cache:
   - yarn
 
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
-  - export PATH=$HOME/.yarn/bin:$PATH
+  # - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
+  # - export PATH=$HOME/.yarn/bin:$PATH
   - yarn global add lerna
 
 install:


### PR DESCRIPTION
Travis should have yarn 1.15 or 1.16 pre installed already.