### PR TITLE
feat(neuron-ui): ignore the NodeDisconnected Errors from controller, …

### DIFF
--- a/packages/neuron-ui/src/states/stateProvider/actionCreators/app.ts
+++ b/packages/neuron-ui/src/states/stateProvider/actionCreators/app.ts
@@ -76,6 +76,9 @@ export const addPopup = (text: string) => (dispatch: StateDispatch) => {
 }
 
 export const addNotification = (message: State.Message<ErrorCode>) => (dispatch: StateDispatch) => {
+  if (message && message.code === ErrorCode.NodeDisconnected) {
+    return
+  }
   dispatch({
     type: AppActions.AddNotification,
     payload: message,

--- a/packages/neuron-ui/src/utils/const.ts
+++ b/packages/neuron-ui/src/utils/const.ts
@@ -72,6 +72,7 @@ export enum ErrorCode {
   AmountNotEnough = 100,
   AmountTooSmall = 101,
   PasswordIncorrect = 103,
+  NodeDisconnected = 104,
   // Parameter validation errors from neuron-ui
   FieldRequired = 201,
   FieldUsed = 202,

--- a/packages/neuron-wallet/tests-e2e/tests/notification.ts
+++ b/packages/neuron-wallet/tests-e2e/tests/notification.ts
@@ -3,7 +3,7 @@ import { createWallet } from '../operations'
 import { sleep } from '../application/utils'
 
 /**
- * 1. check the alert, it should be disconnected to the network
+ * 1. check the alert, it should be empty
  * 2. navigate to wallet settingsState
  * 3. delete a wallet
  * 4. input a wrong password
@@ -33,15 +33,14 @@ export default (app: Application) => {
 
   describe('Test alert message and notification', () => {
     const messages = {
-      disconnected: 'Connection to the node is failed',
       incorrectPassword: 'Password is incorrect',
     }
 
-    app.test('It should have an alert message of disconnection', async () => {
+    app.test('There is no alerts after the app launched', async () => {
       const { client } = app.spectron
       const alertComponent = await client.$('.ms-MessageBar-text')
       const msg = await client.elementIdText(alertComponent.value.ELEMENT)
-      expect(msg.value).toBe(messages.disconnected)
+      expect(msg.value).toBe('')
     })
 
     app.test('It should have an alert message of incorrect password', async () => {
@@ -58,14 +57,12 @@ export default (app: Application) => {
       expect(msg.value).toBe(messages.incorrectPassword)
     })
 
-    app.test('It should have two messages in the notification', async () => {
+    app.test('It should have a message in the notification', async () => {
       const { client } = app.spectron
       const messageComponents = await client.$$('.ms-Panel-content p')
       expect(messageComponents.length).toBe(Object.keys(messages).length)
       const incorrectPasswordMsg = await client.element(`//P[text()="${messages.incorrectPassword}"]`)
-      const disconnectMsg = await client.element(`//P[text()="${messages.disconnected}"]`)
       expect(incorrectPasswordMsg.state).not.toBe('failure')
-      expect(disconnectMsg.state).not.toBe('failed')
     })
 
     // TODO: dismiss a message


### PR DESCRIPTION
…the disconnected status will be handled by a [specific subject handler](https://github.com/nervosnetwork/neuron/blob/develop/packages/neuron-ui/src/containers/Main/hooks.ts#L192).
