### PR TITLE
refactor: sort transaction outputs in neuron wallet for performance

### DIFF
--- a/packages/neuron-ui/src/components/Transaction/index.tsx
+++ b/packages/neuron-ui/src/components/Transaction/index.tsx
@@ -55,6 +55,12 @@ const outputColumns: IColumn[] = [
     name: 'Index',
     minWidth: 80,
     maxWidth: 150,
+    onRender: (item?: any | State.DetailedOutput) => {
+      if (item) {
+        return item.outPoint.index
+      }
+      return null
+    },
   },
   {
     key: 'lockHash',
@@ -66,6 +72,12 @@ const outputColumns: IColumn[] = [
     name: 'Capacity',
     minWidth: 200,
     maxWidth: 250,
+    onRender: (output?: State.DetailedOutput) => {
+      if (output) {
+        return `${shannonToCKBFormatter(output.capacity)} CKB`
+      }
+      return null
+    },
   },
 ].map(col => ({
   ariaLabel: col.name,
@@ -191,13 +203,7 @@ const Transaction = () => {
             Outputs
           </Text>
           <DetailsList
-            items={transaction.outputs
-              .map(output => ({
-                ...output,
-                index: output.outPoint.index,
-                capacity: `${shannonToCKBFormatter(output.capacity)} CKB`,
-              }))
-              .sort((o1, o2) => +o1.index - +o2.index)}
+            items={transaction.outputs}
             columns={outputColumns}
             checkboxVisibility={CheckboxVisibility.hidden}
             compact

--- a/packages/neuron-ui/src/types/App/index.d.ts
+++ b/packages/neuron-ui/src/types/App/index.d.ts
@@ -10,6 +10,19 @@ declare namespace State {
     blockNumber: string
     status: 'pending' | 'success' | 'failed'
   }
+
+  interface DetailedOutput {
+    capacity: string
+    lock: {
+      args: string[]
+      codeHash: string
+    }
+    lockHash: string
+    outPoint: {
+      index: string
+      txHash: string
+    }
+  }
   interface DetailedTransaction extends Transaction {
     blockHash: string
     blockNumber: string
@@ -25,18 +38,7 @@ declare namespace State {
         } | null
       }
     }[]
-    outputs: {
-      capacity: string
-      lock: {
-        args: string[]
-        codeHash: string
-      }
-      lockHash: string
-      outPoint: {
-        index: string
-        txHash: string
-      }
-    }[]
+    outputs: DetailedOutput[]
     witnesses: string[]
   }
   interface Output {

--- a/packages/neuron-wallet/src/controllers/transactions.ts
+++ b/packages/neuron-wallet/src/controllers/transactions.ts
@@ -115,6 +115,11 @@ export default class TransactionsController {
       .reduce((result, c) => result + c, BigInt(0))
     const value: bigint = outputCapacities - inputCapacities
     transaction.value = value.toString()
+    if (transaction.outputs) {
+      transaction.outputs = transaction
+        .outputs.sort((o1, o2) => +o1.outPoint!.index - +o2.outPoint!.index)
+        .slice(0, 200)
+    }
 
     return {
       status: ResponseCode.Success,


### PR DESCRIPTION
This is a workaround for the performance problem of Transaction View.

It needs more work on handling the remote object.