### PR TITLE
Improve qr scanner

### DIFF
--- a/packages/neuron-ui/src/components/Receive/index.tsx
+++ b/packages/neuron-ui/src/components/Receive/index.tsx
@@ -63,6 +63,7 @@ const Receive = ({
             onQRCodeClick={() => setShowLargeQRCode(true)}
             size={256}
             exportable
+            includeMargin
             dispatch={dispatch}
           />
         </Stack>

--- a/packages/neuron-ui/src/widgets/QRCode/index.tsx
+++ b/packages/neuron-ui/src/widgets/QRCode/index.tsx
@@ -102,12 +102,18 @@ const QRCode = ({
   qrcode.make()
 
   const cells = qrcode.modules || []
-  const margin = includeMargin ? 4 : 0
+  const margin = includeMargin ? 1 : 0
   const fgPath = generatePath(cells, margin)
   const numCells = cells.length + margin * 2
 
-  const svgStr = `<svg shapeRendering="crispEdges" height="${scale * size}" width="${scale *
-    size}" viewBox="0 0 ${numCells} ${numCells}" ><path fill="${bgColor}" d="M0, 0 h${numCells} v${numCells} H0z" /><path fill="${fgColor}" d="${fgPath}" /></svg>`
+  const svgStr = `<svg shapeRendering="crispEdges"
+    width="${scale * size}"
+    height="${scale * size}"
+    viewBox="0 0 ${numCells} ${numCells}"
+  >
+    <path fill="${bgColor}" d="M0, 0 h${numCells} v${numCells} H0z" />
+    <path fill="${fgColor}" d="${fgPath}" />
+  </svg>`
 
   const onDownload = useCallback(() => {
     if (canvasRef.current === null) {
@@ -147,7 +153,7 @@ const QRCode = ({
   }, [svgStr, size])
 
   return (
-    <Stack tokens={{ childrenGap: 15 }}>
+    <Stack tokens={{ childrenGap: 15 }} horizontalAlign="center" verticalAlign="center">
       <Stack.Item>
         <canvas ref={canvasRef} width={size} height={size} onClick={onQRCodeClick} />
       </Stack.Item>

--- a/packages/neuron-ui/src/widgets/QRScanner/index.tsx
+++ b/packages/neuron-ui/src/widgets/QRScanner/index.tsx
@@ -88,8 +88,8 @@ const QRScanner = ({ title, label, onConfirm, styles }: QRScannerProps) => {
                   color,
                 })
                 if (verifyAddress(code.data)) {
-                  onConfirm(code.data)
                   onDismiss()
+                  onConfirm(code.data)
                 } else {
                   setData(code.data)
                 }


### PR DESCRIPTION
According to [some tutorials](https://www.qrcode-monkey.com/6-reasons-why-your-qr-code-is-not-working)
>6. Leave a border space around your QR Code
Always leave a space between your QR code and the content or design around it. The QR Code should always stand alone on the background and the foreground should not touch other elements. It is important for QR code scanner apps to detect the corner elements as stand-alone objects.

I've added a blank border around the QR Code like this:
![image](https://user-images.githubusercontent.com/7271329/64670885-37a29f00-d499-11e9-828b-a5217c3f4938.png)
While an indent between the Image and buttons is introduced on the Receive View
![image](https://user-images.githubusercontent.com/7271329/64670947-6c165b00-d499-11e9-8e14-d61cb126bce3.png)

I prefer to keep it since the blank margin is a part of the QR Code and not aberrant.