### PR TITLE
feat(neuron-ui): hide the top alert on removing the last error messag…

### DIFF
--- a/packages/neuron-ui/src/states/stateProvider/reducer.ts
+++ b/packages/neuron-ui/src/states/stateProvider/reducer.ts
@@ -424,6 +424,10 @@ export const reducer = (
           },
           notifications: app.notifications.filter(({ timestamp }) => timestamp !== payload),
           showAllNotifications: app.notifications.length > 1,
+          showTopAlert:
+            app.notifications.findIndex(message => message.timestamp === payload) === app.notifications.length - 1
+              ? false
+              : app.showTopAlert,
         },
       }
     }


### PR DESCRIPTION
…e from the notification panel