### PR TITLE
feat(neuron-ui): add TransactionUpdated listener

### DIFF
--- a/packages/neuron-ui/src/services/UILayer.ts
+++ b/packages/neuron-ui/src/services/UILayer.ts
@@ -48,6 +48,7 @@ export enum TransactionsMethod {
   GetAllByKeywords = 'getAllByKeywords',
   Get = 'get',
   UpdateDescription = 'updateDescription',
+  TransactionUpdated = 'transactionUpdated',
 }
 
 export enum HelpersMethod {


### PR DESCRIPTION
update transaction list and current transaction if the updated one is displayed

- if the updated transaction has a timestamp of `null` and the page number is 1, insert it in the transaction list.
- if the updated transaction is listed in the transaction list, replace it directly
- if the updated transaction is the one displayed in the transaction detail view, update the transaction detail view.