### PR TITLE
feat(neuron-ui): display confirmations of pending transactions in the…

### DIFF
--- a/packages/neuron-ui/src/components/CustomRows/ActivityRow.tsx
+++ b/packages/neuron-ui/src/components/CustomRows/ActivityRow.tsx
@@ -34,13 +34,13 @@ const ActivityRow = (props?: ActivityRowProps) => {
   return (
     <div
       className={`${styles.activityRow} ${styles[status]}`}
-      title={`${hash}: ${description}`}
+      title={`${hash}: ${description || ''}`}
       onDoubleClick={onDoubleClick}
     >
       <div className={styles.action}>{`${typeLabel} ${shannonToCKBFormatter(value)} CKB`}</div>
       <div className={styles.status}>{statusLabel}</div>
       <div className={styles.time}>{time}</div>
-      <div className={styles.meta}>{status === 'success' ? confirmations : ''}</div>
+      <div className={styles.meta}>{confirmations}</div>
     </div>
   )
 }

--- a/packages/neuron-ui/src/components/Overview/index.tsx
+++ b/packages/neuron-ui/src/components/Overview/index.tsx
@@ -118,7 +118,7 @@ const Overview = ({
   const activityItems: ActivityItem[] = useMemo(
     () =>
       items.map(item => {
-        let confirmations = '(-)'
+        let confirmations = ''
         let typeLabel: string = item.type
         let { status } = item
         if (item.blockNumber !== undefined) {
@@ -147,7 +147,7 @@ const Overview = ({
           status,
           statusLabel: t(`overview.statusLabel.${status}`),
           value: item.value.replace(/^-/, ''),
-          confirmations: item.status === 'success' ? confirmations : '',
+          confirmations: ['success', 'pending'].includes(item.status) ? confirmations : '',
           typeLabel: t(`overview.${typeLabel}`),
         }
       }),


### PR DESCRIPTION
… recent activity list

![image](https://user-images.githubusercontent.com/7271329/67412224-76c42400-f5f1-11e9-9fe5-b82bab68d21d.png)
