### PR TITLE
fix(neuron-ui): fix typo in class name

### DIFF
--- a/packages/neuron-ui/src/components/Addresses/index.tsx
+++ b/packages/neuron-ui/src/components/Addresses/index.tsx
@@ -73,7 +73,7 @@ const Addresses = ({
         onRender: (item?: State.Address) => {
           if (item) {
             return (
-              <span className="text-overflow" title={item.address}>
+              <span className="textOverflow" title={item.address}>
                 {item.address}
               </span>
             )
@@ -130,7 +130,7 @@ const Addresses = ({
         onRender: (item?: State.Address) => {
           if (item) {
             return (
-              <span title={`${item.balance} shannon`} className="text-overflow">
+              <span title={`${item.balance} shannon`} className="textOverflow">
                 {`${shannonToCKBFormatter(item.balance)} CKB`}
               </span>
             )

--- a/packages/neuron-ui/src/components/TransactionList/index.tsx
+++ b/packages/neuron-ui/src/components/TransactionList/index.tsx
@@ -117,7 +117,7 @@ const TransactionList = ({
               return '-'
             }
             return (
-              <span className="text-overflow monospacedFont" title={item.hash}>
+              <span className="textOverflow monospacedFont" title={item.hash}>
                 {`${item.hash.slice(0, 8)}...${item.hash.slice(-6)}`}
               </span>
             )
@@ -140,7 +140,7 @@ const TransactionList = ({
             }
             const confirmations = localNumberFormatter(confirmationCount)
             return (
-              <span title={`${confirmations}`} className="text-overflow">
+              <span title={`${confirmations}`} className="textOverflow">
                 {confirmations}
               </span>
             )
@@ -213,7 +213,7 @@ const TransactionList = ({
           onRender: (item?: FormatTransaction) => {
             if (item) {
               return (
-                <span title={`${item.value} shannon`} className="text-overflow">
+                <span title={`${item.value} shannon`} className="textOverflow">
                   {`${shannonToCKBFormatter(item.value, true)} CKB`}
                 </span>
               )

--- a/packages/neuron-ui/src/styles/index.scss
+++ b/packages/neuron-ui/src/styles/index.scss
@@ -82,7 +82,7 @@ navbar {
     }
   }
 
-  .text-overflow {
+  .textOverflow {
     overflow: hidden;
     text-overflow: ellipsis;
   }


### PR DESCRIPTION
rename .text-overflow to .textOverflow