### PR TITLE
fix(neuron-ui): show 0 confirmations if the real data is negative

### DIFF
--- a/packages/neuron-ui/src/components/TransactionList/index.tsx
+++ b/packages/neuron-ui/src/components/TransactionList/index.tsx
@@ -133,7 +133,7 @@ const TransactionList = ({
             const confirmationCount = 1 + +tipBlockNumber - +item.blockNumber
             if (confirmationCount < CONFIRMATION_THRESHOLD) {
               return t(`history.confirming-with-count`, {
-                confirmations: `${confirmationCount} / ${CONFIRMATION_THRESHOLD}`,
+                confirmations: `${Math.max(0, confirmationCount)} / ${CONFIRMATION_THRESHOLD}`,
               })
             }
             const confirmations = localNumberFormatter(confirmationCount)


### PR DESCRIPTION
Before PR:
![image](https://user-images.githubusercontent.com/7271329/65852748-b482b380-e389-11e9-9513-1ef79624af1d.png)
After PR:
![image](https://user-images.githubusercontent.com/7271329/65852753-b8163a80-e389-11e9-9ec7-70735c878973.png)
