### PR TITLE
fix(neuron-ui): hide unrelated columns when the mainnet address is di…

### DIFF
--- a/packages/neuron-ui/src/components/Addresses/index.tsx
+++ b/packages/neuron-ui/src/components/Addresses/index.tsx
@@ -189,7 +189,9 @@ const Addresses = ({
       <ShimmeredDetailsList
         enableShimmer={isLoading}
         checkboxVisibility={CheckboxVisibility.hidden}
-        columns={addressColumns.map(col => ({ ...col, name: t(col.name) }))}
+        columns={addressColumns
+          .filter(col => !showMainnetAddress || col.key === 'address')
+          .map(col => ({ ...col, name: t(col.name) }))}
         items={addresses.map(addr => ({
           ...addr,
           address: showMainnetAddress


### PR DESCRIPTION
…splayed
When it is the mainnet(disregard the addresses)
![image](https://user-images.githubusercontent.com/7271329/65591828-d8c44600-dfbf-11e9-9bcb-ed523d7560d0.png)

When it is the testnet
![image](https://user-images.githubusercontent.com/7271329/65591851-e5489e80-dfbf-11e9-98b3-aabb0c654832.png)
![image](https://user-images.githubusercontent.com/7271329/65591858-e7aaf880-dfbf-11e9-9b10-c5ecb56fe6af.png)
