### PR TITLE
Optimize non indexer sync

### DIFF
--- a/packages/neuron-wallet/src/services/sync/check-and-save/output.ts
+++ b/packages/neuron-wallet/src/services/sync/check-and-save/output.ts
@@ -18,7 +18,7 @@ export default class CheckOutput {
     return this.output
   }
 
-  public checkLockHash = async (lockHashList: string[]): Promise<boolean | undefined> => {
+  public checkLockHash = (lockHashList: string[]): boolean => {
     return lockHashList.includes(this.output.lockHash!)
   }
 }

--- a/packages/neuron-wallet/src/services/sync/check-and-save/tx.ts
+++ b/packages/neuron-wallet/src/services/sync/check-and-save/tx.ts
@@ -25,7 +25,7 @@ export default class CheckTx {
   }
 
   public check = async (lockHashes: string[]): Promise<string[]> => {
-    const outputs: Cell[] = await this.filterOutputs(lockHashes)
+    const outputs: Cell[] = this.filterOutputs(lockHashes)
     const inputAddresses = await this.filterInputs(lockHashes)
 
     const outputAddresses: string[] = outputs.map(output => {
@@ -50,17 +50,15 @@ export default class CheckTx {
     return false
   }
 
-  public filterOutputs = async (lockHashes: string[]) => {
-    const cells: Cell[] = (await Promise.all(
-      this.tx.outputs!.map(async output => {
-        const checkOutput = new CheckOutput(output)
-        const result = await checkOutput.checkLockHash(lockHashes)
-        if (result) {
-          return output
-        }
-        return false
-      })
-    )).filter(cell => !!cell) as Cell[]
+  public filterOutputs = (lockHashes: string[]) => {
+    const cells: Cell[] = this.tx.outputs!.map(output => {
+      const checkOutput = new CheckOutput(output)
+      const result = checkOutput.checkLockHash(lockHashes)
+      if (result) {
+        return output
+      }
+      return false
+    }).filter(cell => !!cell) as Cell[]
     return cells
   }
 

--- a/packages/neuron-wallet/src/services/sync/queue.ts
+++ b/packages/neuron-wallet/src/services/sync/queue.ts
@@ -136,7 +136,7 @@ export default class Queue {
         const range = await this.rangeForCheck.getRange()
         const rangeFirstBlockHeader: BlockHeader = range[0]
         await this.currentBlockNumber.updateCurrent(BigInt(rangeFirstBlockHeader.number))
-        await this.rangeForCheck.clearRange()
+        this.rangeForCheck.clearRange()
         await TransactionPersistor.deleteWhenFork(rangeFirstBlockHeader.number)
         throw new Error(`chain forked: ${checkResult.type}`)
       } else if (checkResult.type === CheckResultType.BlockHeadersNotMatch) {


### PR DESCRIPTION
Local optimization for batch txs from and to the same address.

For each block, simply add a hash map to cache the output tx used by input.

This speeds up tx insert for our batch txs test (e.g. https://explorer.nervos.org/transaction/0x774a3e608afe267617d28db098dd9e36c93df9de75aedf10d8e5fcb55e38e774) from 2-5 txs/sec to 50~ txs/sec.

Note for a real world block that contains many unrelated transactions this optimization won't help. We still need to figure out how to tweak that. But for end user usage I don't think a wallet would have so many transactions.