### PR TITLE
feat: Support registering grommet icons to be used as fabric icons

### DIFF
--- a/packages/neuron-ui/package.json
+++ b/packages/neuron-ui/package.json
@@ -37,6 +37,7 @@
     "last 2 chrome versions"
   ],
   "dependencies": {
+    "@uifabric/styling": "7.1.1",
     "bootstrap": "4.3.1",
     "grommet-icons": "4.2.0",
     "i18next": "15.1.3",

--- a/packages/neuron-ui/src/components/WalletWizard/index.tsx
+++ b/packages/neuron-ui/src/components/WalletWizard/index.tsx
@@ -1,12 +1,14 @@
 import React, { useCallback, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Stack, Text, Label, PrimaryButton, DefaultButton, TextField, FontSizes } from 'office-ui-fabric-react'
+import { FormAdd, FormUpload } from 'grommet-icons'
 
 import withWizard, { WizardElementProps, WithWizardState } from 'components/withWizard'
 
 import { MnemonicAction, BUTTON_GAP } from 'utils/const'
 import { verifyWalletSubmission } from 'utils/validators'
 import { helpersCall, walletsCall } from 'services/UILayer'
+import { registerIcons, buttonGrommetIconStyles } from 'utils/icons'
 
 export enum WalletWizardPath {
   Welcome = '/welcome',
@@ -34,6 +36,13 @@ const submissionInputs = [
   { label: 'confirm-password', key: 'confirmPassword', type: 'password', autoFocus: false },
 ]
 
+registerIcons({
+  icons: {
+    Add: <FormAdd />,
+    Import: <FormUpload />,
+  },
+})
+
 const Welcome = ({ rootPath = '/wizard', history }: WizardElementProps<{ rootPath: string }>) => {
   const [t] = useTranslation()
 
@@ -42,10 +51,12 @@ const Welcome = ({ rootPath = '/wizard', history }: WizardElementProps<{ rootPat
       {
         text: 'wizard.import-wallet',
         link: `${rootPath}${WalletWizardPath.Mnemonic}/${MnemonicAction.Import}`,
+        icon: 'Import',
       },
       {
         text: 'wizard.create-new-wallet',
         link: `${rootPath}${WalletWizardPath.Mnemonic}/${MnemonicAction.Create}`,
+        icon: 'Add',
       },
     ],
     [rootPath]
@@ -65,8 +76,12 @@ const Welcome = ({ rootPath = '/wizard', history }: WizardElementProps<{ rootPat
         <Text variant="large">{t('wizard.please-setup-the-wallet')}</Text>
       </Stack>
       <Stack horizontal horizontalAlign="start" tokens={{ childrenGap: 100 }} styles={{ root: { width: '100%' } }}>
-        {buttons.map(({ text, link }) => (
-          <DefaultButton text={t(text)} onClick={next(link)} />
+        {buttons.map(({ text, link, icon }) => (
+          <DefaultButton
+            text={t(text)}
+            onClick={next(link)}
+            iconProps={{ iconName: icon, styles: buttonGrommetIconStyles }}
+          />
         ))}
       </Stack>
     </Stack>

--- a/packages/neuron-ui/src/utils/icons.ts
+++ b/packages/neuron-ui/src/utils/icons.ts
@@ -1,0 +1,6 @@
+import { registerIcons } from '@uifabric/styling'
+
+// Fabric button's default icon height doesn't fit Grommet Icons
+export const buttonGrommetIconStyles = { root: { height: '24px' } }
+
+export { registerIcons }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2471,11 +2471,30 @@
     "@uifabric/set-version" "^7.0.0"
     tslib "^1.7.1"
 
+"@uifabric/merge-styles@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@uifabric/merge-styles/-/merge-styles-7.1.1.tgz#8af9f5b7e7f6e5597d9d18c7f87077d1fe04e60c"
+  integrity sha512-FrQvdydkFPcwLkI4GykKdeUXMZJ6VlAsWl5McNDZq3UQEkwDS69OUwwA+zdwtNZMSrgo5TT1MshViUvwHvFFIA==
+  dependencies:
+    "@uifabric/set-version" "^7.0.0"
+    tslib "^1.7.1"
+
 "@uifabric/set-version@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@uifabric/set-version/-/set-version-7.0.0.tgz#2c9be5fb368354dc924868627c4a2ed3ee7a0635"
   integrity sha512-0cdpZJ5AHmrzb1RMrA420+sRxJiMRwgiOfLoRCSpOqkSwn2TILACGGfTJ9vRWuKEugBiz/+qVltBUYMcdPlATQ==
   dependencies:
+    tslib "^1.7.1"
+
+"@uifabric/styling@7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@uifabric/styling/-/styling-7.1.1.tgz#95cc5c40e340b0cfef8ee6cf4ec21b32952b4f0d"
+  integrity sha512-UiBIj7HZwRk3qLKO+RcSnT59Vizu6+QPrv94e5MIFVIbh241J8N+PRFHK6U44Se+7ZjGON1DvZKs1ll57NWufg==
+  dependencies:
+    "@microsoft/load-themed-styles" "^1.7.13"
+    "@uifabric/merge-styles" "^7.1.1"
+    "@uifabric/set-version" "^7.0.0"
+    "@uifabric/utilities" "^7.0.6"
     tslib "^1.7.1"
 
 "@uifabric/styling@^7.0.2", "@uifabric/styling@^7.1.0":
@@ -2495,6 +2514,16 @@
   integrity sha512-B4eSp1gzF2PHwd1pXbRwHTpnIqrgO+qPA6IQ1g5AiNVt+2lGuaxd+kY3JW00RadTTYePmk9dmql8G/unsLMFaA==
   dependencies:
     "@uifabric/merge-styles" "^7.1.0"
+    "@uifabric/set-version" "^7.0.0"
+    prop-types "^15.5.10"
+    tslib "^1.7.1"
+
+"@uifabric/utilities@^7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@uifabric/utilities/-/utilities-7.0.6.tgz#170e1f361b3688fa64869b2da737c93d00e5be29"
+  integrity sha512-5rvfwfcbUm7YWgeQ1fiQ67gi6P2PSQG5N7sX9xIs/Jzoem/qpE5E9+QIP7UTnB6tOrpDJgFwWsBYKY8CfAlZsg==
+  dependencies:
+    "@uifabric/merge-styles" "^7.1.1"
     "@uifabric/set-version" "^7.0.0"
     prop-types "^15.5.10"
     tslib "^1.7.1"


### PR DESCRIPTION
This allows us to use Grommet icons with Fabric buttons. Their sizes are different though, so we have to use `buttonGrommetIconStyles` for Fabric button's `iconProps` to adjust them to fit.

Note: we use Grommet icons as they are offline, while Fabric's icon sets are hosted from CDN.