### PR TITLE
feat(neuron-ui): update confirmation threshold of confirmations

### DIFF
--- a/packages/neuron-ui/src/components/Overview/index.tsx
+++ b/packages/neuron-ui/src/components/Overview/index.tsx
@@ -285,9 +285,16 @@ const Overview = ({
       items.map(item => {
         let confirmations = '(-)'
         let typeLabel: string = item.type
+        let { status } = item
         if (item.blockNumber !== undefined) {
           const confirmationCount = 1 + Math.max(+syncedBlockNumber, +tipBlockNumber) - +item.blockNumber
+
+          if (status === 'success' && confirmationCount < CONFIRMATION_THRESHOLD) {
+            status = 'pending'
+          }
+
           typeLabel = genTypeLabel(item.type, confirmationCount)
+
           if (confirmationCount === 1) {
             confirmations = `(${t('overview.confirmation', {
               confirmationCount: localNumberFormatter(confirmationCount),
@@ -298,8 +305,10 @@ const Overview = ({
             })})`
           }
         }
+
         return {
           ...item,
+          status,
           confirmations: item.status === 'success' ? confirmations : '',
           typeLabel: t(`overview.${typeLabel}`),
         }

--- a/packages/neuron-ui/src/utils/const.ts
+++ b/packages/neuron-ui/src/utils/const.ts
@@ -6,7 +6,7 @@ export const MIN_AMOUNT = 61
 export const PAGE_SIZE = 15
 export const UNREMOVABLE_NETWORK = 'Testnet'
 export const UNREMOVABLE_NETWORK_ID = '0'
-export const CONFIRMATION_THRESHOLD = 6
+export const CONFIRMATION_THRESHOLD = 10
 
 export enum ConnectionStatus {
   Online = 'online',


### PR DESCRIPTION
1. set the threshold of confirmations to 10.
2. display a recent activity as a pending one if its status is success while its confirmations is less the the threshold of confirmations.

![image](https://user-images.githubusercontent.com/7271329/62843718-9df79e80-bcee-11e9-903a-d154a3e6cc75.png)
