### PR TITLE
feat(neuron-wallet): send connection status to the neuron-ui periodic…

### DIFF
--- a/packages/neuron-wallet/src/services/node.ts
+++ b/packages/neuron-wallet/src/services/node.ts
@@ -1,6 +1,6 @@
 import Core from '@nervosnetwork/ckb-sdk-core'
 import { interval, BehaviorSubject } from 'rxjs'
-import { distinctUntilChanged, flatMap, delay, retry } from 'rxjs/operators'
+import { distinctUntilChanged, sampleTime, flatMap, delay, retry } from 'rxjs/operators'
 import { ShouldBeTypeOf } from '../exceptions'
 import windowManager from '../models/window-manager'
 import { Channel, ResponseCode } from '../utils/const'
@@ -28,7 +28,7 @@ class NodeService {
   }
 
   public syncConnectStatus = () => {
-    this.connectStatusSubject.pipe(distinctUntilChanged()).subscribe(connectStatus => {
+    this.connectStatusSubject.pipe(sampleTime(10000)).subscribe(connectStatus => {
       windowManager.broadcast(Channel.Chain, 'status', {
         status: ResponseCode.Success,
         result: connectStatus,


### PR DESCRIPTION
…ally

the interval keeps the same as that in the neuron-ui, namely 10s