### PR TITLE
fix: rename class name from text-overflow to textOverflow

### DIFF
--- a/packages/neuron-ui/src/components/Addresses/index.tsx
+++ b/packages/neuron-ui/src/components/Addresses/index.tsx
@@ -81,7 +81,7 @@ const Addresses = ({
                     display: 'flex',
                   }}
                 >
-                  <span className="text-overflow">{item.address.slice(0, -6)}</span>
+                  <span className="textOverflow">{item.address.slice(0, -6)}</span>
                   <span>{item.address.slice(-6)}</span>
                 </div>
               )

--- a/packages/neuron-ui/src/components/Transaction/index.tsx
+++ b/packages/neuron-ui/src/components/Transaction/index.tsx
@@ -18,7 +18,7 @@ const inputColumns: IColumn[] = [
     minWidth: 100,
     maxWidth: 200,
     onRender: (item: any) => (
-      <span title={item.lockHash || 'none'} className="text-overflow">
+      <span title={item.lockHash || 'none'} className="textOverflow">
         {item.lockHash || 'none'}
       </span>
     ),
@@ -30,7 +30,7 @@ const inputColumns: IColumn[] = [
     onRender: (item: any) => {
       const text = item.previousOutput ? `${item.previousOutput.txHash}[${item.previousOutput.index}]` : 'none'
       return (
-        <span title={text} className="text-overflow">
+        <span title={text} className="textOverflow">
           {text}
         </span>
       )


### PR DESCRIPTION
Some fixes missing in https://github.com/nervosnetwork/neuron/commit/3417445e0909d8a5f8a2761bee736abbb04febae