### PR TITLE
refactor: Show mnemonic field border even when it's readonly

### DIFF
--- a/packages/neuron-ui/src/components/WalletWizard/index.tsx
+++ b/packages/neuron-ui/src/components/WalletWizard/index.tsx
@@ -146,7 +146,6 @@ const Mnemonic = ({
         resizable={false}
         rows={3}
         readOnly={isCreate}
-        borderless={isCreate}
         value={isCreate ? generated : imported}
         onChange={onChange}
         description={t(hint)}


### PR DESCRIPTION
We're styling the main content area with white background now. It doesn't look natural if the readonly text field doesn't show border.

We may want to use a custom border style for `readOnly` though.