### PR TITLE
Remove sdk ts config

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     }
   },
   "devDependencies": {
-    "@cryptape/sdk-ts-config": "0.0.1",
     "@types/jest": "24.0.13",
     "@typescript-eslint/eslint-plugin": "1.10.2",
     "@typescript-eslint/parser": "1.10.2",

--- a/packages/neuron-ui/tsconfig.json
+++ b/packages/neuron-ui/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": "./src",
     "lib": [
@@ -6,28 +7,10 @@
       "dom.iterable",
       "esnext"
     ],
-    "target": "es6",
-    "moduleResolution": "node",
-    "esModuleInterop": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "esnext",
-    "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "alwaysStrict": true,
-    "experimentalDecorators": true,
-    "noImplicitAny": true,
-    "noImplicitThis": true,
-    "noUnusedParameters": true,
-    "noUnusedLocals": true,
-    "strictNullChecks": true,
-    "strictPropertyInitialization": true,
-    "removeComments": true,
-    "preserveConstEnums": true,
-    "allowJs": false,
-    "allowSyntheticDefaultImports": true,
-    "skipLibCheck": true,
     "jsx": "preserve",
     "typeRoots": [
       "src/types",
@@ -35,7 +18,5 @@
       "node_modules/@types"
     ]
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/packages/neuron-ui/tsconfig.json
+++ b/packages/neuron-ui/tsconfig.json
@@ -16,7 +16,11 @@
       "src/types",
       "node_modules/@nervosnetwork/ckb-types",
       "node_modules/@types"
-    ]
+    ],
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/packages/neuron-wallet/tsconfig.json
+++ b/packages/neuron-wallet/tsconfig.json
@@ -3,9 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "sourceMap": true,
+    "declaration": true,
     "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "resolveJsonModule": true,
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,23 @@
 {
-  "extends": "@cryptape/sdk-ts-config/tsconfig.json",
   "compilerOptions": {
     "target": "es6",
-    "moduleResolution": "node",
     "esModuleInterop": true,
-    "incremental": true
+    "incremental": true,
+    "module": "commonjs",
+    "alwaysStrict": true,
+    "declaration": true,
+    "experimentalDecorators": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noUnusedParameters": true,
+    "noUnusedLocals": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "removeComments": true,
+    "preserveConstEnums": true,
+    "allowJs": false,
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "classic",
+    "skipLibCheck": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,11 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "module": "esnext",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "incremental": true,
-    "module": "commonjs",
     "alwaysStrict": true,
-    "declaration": true,
     "experimentalDecorators": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
@@ -18,6 +17,7 @@
     "preserveConstEnums": true,
     "allowJs": false,
     "allowSyntheticDefaultImports": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,8 +15,6 @@
     "strictPropertyInitialization": true,
     "removeComments": true,
     "preserveConstEnums": true,
-    "allowJs": false,
-    "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "resolveJsonModule": true
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "moduleResolution": "node",
     "esModuleInterop": true,
     "incremental": true,
     "module": "commonjs",
@@ -17,7 +18,6 @@
     "preserveConstEnums": true,
     "allowJs": false,
     "allowSyntheticDefaultImports": true,
-    "moduleResolution": "classic",
     "skipLibCheck": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1172,11 +1172,6 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@cryptape/sdk-ts-config@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@cryptape/sdk-ts-config/-/sdk-ts-config-0.0.1.tgz#6e61db1a054fb13d0b0c24efcd5cf689e1fee7b3"
-  integrity sha512-LQNESxwR3by07QuyPgM2QZ8WMl58PMX9c4GjRU8xPHu094pCiPy2AotHHP4ZF51tpR1rNztRPwwC/SmWRQH/9w==
-
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"


### PR DESCRIPTION
Rationale:

* Neuron is not a SDK; confirming to a `sdk-ts-config` is misleading.
* From time to time we need to adjust tsconfig. Having a config that's not depending on an external repo is more convenient.

We should also probably further tweaking this by removing unnecessary config items in tsconfig.json.