### PR TITLE
feat: Polish send view fee panel

### DIFF
--- a/packages/neuron-ui/src/components/Receive/index.tsx
+++ b/packages/neuron-ui/src/components/Receive/index.tsx
@@ -32,7 +32,7 @@ const Receive = ({
 
   return (
     <>
-      <Stack horizontal tokens={{ childrenGap: 40 }} padding="20px 0 0 0 " horizontalAlign="space-between">
+      <Stack horizontal tokens={{ childrenGap: 40 }} padding="20px 0 0 0" horizontalAlign="space-between">
         <Stack styles={{ root: { flex: 1 } }}>
           <TooltipHost content={t('receive.click-to-copy')} calloutProps={{ gapSpace: 0 }}>
             <Stack horizontal horizontalAlign="stretch" tokens={{ childrenGap: 15 }}>

--- a/packages/neuron-ui/src/components/Send/index.tsx
+++ b/packages/neuron-ui/src/components/Send/index.tsx
@@ -52,7 +52,8 @@ const Send = ({
     onDescriptionChange,
     onClear,
   } = useInitialize(address, send.outputs, dispatch, history)
-  const labelWidthStyles = { root: { width: '140px' } }
+  const leftStackWidth = '70%'
+  const labelWidth = '140px'
   const actionSpacer = (
     <Stack.Item styles={{ root: { width: '48px' } }}>
       <span> </span>
@@ -74,10 +75,10 @@ const Send = ({
                   <Stack
                     horizontal
                     verticalAlign="end"
-                    styles={{ root: { width: '70%' } }}
+                    styles={{ root: { width: leftStackWidth } }}
                     tokens={{ childrenGap: 20 }}
                   >
-                    <Stack.Item styles={labelWidthStyles}>
+                    <Stack.Item styles={{ root: { width: labelWidth } }}>
                       <Label>{t('send.address')}</Label>
                     </Stack.Item>
                     <Stack.Item styles={{ root: { flex: 1 } }}>
@@ -111,10 +112,10 @@ const Send = ({
                   <Stack
                     horizontal
                     verticalAlign="end"
-                    styles={{ root: { width: '70%' } }}
+                    styles={{ root: { width: leftStackWidth } }}
                     tokens={{ childrenGap: 20 }}
                   >
-                    <Stack.Item styles={labelWidthStyles}>
+                    <Stack.Item styles={{ root: { width: labelWidth } }}>
                       <Label>{t('send.amount')}</Label>
                     </Stack.Item>
                     <Stack.Item styles={{ root: { flex: 1 } }}>
@@ -148,8 +149,8 @@ const Send = ({
       </Stack.Item>
 
       <Stack horizontal verticalAlign="end" horizontalAlign="space-between">
-        <Stack horizontal verticalAlign="end" styles={{ root: { width: '70%' } }} tokens={{ childrenGap: 20 }}>
-          <Stack.Item styles={labelWidthStyles}>
+        <Stack horizontal verticalAlign="end" styles={{ root: { width: leftStackWidth } }} tokens={{ childrenGap: 20 }}>
+          <Stack.Item styles={{ root: { width: labelWidth } }}>
             <Label>{t('send.description')}</Label>
           </Stack.Item>
           <Stack.Item styles={{ root: { flex: 1 } }}>
@@ -162,7 +163,7 @@ const Send = ({
       <TransactionFeePanel fee="10" cycles="10" price={send.price} onPriceChange={updateTransactionPrice} />
 
       <Stack horizontal verticalAlign="center" tokens={{ childrenGap: 20 }}>
-        <Stack.Item styles={labelWidthStyles}>
+        <Stack.Item styles={{ root: { width: labelWidth } }}>
           <Label>{t('send.balance')}</Label>
         </Stack.Item>
         <Stack.Item>

--- a/packages/neuron-ui/src/components/Send/index.tsx
+++ b/packages/neuron-ui/src/components/Send/index.tsx
@@ -3,6 +3,8 @@ import { RouteComponentProps } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import {
   Stack,
+  Label,
+  Text,
   List,
   TextField,
   PrimaryButton,
@@ -50,9 +52,15 @@ const Send = ({
     onDescriptionChange,
     onClear,
   } = useInitialize(address, send.outputs, dispatch, history)
+  const labelWidthStyles = { root: { width: '140px' } }
+  const actionSpacer = (
+    <Stack.Item styles={{ root: { width: '48px' } }}>
+      <span> </span>
+    </Stack.Item>
+  )
 
   return (
-    <Stack verticalFill tokens={{ childrenGap: 15 }}>
+    <Stack verticalFill tokens={{ childrenGap: 15 }} padding="20px 0 0 0">
       <Stack.Item>
         <List
           items={send.outputs || []}
@@ -63,14 +71,21 @@ const Send = ({
             return (
               <Stack tokens={{ childrenGap: 15 }}>
                 <Stack horizontal verticalAlign="end" horizontalAlign="space-between">
-                  <Stack horizontal verticalAlign="end" styles={{ root: { width: '70%' } }}>
+                  <Stack
+                    horizontal
+                    verticalAlign="end"
+                    styles={{ root: { width: '70%' } }}
+                    tokens={{ childrenGap: 20 }}
+                  >
+                    <Stack.Item styles={labelWidthStyles}>
+                      <Label>{t('send.address')}</Label>
+                    </Stack.Item>
                     <Stack.Item styles={{ root: { flex: 1 } }}>
                       <TextField
                         disabled={sending}
                         value={item.address || ''}
                         onChange={onItemChange('address', idx)}
                         placeholder={PlaceHolders.send.Address}
-                        label={t('send.address')}
                         required
                       />
                     </Stack.Item>
@@ -86,17 +101,24 @@ const Send = ({
                   <Stack.Item>
                     {send.outputs.length > 1 ? (
                       <IconButton text={t('send.remove-this')} onClick={() => removeTransactionOutput(idx)}>
-                        <RemoveIcon />
+                        <RemoveIcon color="red" />
                       </IconButton>
                     ) : null}
                   </Stack.Item>
                 </Stack>
 
                 <Stack horizontal verticalAlign="end" horizontalAlign="space-between">
-                  <Stack horizontal verticalAlign="end" styles={{ root: { width: '70%' } }}>
+                  <Stack
+                    horizontal
+                    verticalAlign="end"
+                    styles={{ root: { width: '70%' } }}
+                    tokens={{ childrenGap: 20 }}
+                  >
+                    <Stack.Item styles={labelWidthStyles}>
+                      <Label>{t('send.amount')}</Label>
+                    </Stack.Item>
                     <Stack.Item styles={{ root: { flex: 1 } }}>
                       <TextField
-                        label={t('send.amount')}
                         value={item.amount}
                         placeholder={PlaceHolders.send.Amount}
                         onChange={onItemChange('amount', idx)}
@@ -126,25 +148,27 @@ const Send = ({
       </Stack.Item>
 
       <Stack horizontal verticalAlign="end" horizontalAlign="space-between">
-        <Stack horizontal verticalAlign="end" styles={{ root: { width: '70%' } }}>
+        <Stack horizontal verticalAlign="end" styles={{ root: { width: '70%' } }} tokens={{ childrenGap: 20 }}>
+          <Stack.Item styles={labelWidthStyles}>
+            <Label>{t('send.description')}</Label>
+          </Stack.Item>
           <Stack.Item styles={{ root: { flex: 1 } }}>
-            <TextField
-              label={t('send.description-optional')}
-              id="description"
-              alt="description"
-              value={send.description}
-              onChange={onDescriptionChange}
-            />
+            <TextField id="description" alt="description" value={send.description} onChange={onDescriptionChange} />
           </Stack.Item>
-          <Stack.Item styles={{ root: { width: '43px', paddingLeft: '5px' } }}>
-            <span> </span>
-          </Stack.Item>
+          {actionSpacer}
         </Stack>
       </Stack>
 
       <TransactionFeePanel fee="10" cycles="10" price={send.price} onPriceChange={updateTransactionPrice} />
 
-      <div>{`${t('send.balance')}: ${shannonToCKBFormatter(balance)} CKB`}</div>
+      <Stack horizontal verticalAlign="center" tokens={{ childrenGap: 20 }}>
+        <Stack.Item styles={labelWidthStyles}>
+          <Label>{t('send.balance')}</Label>
+        </Stack.Item>
+        <Stack.Item>
+          <Text>{`${shannonToCKBFormatter(balance)} CKB`}</Text>
+        </Stack.Item>
+      </Stack>
 
       <Stack horizontal horizontalAlign="end" tokens={{ childrenGap: 20 }}>
         <DefaultButton type="reset" onClick={onClear}>

--- a/packages/neuron-ui/src/components/TransactionFeePanel/index.tsx
+++ b/packages/neuron-ui/src/components/TransactionFeePanel/index.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react'
-import { Stack, Label, TextField, Dropdown, IconButton } from 'office-ui-fabric-react'
-import { CaretDown } from 'grommet-icons'
+import { Stack, Label, TextField, Dropdown, IconButton, Icon } from 'office-ui-fabric-react'
+import { CaretDown, Down } from 'grommet-icons'
 import { useTranslation } from 'react-i18next'
+
+import { registerIcons } from 'utils/icons'
 
 interface TransactionFee {
   fee: string
@@ -9,6 +11,12 @@ interface TransactionFee {
   price: string
   onPriceChange: any
 }
+
+registerIcons({
+  icons: {
+    ArrowDown: <Down size="small" />,
+  },
+})
 
 const TransactionFee: React.FunctionComponent<TransactionFee> = ({
   cycles,
@@ -84,6 +92,9 @@ const TransactionFee: React.FunctionComponent<TransactionFee> = ({
                 { key: '60', text: '~ 1min' },
                 { key: '180', text: '~ 3min' },
               ]}
+              onRenderCaretDown={() => {
+                return <Icon iconName="ArrowDown" />
+              }}
             />
           </Stack.Item>
         </Stack>

--- a/packages/neuron-ui/src/components/TransactionFeePanel/index.tsx
+++ b/packages/neuron-ui/src/components/TransactionFeePanel/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Stack, Label, TextField, Dropdown } from 'office-ui-fabric-react'
+import { Stack, Label, TextField, Dropdown, IconButton } from 'office-ui-fabric-react'
 import { CaretDown } from 'grommet-icons'
 import { useTranslation } from 'react-i18next'
 
@@ -18,43 +18,60 @@ const TransactionFee: React.FunctionComponent<TransactionFee> = ({
 }: TransactionFee) => {
   const [t] = useTranslation()
   const [showDetail, setShowDetail] = useState(false)
+  const labelWidthStyles = { root: { width: '140px' } }
+  const actionSpacer = (
+    <Stack.Item styles={{ root: { width: '48px' } }}>
+      <span> </span>
+    </Stack.Item>
+  )
+
   return (
     <Stack tokens={{ childrenGap: 15 }}>
-      <Stack horizontal tokens={{ childrenGap: 20 }}>
+      <Stack horizontal verticalAlign="end" horizontalAlign="space-between">
+        <Stack horizontal tokens={{ childrenGap: 20 }} styles={{ root: { width: '70%' } }}>
+          <Stack.Item styles={labelWidthStyles}>
+            <Label>{t('send.fee')}</Label>
+          </Stack.Item>
+          <Stack.Item grow>
+            <TextField value={fee} readOnly />
+          </Stack.Item>
+          {actionSpacer}
+        </Stack>
+
         <Stack.Item>
-          <Label>{t('send.fee')}</Label>
-        </Stack.Item>
-        <Stack.Item grow>
-          <TextField value={fee} readOnly />
-        </Stack.Item>
-        <Stack.Item>
-          <CaretDown
-            onClick={() => setShowDetail(!showDetail)}
-            style={{
-              transform: showDetail ? 'rotate(180deg)' : 'none',
-            }}
-          />
+          <IconButton onClick={() => setShowDetail(!showDetail)}>
+            <CaretDown
+              onClick={() => setShowDetail(!showDetail)}
+              style={{
+                transform: showDetail ? 'rotate(180deg)' : 'none',
+              }}
+            />
+          </IconButton>
         </Stack.Item>
       </Stack>
+
       <Stack
         tokens={{ childrenGap: 15 }}
         styles={{
           root: {
             maxHeight: showDetail ? '100vw' : '0',
+            width: '70%',
             overflow: 'hidden',
           },
         }}
       >
         <Stack horizontal tokens={{ childrenGap: 20 }}>
-          <Stack.Item>
+          <Stack.Item styles={labelWidthStyles}>
             <Label>{t('send.price')}</Label>
           </Stack.Item>
           <Stack.Item grow>
             <TextField type="number" value={price} onChange={onPriceChange} />
           </Stack.Item>
+          {actionSpacer}
         </Stack>
+
         <Stack horizontal tokens={{ childrenGap: 20 }}>
-          <Stack.Item>
+          <Stack.Item styles={labelWidthStyles}>
             <Label>{t('send.expected-speed')}</Label>
           </Stack.Item>
           <Stack.Item>
@@ -69,9 +86,12 @@ const TransactionFee: React.FunctionComponent<TransactionFee> = ({
             />
           </Stack.Item>
         </Stack>
+
         <Stack>
-          <Stack horizontal tokens={{ childrenGap: 20 }}>
-            <Stack.Item>{t('send.total-cycles')}</Stack.Item>
+          <Stack horizontal verticalAlign="center" tokens={{ childrenGap: 20 }}>
+            <Stack.Item styles={labelWidthStyles}>
+              <Label>{t('send.total-cycles')}</Label>
+            </Stack.Item>
             <Stack.Item>{cycles}</Stack.Item>
           </Stack>
         </Stack>

--- a/packages/neuron-ui/src/components/TransactionFeePanel/index.tsx
+++ b/packages/neuron-ui/src/components/TransactionFeePanel/index.tsx
@@ -18,7 +18,8 @@ const TransactionFee: React.FunctionComponent<TransactionFee> = ({
 }: TransactionFee) => {
   const [t] = useTranslation()
   const [showDetail, setShowDetail] = useState(false)
-  const labelWidthStyles = { root: { width: '140px' } }
+  const leftStackWidth = '70%'
+  const labelWidth = '140px'
   const actionSpacer = (
     <Stack.Item styles={{ root: { width: '48px' } }}>
       <span> </span>
@@ -28,8 +29,8 @@ const TransactionFee: React.FunctionComponent<TransactionFee> = ({
   return (
     <Stack tokens={{ childrenGap: 15 }}>
       <Stack horizontal verticalAlign="end" horizontalAlign="space-between">
-        <Stack horizontal tokens={{ childrenGap: 20 }} styles={{ root: { width: '70%' } }}>
-          <Stack.Item styles={labelWidthStyles}>
+        <Stack horizontal tokens={{ childrenGap: 20 }} styles={{ root: { width: leftStackWidth } }}>
+          <Stack.Item styles={{ root: { width: labelWidth } }}>
             <Label>{t('send.fee')}</Label>
           </Stack.Item>
           <Stack.Item grow>
@@ -55,13 +56,13 @@ const TransactionFee: React.FunctionComponent<TransactionFee> = ({
         styles={{
           root: {
             maxHeight: showDetail ? '100vw' : '0',
-            width: '70%',
+            width: leftStackWidth,
             overflow: 'hidden',
           },
         }}
       >
         <Stack horizontal tokens={{ childrenGap: 20 }}>
-          <Stack.Item styles={labelWidthStyles}>
+          <Stack.Item styles={{ root: { width: labelWidth } }}>
             <Label>{t('send.price')}</Label>
           </Stack.Item>
           <Stack.Item grow>
@@ -71,7 +72,7 @@ const TransactionFee: React.FunctionComponent<TransactionFee> = ({
         </Stack>
 
         <Stack horizontal tokens={{ childrenGap: 20 }}>
-          <Stack.Item styles={labelWidthStyles}>
+          <Stack.Item styles={{ root: { width: labelWidth } }}>
             <Label>{t('send.expected-speed')}</Label>
           </Stack.Item>
           <Stack.Item>
@@ -89,7 +90,7 @@ const TransactionFee: React.FunctionComponent<TransactionFee> = ({
 
         <Stack>
           <Stack horizontal verticalAlign="center" tokens={{ childrenGap: 20 }}>
-            <Stack.Item styles={labelWidthStyles}>
+            <Stack.Item styles={{ root: { width: labelWidth } }}>
               <Label>{t('send.total-cycles')}</Label>
             </Stack.Item>
             <Stack.Item>{cycles}</Stack.Item>

--- a/packages/neuron-ui/src/components/TransactionFeePanel/index.tsx
+++ b/packages/neuron-ui/src/components/TransactionFeePanel/index.tsx
@@ -85,6 +85,7 @@ const TransactionFee: React.FunctionComponent<TransactionFee> = ({
           </Stack.Item>
           <Stack.Item>
             <Dropdown
+              dropdownWidth={140}
               defaultSelectedKey="0"
               options={[
                 { key: '0', text: 'immediately' },

--- a/packages/neuron-ui/src/components/TransactionFeePanel/index.tsx
+++ b/packages/neuron-ui/src/components/TransactionFeePanel/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
-import { Stack, Label, TextField, Dropdown, IconButton, Icon } from 'office-ui-fabric-react'
-import { CaretDown, Down } from 'grommet-icons'
+import { Stack, Label, TextField, Dropdown, Toggle, Icon } from 'office-ui-fabric-react'
+import { Down } from 'grommet-icons'
 import { useTranslation } from 'react-i18next'
 
 import { registerIcons } from 'utils/icons'
@@ -48,14 +48,13 @@ const TransactionFee: React.FunctionComponent<TransactionFee> = ({
         </Stack>
 
         <Stack.Item>
-          <IconButton onClick={() => setShowDetail(!showDetail)}>
-            <CaretDown
-              onClick={() => setShowDetail(!showDetail)}
-              style={{
-                transform: showDetail ? 'rotate(180deg)' : 'none',
-              }}
-            />
-          </IconButton>
+          <Toggle
+            onChange={() => {
+              setShowDetail(!showDetail)
+            }}
+            label={t('send.advanced-fee-settings')}
+            inlineLabel
+          />
         </Stack.Item>
       </Stack>
 

--- a/packages/neuron-ui/src/locales/en.json
+++ b/packages/neuron-ui/src/locales/en.json
@@ -69,6 +69,7 @@
       "add-one": "Add One More",
       "remove-this": "Remove This",
       "fee": "Transaction Fee",
+      "advanced-fee-settings": "Advanced fee settings",
       "price": "Price",
       "expected-speed": "Expected speed",
       "total-cycles": "Total RISC-V Cycles"

--- a/packages/neuron-ui/src/locales/zh.json
+++ b/packages/neuron-ui/src/locales/zh.json
@@ -69,6 +69,7 @@
       "add-one": "添加",
       "remove-this": "删除",
       "fee": "交易费",
+      "advanced-fee-settings": "交易费高级设置",
       "price": "单价",
       "expected-speed": "预期成交速度",
       "total-cycles": "RISC-V Cycles 总数"


### PR DESCRIPTION
Give the send view some UI love.

Note: since we don't use office ui fabric's icon set, the dropdown button doesn't show the right side arrow. Perhaps should inject a grommet icon instead. Updated: done with e5c2210.

## Before (left on Windows) v.s. After (right on macOS)

<img width="1879" alt="Screen Shot 2019-07-24 at 12 26 20" src="https://user-images.githubusercontent.com/1391/61762861-52985180-ae0e-11e9-851d-85bc81835640.png">
