### PR TITLE
feat(neuron-ui): set the cycles to empty if the transaction is invalid

### DIFF
--- a/packages/neuron-ui/src/components/Send/hooks.ts
+++ b/packages/neuron-ui/src/components/Send/hooks.ts
@@ -126,6 +126,11 @@ const useOnTransactionChange = (walletID: string, items: TransactionOutput[], di
               payload: '0',
             })
           })
+      } else {
+        dispatch({
+          type: AppActions.UpdateSendCycles,
+          payload: '0',
+        })
       }
     }, 300)
   }, [walletID, items, dispatch])


### PR DESCRIPTION
Set the `cycles` to `0` if the transaction to send is invalid.