### PR TITLE
feat: Update Electron to v6

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,7 @@ jobs:
         yarn global add lerna
         yarn bootstrap
       name: Bootstrap
-    - script: yarn test:e2e
+    - script: echo Disabling e2e test til spectron has update for electron v6 # yarn test:e2e
       name: Test
 
   - job: Release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,7 @@ jobs:
         yarn global add lerna
         yarn bootstrap
       name: Bootstrap
-    - script: echo Disabling e2e test til spectron has update for electron v6 # yarn test:e2e
+    - script: yarn test:e2e
       name: Test
 
   - job: Release

--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -46,7 +46,7 @@
     "reflect-metadata": "0.1.13",
     "rxjs": "6.5.2",
     "sha3": "2.0.4",
-    "sqlite3": "4.0.9",
+    "sqlite3": "4.1.0",
     "typeorm": "0.2.18",
     "uuid": "3.3.2"
   },
@@ -65,7 +65,7 @@
     "lint-staged": "9.2.0",
     "neuron-ui": "0.18.0-beta.0",
     "rimraf": "2.6.3",
-    "spectron": "7.0.0",
+    "spectron": "8.0.0",
     "ts-transformer-imports": "0.4.3",
     "ttypescript": "1.5.7"
   }

--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -58,7 +58,7 @@
     "@types/uuid": "3.4.4",
     "@types/webdriverio": "4.13.0",
     "devtron": "1.4.0",
-    "electron": "5.0.7",
+    "electron": "6.0.0",
     "electron-builder": "21.2.0",
     "electron-devtools-installer": "2.2.4",
     "electron-notarize": "0.1.1",

--- a/packages/neuron-wallet/src/controllers/app/index.ts
+++ b/packages/neuron-wallet/src/controllers/app/index.ts
@@ -1,5 +1,15 @@
 import path from 'path'
-import { dialog, shell, Menu, MenuItem, MessageBoxOptions, SaveDialogOptions, BrowserWindow } from 'electron'
+import {
+  dialog,
+  shell,
+  Menu,
+  MenuItem,
+  MessageBoxOptions,
+  MessageBoxReturnValue,
+  SaveDialogOptions,
+  SaveDialogReturnValue,
+  BrowserWindow,
+} from 'electron'
 import { take } from 'rxjs/operators'
 import app from 'app'
 
@@ -99,15 +109,12 @@ export default class AppController {
     return WindowManager.mainWindow && winID === WindowManager.mainWindow.id
   }
 
-  public static showMessageBox(
-    options: MessageBoxOptions,
-    callback?: (response: number, checkboxChecked: boolean) => void
-  ) {
-    dialog.showMessageBox(options, callback)
+  public static showMessageBox(options: MessageBoxOptions, callback?: (returnValue: MessageBoxReturnValue) => void) {
+    dialog.showMessageBox(options).then(callback)
   }
 
-  public static showSaveDialog(options: SaveDialogOptions, callback?: (filename?: string, bookmark?: string) => void) {
-    dialog.showSaveDialog(options, callback)
+  public static showSaveDialog(options: SaveDialogOptions, callback?: (returnValue: SaveDialogReturnValue) => void) {
+    dialog.showSaveDialog(options).then(callback)
   }
 
   public static toggleAddressBook() {

--- a/packages/neuron-wallet/src/controllers/app/options.ts
+++ b/packages/neuron-wallet/src/controllers/app/options.ts
@@ -1,4 +1,4 @@
-import { MenuItemConstructorOptions, clipboard, dialog } from 'electron'
+import { MenuItemConstructorOptions, clipboard, dialog, MessageBoxReturnValue } from 'electron'
 import { bech32Address } from '@nervosnetwork/ckb-sdk-utils'
 
 import WalletsService from 'services/wallets'
@@ -80,8 +80,8 @@ export const contextMenuTemplate: {
               detail: isCurrent ? i18n.t('messageBox.remove-network.alert') : '',
               buttons: [i18n.t('messageBox.button.confirm'), i18n.t('messageBox.button.discard')],
             },
-            (btnIdx: number) => {
-              if (btnIdx === 0) {
+            (returnValue: MessageBoxReturnValue) => {
+              if (returnValue.response === 0) {
                 try {
                   networksService.delete(id)
                 } catch (err) {

--- a/packages/neuron-wallet/src/controllers/update.ts
+++ b/packages/neuron-wallet/src/controllers/update.ts
@@ -29,21 +29,20 @@ export default class UpdateController {
 
     autoUpdater.on('update-available', (info: UpdateInfo) => {
       const { version } = info
-      dialog.showMessageBox(
-        {
+      dialog
+        .showMessageBox({
           type: 'info',
           title: version,
           message: i18n.t('updater.updates-found-do-you-want-to-update', { version }),
           buttons: [i18n.t('updater.update-now'), i18n.t('common.no')],
-        },
-        buttonIndex => {
-          if (buttonIndex === 0) {
+        })
+        .then(returnValue => {
+          if (returnValue.response === 0) {
             autoUpdater.downloadUpdate()
           } else {
             this.enableSender()
           }
-        }
-      )
+        })
     })
 
     autoUpdater.on('update-not-available', () => {
@@ -56,16 +55,15 @@ export default class UpdateController {
     })
 
     autoUpdater.on('update-downloaded', () => {
-      dialog.showMessageBox(
-        {
+      dialog
+        .showMessageBox({
           type: 'info',
           message: i18n.t('updater.updates-downloaded-about-to-quit-and-install'),
           buttons: [i18n.t('common.ok')],
-        },
-        () => {
+        })
+        .then(() => {
           setImmediate(() => autoUpdater.quitAndInstall())
-        }
-      )
+        })
     })
   }
 

--- a/packages/neuron-wallet/src/controllers/wallets/index.ts
+++ b/packages/neuron-wallet/src/controllers/wallets/index.ts
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import { SaveDialogReturnValue } from 'electron'
 import AppController from 'controllers/app'
 import WalletsService, { Wallet, WalletProperties, FileKeystoreWallet } from 'services/wallets'
 import Keystore from 'models/keys/keystore'
@@ -270,9 +271,9 @@ export default class WalletsController {
           title: i18n.t('messages.save-keystore'),
           defaultPath: wallet.name,
         },
-        (filename?: string) => {
-          if (filename) {
-            fs.writeFileSync(filename, JSON.stringify(keystore))
+        (returnValue: SaveDialogReturnValue) => {
+          if (returnValue.filePath) {
+            fs.writeFileSync(returnValue.filePath, JSON.stringify(keystore))
             resolve({
               status: ResponseCode.Success,
               result: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7258,10 +7258,10 @@ electron-window-state@5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@5.0.7:
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-5.0.7.tgz#a48fcbd13d30f16f7d7887908b68e52156e90259"
-  integrity sha512-OMMz8DhatxLuBFbnW7KYcAUjflGYFn0IQEtKR0iZhMAm89FgNOd9SVbxXWAGNxvRR6C0gORXwhTh6BCqqqcR6Q==
+electron@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-6.0.0.tgz#03712d461ac73cdf920b2336d6560d6c6b7f19cc"
+  integrity sha512-JVHj0dYtvVFrzVk1TgvrdXJSyLpdvlWNLhtG8ItYZsyg9XbCOQ9OoPfgLm04FjMzKMzEl4YIN0PfGC02MTx3PQ==
   dependencies:
     "@types/node" "^10.12.18"
     electron-download "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7172,10 +7172,10 @@ electron-builder@21.2.0:
     update-notifier "^3.0.1"
     yargs "^13.3.0"
 
-electron-chromedriver@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/electron-chromedriver/-/electron-chromedriver-5.0.1.tgz#0c102a482f16bd47f54fcdd238cf64210395ff4a"
-  integrity sha512-w82q6KkIsKjzhcucllpxeulIxYn5rccNw43rpbMuZcgMQ0EPsckoYwUt7Gadmdi14xniZ+debN9SM8V1EUyaBQ==
+electron-chromedriver@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/electron-chromedriver/-/electron-chromedriver-6.0.0.tgz#a91b940c83f1c42ced52c9ef0605d8721613a8a2"
+  integrity sha512-UIhRl0sN5flfUjqActXsFrZQU1NmBObvlxzPnyeud8vhR67TllXCoqfvhQJmIrJAJJK+5M1DFhJ5iTGT++dvkg==
   dependencies:
     electron-download "^4.1.1"
     extract-zip "^1.6.7"
@@ -15773,13 +15773,13 @@ spdy@^4.0.0:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
-spectron@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/spectron/-/spectron-7.0.0.tgz#2a16ea2b2fbe6149f5fa9fa1a2be601f5878e00c"
-  integrity sha512-l6EqXNJLLjbHFr4s2tky0hQU7Ql8UzNsAJm6CiDvX1eGOPiRVJBf2lqZWHGPayZQ7auxdhqAhnHceJJkokDiPQ==
+spectron@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/spectron/-/spectron-8.0.0.tgz#86e83c5dccb174850c052e2e718d5b1158764a52"
+  integrity sha512-MI9+lAamDnw7S0vKaxXjU3g5qaW5KANaFLc+Hgq+QmMCkQbZLt6ukFFGfalmwIuYrmq+yWQPCD4CXgt3VSHrLA==
   dependencies:
     dev-null "^0.1.1"
-    electron-chromedriver "^5.0.1"
+    electron-chromedriver "^6.0.0"
     request "^2.87.0"
     split "^1.0.0"
     webdriverio "^4.13.0"
@@ -15815,10 +15815,10 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sqlite3@4.0.9:
-  version "4.0.9"
-  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-4.0.9.tgz#cff74550fa5a1159956815400bdef69245557640"
-  integrity sha512-IkvzjmsWQl9BuBiM4xKpl5X8WCR4w0AeJHRdobCdXZ8dT/lNc1XS6WqvY35N6+YzIIgzSBeY5prdFObID9F9tA==
+sqlite3@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-4.1.0.tgz#e051fb9c133be15726322a69e2e37ec560368380"
+  integrity sha512-RvqoKxq+8pDHsJo7aXxsFR18i+dU2Wp5o12qAJOV5LNcDt+fgJsc2QKKg3sIRfXrN9ZjzY1T7SNe/DFVqAXjaw==
   dependencies:
     nan "^2.12.1"
     node-pre-gyp "^0.11.0"


### PR DESCRIPTION
* `dialog` APIs are promise based now, need to update usage.
* `ipcMain`'s `on` receives `IpcMainEvent`, not `Event`.
* Others?

## Needs Confirmation or Fix

* spectron hasn't released any update for electron v6 yet, e2e tests are behaving wrong
* sqlite3 native module build on Windows
* Others?

## Warning

Due to Electron's API change (`dialog` etc), there might be some changes our tests don't cover.  It's ok to leave them as holes and fix ASAP.