### PR TITLE
chore: Disable verifying update code sign for Windows

### DIFF
--- a/packages/neuron-wallet/electron-builder.yml
+++ b/packages/neuron-wallet/electron-builder.yml
@@ -42,8 +42,7 @@ dmg:
   sign: false
 
 win:
-  publisherName:
-    - 杭州秘猿科技有限公司
+  verifyUpdateCodeSignature: false
   artifactName: "${productName}-v${version}-${os}-${arch}-installer.${ext}"
   icon: assets/images/icon.ico
   target:


### PR DESCRIPTION
Windows update always fail due to cert issue. Our cert has Chinese company
name which might be not handled well by electron-updater.

Note as before, we won't be able to test this until next two alpha versions.