### PR TITLE
Keystore compatibility with cli

### DIFF
--- a/packages/neuron-wallet/src/models/keys/keystore.ts
+++ b/packages/neuron-wallet/src/models/keys/keystore.ts
@@ -61,7 +61,7 @@ export default class Keystore {
       salt: salt.toString('hex'),
       ...params,
     }
-    const derivedKey: Buffer = crypto.scryptSync(Buffer.from(password), salt, kdfparams.dklen, {
+    const derivedKey: Buffer = crypto.scryptSync(password, salt, kdfparams.dklen, {
       N: kdfparams.n,
       r: kdfparams.r,
       p: kdfparams.p,
@@ -99,16 +99,11 @@ export default class Keystore {
   // Decrypt and return serialized extended private key.
   decrypt(password: string): string {
     const { kdfparams } = this.crypto
-    const derivedKey: Buffer = crypto.scryptSync(
-      Buffer.from(password),
-      Buffer.from(kdfparams.salt, 'hex'),
-      kdfparams.dklen,
-      {
-        N: kdfparams.n,
-        r: kdfparams.r,
-        p: kdfparams.p,
-      }
-    )
+    const derivedKey: Buffer = crypto.scryptSync(password, Buffer.from(kdfparams.salt, 'hex'), kdfparams.dklen, {
+      N: kdfparams.n,
+      r: kdfparams.r,
+      p: kdfparams.p,
+    })
     const ciphertext = Buffer.from(this.crypto.ciphertext, 'hex')
     const mac = new SHA3(256)
       .update(Buffer.concat([derivedKey.slice(16, 32), ciphertext]))
@@ -131,16 +126,11 @@ export default class Keystore {
 
   checkPassword = (password: string) => {
     const { kdfparams } = this.crypto
-    const derivedKey: Buffer = crypto.scryptSync(
-      Buffer.from(password),
-      Buffer.from(kdfparams.salt, 'hex'),
-      kdfparams.dklen,
-      {
-        N: kdfparams.n,
-        r: kdfparams.r,
-        p: kdfparams.p,
-      }
-    )
+    const derivedKey: Buffer = crypto.scryptSync(password, Buffer.from(kdfparams.salt, 'hex'), kdfparams.dklen, {
+      N: kdfparams.n,
+      r: kdfparams.r,
+      p: kdfparams.p,
+    })
     const ciphertext = Buffer.from(this.crypto.ciphertext, 'hex')
     const mac = new SHA3(256)
       .update(Buffer.concat([derivedKey.slice(16, 32), ciphertext]))

--- a/packages/neuron-wallet/src/models/keys/keystore.ts
+++ b/packages/neuron-wallet/src/models/keys/keystore.ts
@@ -48,9 +48,13 @@ export default class Keystore {
     }
   }
 
-  static create = (extendedPrivateKey: ExtendedPrivateKey, password: string) => {
-    const salt = crypto.randomBytes(32)
-    const iv = crypto.randomBytes(16)
+  static create = (
+    extendedPrivateKey: ExtendedPrivateKey,
+    password: string,
+    options: { salt?: Buffer; iv?: Buffer } = {}
+  ) => {
+    const salt = options.salt || crypto.randomBytes(32)
+    const iv = options.iv || crypto.randomBytes(16)
     const kdfparams: KdfParams = {
       dklen: 32,
       salt: salt.toString('hex'),

--- a/packages/neuron-wallet/src/models/keys/keystore.ts
+++ b/packages/neuron-wallet/src/models/keys/keystore.ts
@@ -58,7 +58,7 @@ export default class Keystore {
     const kdfparams: KdfParams = {
       dklen: 32,
       salt: salt.toString('hex'),
-      n: 8192,
+      n: 2 ** 18,
       r: 8,
       p: 1,
     }

--- a/packages/neuron-wallet/tests/models/keys/keystore.test.ts
+++ b/packages/neuron-wallet/tests/models/keys/keystore.test.ts
@@ -19,7 +19,7 @@ describe('load and check password', () => {
     expect(keystore.checkPassword(password)).toBe(true)
   })
 
-  it('descrypt', () => {
+  it('decrypts', () => {
     expect(keystore.decrypt(password)).toEqual(
       new ExtendedPrivateKey(fixture.privateKey, fixture.chainCode).serialize()
     )
@@ -29,5 +29,16 @@ describe('load and check password', () => {
     const extendedPrivateKey = keystore.extendedPrivateKey(password)
     expect(extendedPrivateKey.privateKey).toEqual(fixture.privateKey)
     expect(extendedPrivateKey.chainCode).toEqual(fixture.chainCode)
+  })
+})
+
+describe('load ckb cli light keystore', () => {
+  const password = '123'
+  const keystoreString =
+    '{"address":"c99d0619cc212febaf347eb265ae9517c9099ee0","crypto":{"cipher":"aes-128-ctr","cipherparams":{"iv":"aeaff7e3cecb7bb10fcc9b46a107f15e"},"ciphertext":"9d6aec2980833a6ee52bcdab4dd6f0945a838f66ef4e300e2b0bf32c56249bd8ce32007d47441ac4b8ea307c2a8a131b5f6c53690c1e51ff71b44ce73ab68d68","kdf":"scrypt","kdfparams":{"dklen":32,"n":4096,"p":6,"r":8,"salt":"9c6ab8596703e6934faaa1a48f41dbc96ee590dc7b1f3dc3c05139ef588dde6d"},"mac":"f2a3975897d4794b8b4e74ca5f1be09cd5069d90165ec3acf53bda11ac37338e"},"id":"af3de9c9-530e-4304-9db0-d4e5596cf2c6","version":3}'
+  const keystore = Keystore.fromJson(keystoreString)
+
+  it('checks correct password', () => {
+    expect(keystore.checkPassword(password)).toBe(true)
   })
 })

--- a/packages/neuron-wallet/tests/models/keys/keystore.test.ts
+++ b/packages/neuron-wallet/tests/models/keys/keystore.test.ts
@@ -42,3 +42,14 @@ describe('load ckb cli light keystore', () => {
     expect(keystore.checkPassword(password)).toBe(true)
   })
 })
+
+describe('load ckb cli standard keystore', () => {
+  const password = '123'
+  const keystoreString =
+    '{"address":"02bf67769d8e12bd956550c71e7a4e344755afd9","crypto":{"cipher":"aes-128-ctr","cipherparams":{"iv":"4e530f7bc3b59909ce97d4e7baced7ad"},"ciphertext":"e26a1e4affd919c4c00a46920a44113a526d29aa4472d0d0f84e169841853b3f350a5d76f0de6c0a0a5bdd7b03495bb904b49c11d1e241090b77792480ba255d","kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"37495d0caf3a816db294dc3f97ad8b4dd266820cccbabd7593356ff19be99e8d"},"mac":"5054f1fe0bf13cf6a1e3e4d7538eee451e263e61a935163a5b80a962849e6af3"},"id":"7f60eca5-3128-45e0-95be-08ee34c9ab37","version":3}'
+  const keystore = Keystore.fromJson(keystoreString)
+
+  it('checks correct password', () => {
+    expect(keystore.checkPassword(password)).toBe(true)
+  })
+})

--- a/packages/neuron-wallet/tests/models/keys/keystore.test.ts
+++ b/packages/neuron-wallet/tests/models/keys/keystore.test.ts
@@ -35,7 +35,7 @@ describe('load and check password', () => {
 describe('load ckb cli light keystore', () => {
   const password = '123'
   const keystoreString =
-    '{"address":"c99d0619cc212febaf347eb265ae9517c9099ee0","crypto":{"cipher":"aes-128-ctr","cipherparams":{"iv":"aeaff7e3cecb7bb10fcc9b46a107f15e"},"ciphertext":"9d6aec2980833a6ee52bcdab4dd6f0945a838f66ef4e300e2b0bf32c56249bd8ce32007d47441ac4b8ea307c2a8a131b5f6c53690c1e51ff71b44ce73ab68d68","kdf":"scrypt","kdfparams":{"dklen":32,"n":4096,"p":6,"r":8,"salt":"9c6ab8596703e6934faaa1a48f41dbc96ee590dc7b1f3dc3c05139ef588dde6d"},"mac":"f2a3975897d4794b8b4e74ca5f1be09cd5069d90165ec3acf53bda11ac37338e"},"id":"af3de9c9-530e-4304-9db0-d4e5596cf2c6","version":3}'
+    '{"crypto":{"cipher": "aes-128-ctr", "ciphertext": "253397209cae86474e368720f9baa30f448767047d2cc5a7672ef121861974ed", "cipherparams": {"iv": "8bd8523e0048db3a4ae2534aec6d303a"}, "kdf": "scrypt", "kdfparams": {"dklen": 32, "n": 4096, "p": 6, "r": 8, "salt": "be3d86c99f4895f99d1a0048afb61a34153fa83d5edd033fc914de2c502f57e7"}, "mac": "4453cf5d4f6ec43d0664c3895c4ab9b1c9bcd2d02c7abb190c84375a42739099" },"id": "id", "version": 3}'
   const keystore = Keystore.fromJson(keystoreString)
 
   it('checks correct password', () => {

--- a/packages/neuron-wallet/tests/models/keys/keystore.test.ts
+++ b/packages/neuron-wallet/tests/models/keys/keystore.test.ts
@@ -46,10 +46,16 @@ describe('load ckb cli light keystore', () => {
 describe('load ckb cli standard keystore', () => {
   const password = '123'
   const keystoreString =
-    '{"address":"02bf67769d8e12bd956550c71e7a4e344755afd9","crypto":{"cipher":"aes-128-ctr","cipherparams":{"iv":"4e530f7bc3b59909ce97d4e7baced7ad"},"ciphertext":"e26a1e4affd919c4c00a46920a44113a526d29aa4472d0d0f84e169841853b3f350a5d76f0de6c0a0a5bdd7b03495bb904b49c11d1e241090b77792480ba255d","kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"37495d0caf3a816db294dc3f97ad8b4dd266820cccbabd7593356ff19be99e8d"},"mac":"5054f1fe0bf13cf6a1e3e4d7538eee451e263e61a935163a5b80a962849e6af3"},"id":"7f60eca5-3128-45e0-95be-08ee34c9ab37","version":3}'
+    '{"address":"ea22142fa5be326e834681144ca30326f99a6d5a","crypto":{"cipher":"aes-128-ctr","cipherparams":{"iv":"29304e5bcbb1885ef5cdcb40b5312b58"},"ciphertext":"93054530a8fbe5b11995acda856585d7362ac7d2b1e4f268c633d997be2d6532c4962501d0835bf52a4693ae7a091ac9bac9297793f4116ef7c123edb00dbc85","kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"724327e67ca321ccf15035bb78a0a05c816bebbe218a0840abdc26da8453c1f4"},"mac":"1d0e5660ffbfc1f9ff4da97aefcfc2153c0ec1b411e35ffee26ee92815cc06f9"},"id":"43c1116e-efd5-4c9e-a86a-3ec0ab163122","version":3}'
   const keystore = Keystore.fromJson(keystoreString)
 
   it('checks correct password', () => {
     expect(keystore.checkPassword(password)).toBe(true)
+  })
+
+  it('loads private key', () => {
+    const extendedPrivateKey = keystore.extendedPrivateKey(password)
+    expect(extendedPrivateKey.privateKey).toEqual('8af124598932440269a81771ad662642e83a38b323b2f70223b8ae0b6c5e0779')
+    expect(extendedPrivateKey.chainCode).toEqual('615302e2c93151a55c29121dd02ad554e47908a6df6d7374f357092cec11675b')
   })
 })


### PR DESCRIPTION
Having two issues needing fix:

* Neuron doesn't seem to be able to handle CKB cli's standard keystore( `262144` of `n` param), resulting OPENSSL `MEMORY_LIMIT_EXCEEDED` error.
* Neuron keystore password logic has flaw.

## Worth noting

We don't aim 100% compatibility. CKB CLI uses the master private key to derive mainnet/testnet addresses. Neuron on the other hand generates HD addresses (both receiving and change) with full path (`m/44'/309'/0'/0/n`, and `m/44'/309'/0'/1/n`).

This means the address you see from cli will NOT appear in Neuron.

One more thing, our Keystore format doesn't conform to Ethereum wallets in the way that we save the encrypted extended master key, not the encrypted master private key.

## To fix

- [x] CLI Standard keystore import
- [x] password/mac algorithm