### PR TITLE
feat(neuron-ui): dismiss pinned top alert if it's related to auto-dis…

### DIFF
--- a/packages/neuron-ui/src/states/stateProvider/reducer.ts
+++ b/packages/neuron-ui/src/states/stateProvider/reducer.ts
@@ -476,6 +476,7 @@ export const reducer = (
       }
     }
     case AppActions.ClearNotificationsOfCode: {
+      const notifications = app.notifications.filter(({ code }) => code !== payload)
       return {
         ...state,
         app: {
@@ -483,11 +484,11 @@ export const reducer = (
           messages: {
             ...app.messages,
           },
-          showTopAlert: !(
-            app.notifications[app.notifications.length - 1] &&
-            app.notifications[app.notifications.length - 1].code === payload
-          ),
-          notifications: app.notifications.filter(({ code }) => code !== payload),
+          showTopAlert:
+            app.showTopAlert &&
+            notifications.length > 0 &&
+            !(app.notifications.length > 0 && app.notifications[app.notifications.length - 1].code === payload),
+          notifications,
         },
       }
     }

--- a/packages/neuron-ui/src/states/stateProvider/reducer.ts
+++ b/packages/neuron-ui/src/states/stateProvider/reducer.ts
@@ -483,6 +483,10 @@ export const reducer = (
           messages: {
             ...app.messages,
           },
+          showTopAlert: !(
+            app.notifications[app.notifications.length - 1] &&
+            app.notifications[app.notifications.length - 1].code === payload
+          ),
           notifications: app.notifications.filter(({ code }) => code !== payload),
         },
       }

--- a/packages/neuron-wallet/tests-e2e/tests/notification.ts
+++ b/packages/neuron-wallet/tests-e2e/tests/notification.ts
@@ -79,9 +79,8 @@ export default (app: Application) => {
       client.click('button[type=submit]')
       await app.waitUntilLoaded()
       sleep(4000)
-      const alertComponent = await client.$('.ms-MessageBar-text')
-      const msg = await client.elementIdText(alertComponent.value.ELEMENT)
-      expect(msg.value).toBe(messages.disconnected)
+      const alertComponent = await client.$('.ms-MessageBar--error')
+      expect(alertComponent.state).toBe('failure')
     })
   })
 }


### PR DESCRIPTION
…missed notifications

Suppose there are two notifications `['disconnected', 'incorrect password']`, the `incorrect password` is pinned at the top of the app, and after inputting the correct password, there's only one notification `[disconnected]` .

Before this PR:
The pinned alert turns into `disconnected`

After this PR:
The pinned alert will be dismissed instead of updating its text to `disconnected`