### PR TITLE
fix(neuron-ui): replace delimiters in error messages

### DIFF
--- a/packages/neuron-ui/src/services/remote/controllerMethodWrapper.ts
+++ b/packages/neuron-ui/src/services/remote/controllerMethodWrapper.ts
@@ -66,7 +66,7 @@ export const controllerMethodWrapper = (controllerName: string) => (
   }
   return {
     status: 0,
-    message: { title },
+    message: { title: title.replace(/(\.|:)/g, '_') },
   }
 }
 


### PR DESCRIPTION
replace the '.' and ':' in error messages which make the i18n work improperly.

With `.` and `:` in the messages, the alert is not rendered correctly. 
![image](https://user-images.githubusercontent.com/7271329/62862869-bfca4300-bd39-11e9-98f5-4defc1f09735.png)
![image](https://user-images.githubusercontent.com/7271329/62862863-b9d46200-bd39-11e9-8335-ec3d4ca99cb0.png)

The `i18n` recognizes the `127.0.0.1:8114` as 
```json
{
  "127": {
    "0": {
      "0": {
        "1": {
          "8114": undefined
        }
      }
    }
  }
}
```
After the replacement, the alert is rendered correctlly:
![image](https://user-images.githubusercontent.com/7271329/62863595-d40f3f80-bd3b-11e9-985d-7303bf196f1f.png)
