### PR TITLE
Eslint no unused vars

### DIFF
--- a/packages/neuron-wallet/.eslintrc.js
+++ b/packages/neuron-wallet/.eslintrc.js
@@ -14,13 +14,14 @@ module.exports = {
     "@typescript-eslint/no-unused-vars": ["error", {
       "vars": "local",
       "args": "after-used",
-      "ignoreRestSiblings": false
+      "ignoreRestSiblings": false,
+      "argsIgnorePattern": "^_"
     }],
     "curly": [2, "all"],
     "implicit-arrow-linebreak": "off",
     "arrow-parens": [2, "as-needed"],
     "max-len": [2, {
-      "code": 120,
+      "code": 140,
       "ignoreComments": true,
       "ignoreTrailingComments": true,
       "ignoreUrls": true,

--- a/packages/neuron-wallet/src/database/chain/entities/input.ts
+++ b/packages/neuron-wallet/src/database/chain/entities/input.ts
@@ -2,7 +2,6 @@ import { Entity, BaseEntity, Column, ManyToOne, PrimaryGeneratedColumn } from 't
 import { OutPoint, Input as InputInterface, Script } from 'types/cell-types'
 import Transaction from './transaction'
 
-/* eslint @typescript-eslint/no-unused-vars: "warn" */
 // cellbase input may have same OutPoint
 @Entity()
 export default class Input extends BaseEntity {

--- a/packages/neuron-wallet/src/database/chain/entities/output.ts
+++ b/packages/neuron-wallet/src/database/chain/entities/output.ts
@@ -2,7 +2,6 @@ import { Entity, BaseEntity, Column, PrimaryColumn, ManyToOne } from 'typeorm'
 import { Script, OutPoint, Cell } from 'types/cell-types'
 import TransactionEntity from './transaction'
 
-/* eslint @typescript-eslint/no-unused-vars: "warn" */
 @Entity()
 export default class Output extends BaseEntity {
   @PrimaryColumn({

--- a/packages/neuron-wallet/src/database/chain/entities/transaction.ts
+++ b/packages/neuron-wallet/src/database/chain/entities/transaction.ts
@@ -21,7 +21,6 @@ const txDbChangedSubject = isRenderer
   ? remote.require('./models/subjects/tx-db-changed-subject').default.getSubject()
   : TxDbChangedSubject.getSubject()
 
-/* eslint @typescript-eslint/no-unused-vars: "warn" */
 @Entity()
 export default class Transaction extends BaseEntity {
   @PrimaryColumn({

--- a/packages/neuron-wallet/src/services/cells.ts
+++ b/packages/neuron-wallet/src/services/cells.ts
@@ -7,9 +7,6 @@ import SkipDataAndType from './settings/skip-data-and-type'
 
 export const MIN_CELL_CAPACITY = '6100000000'
 
-/* eslint @typescript-eslint/no-unused-vars: "warn" */
-/* eslint no-await-in-loop: "warn" */
-/* eslint no-restricted-syntax: "warn" */
 export default class CellsService {
   // exclude hasData = true and typeScript != null
   public static getBalance = async (

--- a/packages/neuron-wallet/src/services/indexer/indexer-rpc.ts
+++ b/packages/neuron-wallet/src/services/indexer/indexer-rpc.ts
@@ -16,27 +16,15 @@ export default class IndexerRPC {
     return this.core.rpc.indexLockHash(lockHash, indexFrom)
   }
 
-  public getTransactionByLockHash = async (
-    lockHash: string,
-    page: string,
-    per: string,
-    reverseOrder: boolean = false
-  ) => {
-    const result = await this.core.rpc.getTransactionsByLockHash(lockHash, page, per, reverseOrder)
-    return result
+  public getTransactionsByLockHash = async (lockHash: string, page: string, per: string, reverseOrder: boolean = false) => {
+    return await this.core.rpc.getTransactionsByLockHash(lockHash, page, per, reverseOrder)
   }
 
   public getLockHashIndexStates = async () => {
     return this.core.rpc.getLockHashIndexStates()
   }
 
-  public getLiveCellsByLockHash = async (
-    lockHash: string,
-    page: string,
-    per: string,
-    reverseOrder: boolean = false
-  ) => {
-    const result = await this.core.rpc.getLiveCellsByLockHash(lockHash, page, per, reverseOrder)
-    return result
+  public getLiveCellsByLockHash = async (lockHash: string, page: string, per: string, reverseOrder: boolean = false) => {
+    return await this.core.rpc.getLiveCellsByLockHash(lockHash, page, per, reverseOrder)
   }
 }

--- a/packages/neuron-wallet/src/services/indexer/queue.ts
+++ b/packages/neuron-wallet/src/services/indexer/queue.ts
@@ -143,8 +143,7 @@ export default class IndexerQueue {
       .map(state => HexUtils.toDecimal(state.blockNumber))
     const uniqueBlockNumbers = [...new Set(blockNumbers)]
     const blockNumbersBigInt = uniqueBlockNumbers.map(num => BigInt(num))
-    const minBlockNumber = Utils.min(blockNumbersBigInt)
-    return minBlockNumber
+    return Utils.min(blockNumbersBigInt)
   }
 
   public indexLockHashes = async (lockHashInfos: LockHashInfo[]) => {
@@ -163,7 +162,7 @@ export default class IndexerQueue {
     let page = 0
     let stopped = false
     while (!stopped) {
-      const txs = await this.indexerRPC.getTransactionByLockHash(lockHash, `0x${page.toString(16)}`, `0x${this.per.toString(16)}`)
+      const txs = await this.indexerRPC.getTransactionsByLockHash(lockHash, `0x${page.toString(16)}`, `0x${this.per.toString(16)}`)
       if (txs.length < this.per) {
         stopped = true
       }

--- a/packages/neuron-wallet/src/services/indexer/queue.ts
+++ b/packages/neuron-wallet/src/services/indexer/queue.ts
@@ -26,7 +26,6 @@ enum TxPointType {
 }
 
 export default class IndexerQueue {
-  // private lockHashes: string[]
   private lockHashInfos: LockHashInfo[]
   private indexerRPC: IndexerRPC
   private getBlocksService: GetBlocks
@@ -48,7 +47,6 @@ export default class IndexerQueue {
   private url: string
 
   constructor(url: string, lockHashInfos: LockHashInfo[], tipNumberSubject: Subject<string | undefined>) {
-    // this.lockHashes = lockHashes
     this.lockHashInfos = lockHashInfos
     this.url = url
     this.indexerRPC = new IndexerRPC(url)
@@ -62,7 +60,6 @@ export default class IndexerQueue {
   }
 
   public setLockHashInfos = (lockHashInfos: LockHashInfo[]): void => {
-    // this.lockHashes = lockHashes
     this.lockHashInfos = lockHashInfos
     this.indexed = false
   }
@@ -76,8 +73,6 @@ export default class IndexerQueue {
     this.resetFlag = true
   }
 
-  /* eslint no-await-in-loop: "off" */
-  /* eslint no-restricted-syntax: "off" */
   public start = async () => {
     while (!this.stopped) {
       try {

--- a/packages/neuron-wallet/src/services/sync/get-blocks.ts
+++ b/packages/neuron-wallet/src/services/sync/get-blocks.ts
@@ -64,16 +64,14 @@ export default class GetBlocks {
 
   public retryGetBlock = async (num: string): Promise<Block> => {
     const block: Block = await Utils.retry(this.retryTime, this.retryInterval, async () => {
-      const b: Block = await this.getBlockByNumber(num)
-      return b
+      return await this.getBlockByNumber(num)
     })
 
     return block
   }
 
   public getTransaction = async (hash: string): Promise<CKBComponents.TransactionWithStatus> => {
-    const tx = await this.core.rpc.getTransaction(hash)
-    return tx
+    return await this.core.rpc.getTransaction(hash)
   }
 
   public getHeader = async (hash: string): Promise<BlockHeader> => {
@@ -88,8 +86,7 @@ export default class GetBlocks {
 
   public genesisBlockHash = async (): Promise<string> => {
     const hash: string = await Utils.retry(3, 100, async () => {
-      const h: string = await this.core.rpc.getBlockHash('0x0')
-      return h
+      return await this.core.rpc.getBlockHash('0x0')
     })
 
     return hash

--- a/packages/neuron-wallet/src/services/tx/transaction-persistor.ts
+++ b/packages/neuron-wallet/src/services/tx/transaction-persistor.ts
@@ -7,9 +7,6 @@ import LockUtils from 'models/lock-utils'
 import { OutputStatus, TxSaveType } from './params'
 import Utils from 'services/sync/utils'
 
-/* eslint @typescript-eslint/no-unused-vars: "warn" */
-/* eslint no-await-in-loop: "off" */
-/* eslint no-restricted-syntax: "off" */
 export class TransactionPersistor {
   // After the tx is sent:
   // 1. If the tx is not persisted before sending, output = sent, input = pending

--- a/packages/neuron-wallet/src/services/tx/transaction-service.ts
+++ b/packages/neuron-wallet/src/services/tx/transaction-service.ts
@@ -38,9 +38,6 @@ export enum SearchType {
   Unknown = 'unknown',
 }
 
-/* eslint @typescript-eslint/no-unused-vars: "warn" */
-/* eslint no-await-in-loop: "off" */
-/* eslint no-restricted-syntax: "off" */
 export class TransactionsService {
   public static filterSearchType = (value: string) => {
     if (value === '') {


### PR DESCRIPTION
Allow unused function arg to be ignored if they start with `_`, just as `TypeScript` handles that.