### PR TITLE
fix(neuron-ui): hide the confirmations of pending txs

### DIFF
--- a/packages/neuron-ui/src/components/Overview/index.tsx
+++ b/packages/neuron-ui/src/components/Overview/index.tsx
@@ -123,7 +123,9 @@ const Overview = ({
         let { status } = item
         if (item.blockNumber !== undefined) {
           const confirmationCount =
-            item.blockNumber === undefined ? 0 : 1 + Math.max(+syncedBlockNumber, +tipBlockNumber) - +item.blockNumber
+            item.blockNumber === null || item.status === 'failed'
+              ? 0
+              : 1 + Math.max(+syncedBlockNumber, +tipBlockNumber) - +item.blockNumber
 
           if (status === 'success' && confirmationCount < CONFIRMATION_THRESHOLD) {
             status = 'pending'
@@ -147,7 +149,7 @@ const Overview = ({
           status,
           statusLabel: t(`overview.statusLabel.${status}`),
           value: item.value.replace(/^-/, ''),
-          confirmations: ['success', 'pending'].includes(item.status) ? confirmations : '',
+          confirmations,
           typeLabel: t(`overview.${typeLabel}`),
         }
       }),


### PR DESCRIPTION
Before this PR:
![image](https://user-images.githubusercontent.com/7271329/67761175-bf5e6000-fa7d-11e9-9ba6-4d09eed336f6.png)
After this PR
![image](https://user-images.githubusercontent.com/7271329/67761183-c2595080-fa7d-11e9-93b4-29180c2a362b.png)
