### PR TITLE
refactor: Rename package names removing @nervosnetwork scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nervosnetwork/neuron",
+  "name": "neuron",
   "productName": "Neuron",
   "description": "CKB Neuron Wallet",
   "version": "0.16.0-alpha.2",

--- a/packages/neuron-ui/package.json
+++ b/packages/neuron-ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nervosnetwork/neuron-ui",
+  "name": "neuron-ui",
   "version": "0.16.0-alpha.2",
   "private": true,
   "author": {

--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nervosnetwork/neuron-wallet",
+  "name": "neuron-wallet",
   "productName": "Neuron",
   "description": "CKB Neuron Wallet",
   "homepage": "https://www.nervos.org/",
@@ -53,7 +53,6 @@
   },
   "devDependencies": {
     "@nervosnetwork/ckb-types": "0.16.0",
-    "@nervosnetwork/neuron-ui": "0.16.0-alpha.2",
     "@types/async": "3.0.0",
     "@types/electron-devtools-installer": "2.2.0",
     "@types/elliptic": "6.4.8",
@@ -65,6 +64,7 @@
     "electron-devtools-installer": "2.2.4",
     "electron-notarize": "0.1.1",
     "lint-staged": "9.2.0",
+    "neuron-ui": "0.16.0-alpha.2",
     "rimraf": "2.6.3",
     "spectron": "7.0.0"
   }


### PR DESCRIPTION
## Motivation

* As installation path (especially on Windows) comes from `name` or `productName`, it's odd to have `@nervosnetworkneuron-wallet` (note `/` was removed) as user installation folder.
* `neuron-ui` and `neuron-wallet` are not supposed to be referenced and installed from NPM, so not scoping them with `@nervosnetwork` is not a big concern.