### PR TITLE
fix(neuron-wallet): set current wallet empty if wallet list is empty

### DIFF
--- a/packages/neuron-wallet/src/services/wallets.ts
+++ b/packages/neuron-wallet/src/services/wallets.ts
@@ -245,6 +245,8 @@ export default class WalletService {
     if (currentID === id) {
       if (newWallets.length > 0) {
         this.setCurrent(newWallets[0].id)
+      } else {
+        this.setCurrent('')
       }
     }
 
@@ -258,9 +260,11 @@ export default class WalletService {
       throw new IsRequired('ID')
     }
 
-    const wallet = this.get(id)
-    if (!wallet) {
-      throw new WalletNotFound(id)
+    if (id !== '') {
+      const wallet = this.get(id)
+      if (!wallet) {
+        throw new WalletNotFound(id)
+      }
     }
 
     this.listStore.writeSync(this.currentWalletKey, id)


### PR DESCRIPTION
If the current wallet is not set, the UI will request the previous wallet id on the wallet list updated.