### PR TITLE
fix(neuron-ui): disable the submit button when it's sending

### DIFF
--- a/packages/neuron-ui/src/components/PasswordRequest/index.tsx
+++ b/packages/neuron-ui/src/components/PasswordRequest/index.tsx
@@ -8,7 +8,7 @@ import { priceToFee, CKBToShannonFormatter } from 'utils/formatters'
 
 const PasswordRequest = ({
   app: {
-    send: { txID, outputs, description, price, cycles },
+    send: { txID, outputs, description, price, cycles, loading: isSending },
     passwordRequest: { walletID = '', actionType = null, password = '' },
   },
   settings: { wallets = [] },
@@ -27,6 +27,9 @@ const PasswordRequest = ({
   const onConfirm = useCallback(() => {
     switch (actionType) {
       case 'send': {
+        if (isSending) {
+          break
+        }
         sendTransaction({
           id: txID,
           walletID,
@@ -58,7 +61,7 @@ const PasswordRequest = ({
         break
       }
     }
-  }, [dispatch, walletID, password, actionType, txID, description, outputs, cycles, price, history])
+  }, [dispatch, walletID, password, actionType, txID, description, outputs, cycles, price, history, isSending])
 
   const onChange = useCallback(
     (_e, value?: string) => {
@@ -100,7 +103,7 @@ const PasswordRequest = ({
           <TextField value={password} type="password" onChange={onChange} autoFocus onKeyPress={onKeyPress} />
           <Stack horizontalAlign="end" horizontal tokens={{ childrenGap: 15 }}>
             <DefaultButton onClick={onDismiss}>{t('common.cancel')}</DefaultButton>
-            <PrimaryButton onClick={onConfirm} disabled={!password}>
+            <PrimaryButton onClick={onConfirm} disabled={!password || (actionType === 'send' && isSending)}>
               {t('common.confirm')}
             </PrimaryButton>
           </Stack>


### PR DESCRIPTION
Move the action `set loading to true` next to the parameter verification is unnecessary because there's another user-triggered confirmation after the verification and before the submission, which means it will not submit twice to the neuron-wallet.

This PR just stops double-submit on confirmation to send the transaction with a required password, namely, it stops sending the request to neuron-wallet repeatedly.