### PR TITLE
feature: Allow creating LockUtils instance

### DIFF
--- a/packages/neuron-wallet/src/controllers/transactions.ts
+++ b/packages/neuron-wallet/src/controllers/transactions.ts
@@ -98,7 +98,7 @@ export default class TransactionsController {
       throw new CurrentWalletNotSet()
     }
     const addresses: string[] = (await AddressesService.allAddressesByWalletId(wallet.id)).map(addr => addr.address)
-    const lockHashes: string[] = await LockUtils.addressesToAllLockHashes(addresses)
+    const lockHashes: string[] = new LockUtils(await LockUtils.systemScript()).addressesToAllLockHashes(addresses)
 
     const outputCapacities: bigint = transaction
       .outputs!.filter(o => lockHashes.includes(o.lockHash!))

--- a/packages/neuron-wallet/src/database/address/dao.ts
+++ b/packages/neuron-wallet/src/database/address/dao.ts
@@ -69,11 +69,11 @@ export default class AddressDao {
       TransactionStatus.Pending,
       TransactionStatus.Success,
     ], url)
+    const lockUtils = new LockUtils(await LockUtils.systemScript(url))
     const entities = await Promise.all(
       addressEntities.map(async entity => {
         const addressEntity = entity
         addressEntity.txCount = txCount
-        const lockUtils = new LockUtils(await LockUtils.loadSystemScript(url))
         const lockHashes: string[] = lockUtils.addressToAllLockHashes(addressEntity.address)
         addressEntity.liveBalance = await CellsService.getBalance(lockHashes, OutputStatus.Live, true)
         addressEntity.sentBalance = await CellsService.getBalance(lockHashes, OutputStatus.Sent, true)

--- a/packages/neuron-wallet/src/database/address/dao.ts
+++ b/packages/neuron-wallet/src/database/address/dao.ts
@@ -73,7 +73,8 @@ export default class AddressDao {
       addressEntities.map(async entity => {
         const addressEntity = entity
         addressEntity.txCount = txCount
-        const lockHashes: string[] = await LockUtils.addressToAllLockHashes(addressEntity.address, url)
+        const lockUtils = new LockUtils(await LockUtils.loadSystemScript(url))
+        const lockHashes: string[] = lockUtils.addressToAllLockHashes(addressEntity.address)
         addressEntity.liveBalance = await CellsService.getBalance(lockHashes, OutputStatus.Live, true)
         addressEntity.sentBalance = await CellsService.getBalance(lockHashes, OutputStatus.Sent, true)
         addressEntity.pendingBalance = await CellsService.getBalance(lockHashes, OutputStatus.Pending, true)

--- a/packages/neuron-wallet/src/models/lock-utils.ts
+++ b/packages/neuron-wallet/src/models/lock-utils.ts
@@ -30,16 +30,18 @@ const subscribed = (target: any, propertyName: string) => {
 }
 
 export default class LockUtils {
+  systemScript: SystemScript
+
+  constructor(systemScript: SystemScript) {
+    this.systemScript = systemScript
+  }
+
   @subscribed
   static systemScriptInfo: SystemScript | undefined
 
   static previousURL: string | undefined
 
-  static async systemScript(nodeURL: string = NodeService.getInstance().core.rpc.node.url): Promise<SystemScript> {
-    if (this.systemScriptInfo && nodeURL === LockUtils.previousURL) {
-      return this.systemScriptInfo
-    }
-
+  static async loadSystemScript(nodeURL: string): Promise<SystemScript> {
     const core = new Core(nodeURL)
 
     const systemCell = await core.loadSecp256k1Dep()
@@ -56,25 +58,51 @@ export default class LockUtils {
       txHash = `0x${txHash}`
     }
 
-    const systemScriptInfo = {
+    return {
       codeHash,
-      outPoint: {
-        txHash,
-        index,
-      },
-      hashType: hashType as ScriptHashType,
+      outPoint: { txHash, index },
+      hashType: hashType as ScriptHashType
+    }
+  }
+
+  static async systemScript(nodeURL: string = NodeService.getInstance().core.rpc.node.url): Promise<SystemScript> {
+    if (LockUtils.systemScriptInfo && nodeURL === LockUtils.previousURL) {
+      return LockUtils.systemScriptInfo
     }
 
-    this.systemScriptInfo = systemScriptInfo
+    LockUtils.systemScriptInfo = await LockUtils.loadSystemScript(nodeURL)
     LockUtils.previousURL = nodeURL
 
-    return systemScriptInfo
+    return LockUtils.systemScriptInfo
   }
 
   static setSystemScript(info: SystemScript) {
     LockUtils.systemScriptInfo = info
     LockUtils.previousURL = NodeService.getInstance().core.rpc.node.url
     SystemScriptSubject.next({ codeHash: info.codeHash })
+  }
+
+  addressToLockScript(address: string, hashType: ScriptHashType = ScriptHashType.Type): Script {
+    return {
+      codeHash: this.systemScript.codeHash,
+      args: LockUtils.addressToBlake160(address),
+      hashType,
+    }
+  }
+
+  addressToLockHash(address: string, hashType: ScriptHashType = ScriptHashType.Type): string {
+    const lock = this.addressToLockScript(address, hashType)
+    return LockUtils.lockScriptToHash(lock)
+  }
+
+  addressToAllLockHashes(address: string): string[] {
+    return [this.addressToLockHash(address, ScriptHashType.Type)]
+  }
+
+  addressesToAllLockHashes(addresses: string[]): string[] {
+    return addresses.map(addr => {
+      return this.addressToAllLockHashes(addr)
+    }).reduce((acc, val) => acc.concat(val), [])
   }
 
   static computeScriptHash = (script: Script): string => {
@@ -91,55 +119,9 @@ export default class LockUtils {
     return LockUtils.computeScriptHash(lock)
   }
 
-  static async addressToLockScript(
-    address: string,
-    hashType: ScriptHashType = ScriptHashType.Type,
-    nodeURL: string = NodeService.getInstance().core.rpc.node.url
-  ): Promise<Script> {
-    const systemScript = await this.systemScript(nodeURL)
-
-    const lock: Script = {
-      codeHash: systemScript.codeHash,
-      args: LockUtils.addressToBlake160(address),
-      hashType,
-    }
-    return lock
-  }
-
-  static async addressToLockHash(
-    address: string,
-    hashType: ScriptHashType = ScriptHashType.Type,
-    nodeURL: string = NodeService.getInstance().core.rpc.node.url
-  ): Promise<string> {
-    const lock: Script = await this.addressToLockScript(address, hashType, nodeURL)
-    const lockHash: string = this.lockScriptToHash(lock)
-
-    return lockHash
-  }
-
-  static async addressToAllLockHashes(
-    address: string,
-    nodeURL: string = NodeService.getInstance().core.rpc.node.url
-  ): Promise<string[]> {
-    const dataLockHash = await LockUtils.addressToLockHash(address, ScriptHashType.Type, nodeURL)
-    return [dataLockHash]
-  }
-
-  static async addressesToAllLockHashes(
-    addresses: string[],
-    nodeURL: string = NodeService.getInstance().core.rpc.node.url
-  ): Promise<string[]> {
-    const lockHashes: string[] = (await Promise.all(
-      addresses.map(async addr => {
-        return LockUtils.addressToAllLockHashes(addr, nodeURL)
-      })
-    )).reduce((acc, val) => acc.concat(val), [])
-    return lockHashes
-  }
-
   static lockScriptToAddress(lock: Script): string {
     const blake160: string = lock.args!
-    return this.blake160ToAddress(blake160)
+    return LockUtils.blake160ToAddress(blake160)
   }
 
   static blake160ToAddress(blake160: string): string {

--- a/packages/neuron-wallet/src/services/tx/transaction-service.ts
+++ b/packages/neuron-wallet/src/services/tx/transaction-service.ts
@@ -307,7 +307,7 @@ export class TransactionsService {
     status: TransactionStatus[],
     url: string = NodeService.getInstance().core.rpc.node.url
   ): Promise<number> => {
-    const lockHashes: string[] = new LockUtils(await LockUtils.loadSystemScript(url)).addressToAllLockHashes(address)
+    const lockHashes: string[] = new LockUtils(await LockUtils.systemScript(url)).addressToAllLockHashes(address)
     return TransactionsService.getCountByLockHashesAndStatus(lockHashes, status)
   }
 

--- a/packages/neuron-wallet/src/services/tx/transaction-service.ts
+++ b/packages/neuron-wallet/src/services/tx/transaction-service.ts
@@ -72,7 +72,7 @@ export class TransactionsService {
       return base
     }
     if (type === SearchType.Address) {
-      const lockHashes: string[] = await LockUtils.addressToAllLockHashes(value)
+      const lockHashes: string[] = await new LockUtils(await LockUtils.systemScript()).addressToAllLockHashes(value)
       return ['input.lockHash IN (:...lockHashes) OR output.lockHash IN (:...lockHashes)', { lockHashes }]
     }
     if (type === SearchType.TxHash) {
@@ -207,7 +207,8 @@ export class TransactionsService {
     params: TransactionsByAddressesParam,
     searchValue: string = ''
   ): Promise<PaginationResult<Transaction>> => {
-    const lockHashes: string[] = await LockUtils.addressesToAllLockHashes(params.addresses)
+    const lockHashes: string[] = new LockUtils(await LockUtils.systemScript())
+      .addressesToAllLockHashes(params.addresses)
 
     return TransactionsService.getAll(
       {
@@ -228,7 +229,7 @@ export class TransactionsService {
       return addr
     })
 
-    const lockHashes = await LockUtils.addressesToAllLockHashes(addresses)
+    const lockHashes = new LockUtils(await LockUtils.systemScript()).addressesToAllLockHashes(addresses)
 
     return TransactionsService.getAll(
       {
@@ -306,7 +307,7 @@ export class TransactionsService {
     status: TransactionStatus[],
     url: string = NodeService.getInstance().core.rpc.node.url
   ): Promise<number> => {
-    const lockHashes: string[] = await LockUtils.addressToAllLockHashes(address, url)
+    const lockHashes: string[] = new LockUtils(await LockUtils.loadSystemScript(url)).addressToAllLockHashes(address)
     return TransactionsService.getCountByLockHashesAndStatus(lockHashes, status)
   }
 

--- a/packages/neuron-wallet/src/services/wallets.ts
+++ b/packages/neuron-wallet/src/services/wallets.ts
@@ -280,7 +280,7 @@ export default class WalletService {
     if (deindexAddresses.length !== 0) {
       const lockHashes: string[] = await Promise.all(
         deindexAddresses.map(async address => {
-          return LockUtils.addressToLockHash(address)
+          return new LockUtils(await LockUtils.systemScript()).addressToLockHash(address)
         })
       )
       // don't await
@@ -351,7 +351,7 @@ export default class WalletService {
 
     const addresses: string[] = addressInfos.map(info => info.address)
 
-    const lockHashes: string[] = await LockUtils.addressesToAllLockHashes(addresses)
+    const lockHashes: string[] = new LockUtils(await LockUtils.systemScript()).addressesToAllLockHashes(addresses)
 
     const targetOutputs = items.map(item => ({
       ...item,
@@ -419,7 +419,7 @@ export default class WalletService {
 
     const addresses: string[] = addressInfos.map(info => info.address)
 
-    const lockHashes: string[] = await LockUtils.addressesToAllLockHashes(addresses)
+    const lockHashes: string[] = new LockUtils(await LockUtils.systemScript()).addressesToAllLockHashes(addresses)
 
     const { inputs } = await CellsService.gatherInputs(capacities, lockHashes, '0')
     const cycles = SECP_CYCLES * BigInt(inputs.length)

--- a/packages/neuron-wallet/src/startup/sync-block-task/sync.ts
+++ b/packages/neuron-wallet/src/startup/sync-block-task/sync.ts
@@ -20,7 +20,7 @@ export interface LockHashInfo {
 // maybe should call this every time when new address generated
 // load all addresses and convert to lockHashes
 export const loadAddressesAndConvert = async (nodeURL: string): Promise<string[]> => {
-  const lockUtils = new LockUtils(await LockUtils.loadSystemScript(nodeURL))
+  const lockUtils = new LockUtils(await LockUtils.systemScript(nodeURL))
   const addresses = (await AddressService.allAddresses()).map(addr => addr.address)
   return lockUtils.addressesToAllLockHashes(addresses)
 }
@@ -44,7 +44,7 @@ export const switchNetwork = async (url: string, genesisBlockHash: string, chain
   // listen to address created
   addressCreatedSubject.subscribe(async (addresses: Address[]) => {
     if (blockListener) {
-      const lockUtils = new LockUtils(await LockUtils.loadSystemScript(url))
+      const lockUtils = new LockUtils(await LockUtils.systemScript(url))
       const infos: LockHashInfo[] = addresses.map(addr => {
         const hashes: string[] = lockUtils.addressToAllLockHashes(addr.address)
         // undefined means false

--- a/packages/neuron-wallet/tests/models/lock-utils.test.ts
+++ b/packages/neuron-wallet/tests/models/lock-utils.test.ts
@@ -39,13 +39,12 @@ describe('LockUtils Test', () => {
     expect(lockHash).toEqual(bob.lockHash)
   })
 
-  // FIXME: test failed, should fix addressToLockScript
   it('addressToLockScript', async () => {
     const mockContractInfo = jest.fn()
     mockContractInfo.mockReturnValue(systemScript)
     LockUtils.systemScript = mockContractInfo.bind(LockUtils)
 
-    const lockScript: Script = await LockUtils.addressToLockScript(bob.address)
+    const lockScript: Script = new LockUtils(await LockUtils.systemScript()).addressToLockScript(bob.address)
 
     expect(lockScript).toEqual(bob.lockScript)
   })
@@ -55,7 +54,7 @@ describe('LockUtils Test', () => {
     mockContractInfo.mockReturnValue(systemScript)
     LockUtils.systemScript = mockContractInfo.bind(LockUtils)
 
-    const lockHash: string = await LockUtils.addressToLockHash(bob.address)
+    const lockHash: string = new LockUtils(await LockUtils.systemScript()).addressToLockHash(bob.address)
 
     expect(lockHash).toEqual(bob.lockHash)
   })
@@ -65,7 +64,7 @@ describe('LockUtils Test', () => {
     mockContractInfo.mockReturnValue(systemScript)
     LockUtils.systemScript = mockContractInfo.bind(LockUtils)
 
-    const lockHashes: string[] = await LockUtils.addressToAllLockHashes(bob.address)
+    const lockHashes: string[] = new LockUtils(await LockUtils.systemScript()).addressToAllLockHashes(bob.address)
 
     expect(lockHashes).toEqual([bob.lockHash])
   })
@@ -75,7 +74,8 @@ describe('LockUtils Test', () => {
     mockContractInfo.mockReturnValue(systemScript)
     LockUtils.systemScript = mockContractInfo.bind(LockUtils)
 
-    const lockHashes: string[] = await LockUtils.addressesToAllLockHashes([bob.address, alice.address])
+    const lockHashes: string[] = new LockUtils(await LockUtils.systemScript())
+      .addressesToAllLockHashes([bob.address, alice.address])
 
     const expectedResult = [bob.lockHash, alice.lockHash]
 


### PR DESCRIPTION
Eliminate nested async calls and maps. Other than loading the system script,
lock utils should be able to handle batch of addresses <=> lock hashes
in synchronous manner.