### PR TITLE
chore: only use hash_type=Data when generate lock hash

### DIFF
--- a/packages/neuron-wallet/src/models/lock-utils.ts
+++ b/packages/neuron-wallet/src/models/lock-utils.ts
@@ -109,8 +109,7 @@ export default class LockUtils {
 
   static async addressToAllLockHashes(address: string): Promise<string[]> {
     const dataLockHash = await LockUtils.addressToLockHash(address, ScriptHashType.Data)
-    const typeLockHash = await LockUtils.addressToLockHash(address, ScriptHashType.Type)
-    return [dataLockHash, typeLockHash]
+    return [dataLockHash]
   }
 
   static async addressesToAllLockHashes(addresses: string[]): Promise<string[]> {

--- a/packages/neuron-wallet/tests/models/lock-utils.test.ts
+++ b/packages/neuron-wallet/tests/models/lock-utils.test.ts
@@ -81,7 +81,7 @@ describe('LockUtils Test', () => {
 
     const lockHashes: string[] = await LockUtils.addressToAllLockHashes(bob.address)
 
-    expect(lockHashes).toEqual([bob.lockHash, bob.lockHashWhenType])
+    expect(lockHashes).toEqual([bob.lockHash])
   })
 
   it('addressesToAllLockHashes', async () => {
@@ -91,12 +91,7 @@ describe('LockUtils Test', () => {
 
     const lockHashes: string[] = await LockUtils.addressesToAllLockHashes([bob.address, alice.address])
 
-    const expectedResult = [
-      bob.lockHash,
-      bob.lockHashWhenType,
-      alice.lockHash,
-      alice.lockHashWhenType,
-    ]
+    const expectedResult = [bob.lockHash, alice.lockHash]
 
     expect(lockHashes).toEqual(expectedResult)
   })


### PR DESCRIPTION
But hold interfaces and maybe address will map to multi lock hashes.