### PR TITLE
feat: Do not call shell script from yarn start

### DIFF
--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "start": "electron .",
     "start:dev": "yarn run build && electron .",
-    "build": "tsc && ./scripts/copy-renderer-html.sh",
+    "build": "tsc && ncp ./src/startup/sync-block-task/index.html ./dist/startup/sync-block-task/index.html",
     "clean": "rimraf dist/*",
     "test": "jest --color",
     "test:e2e": "jest --config jest.e2e.config.js --color",


### PR DESCRIPTION
to allow running that on Windows

Note: it's fine to call `ncp` directly as there's only one html entry for now. If we need to copy multiple files we still need to think of calling a shell file, as putting several files copying in a single command makes it too long.