### PR TITLE
chore: Specify release tags only for Azure Pipelines to build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ trigger:
       - rc/*
   tags:
     include:
-      - '*'
+      - refs/tags/v*
 
 pr:
   autoCancel: true

--- a/packages/neuron-wallet/scripts/notarize.js
+++ b/packages/neuron-wallet/scripts/notarize.js
@@ -18,7 +18,7 @@ exports.default = async function notarizing(context) {
   return await notarize({
     appBundleId: 'com.nervos.neuron',
     appPath: `${appOutDir}/${appName}.app`,
-    appleId: appldId,
+    appleId: appleId,
     appleIdPassword: appleIdPassword,
   });
 };


### PR DESCRIPTION
For reason unknown yet, from alpha 14 Azure Pipelines stopped building for release tags.

I believe this is a Azure Pipelines [issue](https://github.com/vega/ts-json-schema-generator/issues/49); But there is a stupid notarizing bug we need to fix here.