### PR TITLE
fix(neuron-ui): set current wallet to empty when all wallets are deleted

### DIFF
--- a/packages/neuron-ui/src/states/initStates/wallet.ts
+++ b/packages/neuron-ui/src/states/initStates/wallet.ts
@@ -1,5 +1,12 @@
 import { addresses, currentWallet } from 'services/localCache'
 
+export const emptyWallet: State.Wallet = {
+  name: '',
+  id: '',
+  balance: '0',
+  addresses: [],
+}
+
 const wallet = currentWallet.load()
 
 export const walletState: State.Wallet = {

--- a/packages/neuron-ui/src/states/stateProvider/actionCreators/wallets.ts
+++ b/packages/neuron-ui/src/states/stateProvider/actionCreators/wallets.ts
@@ -14,7 +14,7 @@ import {
   backupWallet as backupRemoteWallet,
   showErrorMessage,
 } from 'services/remote'
-import initStates from 'states/initStates'
+import { emptyWallet } from 'states/initStates/wallet'
 import { WalletWizardPath } from 'components/WalletWizard'
 import i18n from 'utils/i18n'
 import { wallets as walletsCache, currentWallet as currentWalletCache } from 'services/localCache'
@@ -26,7 +26,7 @@ import { addNotification, addPopup } from './app'
 export const updateCurrentWallet = () => (dispatch: StateDispatch, history: any) => {
   getCurrentWallet().then(res => {
     if (res.status === 1) {
-      const payload = res.result || initStates.wallet
+      const payload = res.result || emptyWallet
       if (!payload || !payload.id) {
         history.push(`${Routes.WalletWizard}${WalletWizardPath.Welcome}`)
       }


### PR DESCRIPTION
Before this PR
the `initState.wallet` is possible to have values, which is incorrect when the result is null or undefined.