### PR TITLE
feat(neuron-ui): extend the width of tx type field to 70 px

### DIFF
--- a/packages/neuron-ui/src/components/TransactionList/index.tsx
+++ b/packages/neuron-ui/src/components/TransactionList/index.tsx
@@ -28,8 +28,6 @@ import { CONFIRMATION_THRESHOLD } from 'utils/const'
 const theme = getTheme()
 const { semanticColors } = theme
 
-const MIN_CELL_WIDTH = 50
-
 interface FormatTransaction extends State.Transaction {
   date: string
 }
@@ -82,8 +80,8 @@ const TransactionList = ({
           name: t('history.type'),
           key: 'type',
           fieldName: 'type',
-          minWidth: MIN_CELL_WIDTH,
-          maxWidth: 50,
+          minWidth: 70,
+          maxWidth: 70,
           onRender: (item?: FormatTransaction) => {
             if (!item) {
               return null


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7271329/65747673-97a17280-e134-11e9-8815-5afc193d0c67.png)
![image](https://user-images.githubusercontent.com/7271329/65747686-9d975380-e134-11e9-8cdb-9bfff84b928f.png)
