### PR TITLE
Ruby script to download a release binaries and calculate SHA256 checksums

### DIFF
--- a/scripts/release-checksums.rb
+++ b/scripts/release-checksums.rb
@@ -1,19 +1,23 @@
 #!/usr/bin/env ruby
 
+# curl and sha256sum are required to run this.
+
 tag = ARGV[0]
-puts "generate release checksums for #{tag}"
+puts "Generate release checksums for #{tag}, this could take a while..."
 
 windows_exe = "https://github.com/nervosnetwork/neuron/releases/download/#{tag}/Neuron-#{tag}-win-installer.exe"
 macos_zip = "https://github.com/nervosnetwork/neuron/releases/download/#{tag}/Neuron-#{tag}-mac.zip"
 macos_dmg = "https://github.com/nervosnetwork/neuron/releases/download/#{tag}/Neuron-#{tag}-mac.dmg"
 linux_appimage = "https://github.com/nervosnetwork/neuron/releases/download/#{tag}/Neuron-#{tag}-linux-x86_64.AppImage"
 
-# TODO: Download binaries and calculate checksums
+def get_sha256_checksum(url)
+  %x(curl -L -s #{url} | sha256sum).split(" ").first
+end
 
-windows_exe_sha256 = "{WINDOWS_EXE_SHA256}"
-macos_zip_sha256 =  "{MACOS_ZIP_SHA256}"
-macos_dmg_sha256 = "{MACOS_DMG_SHA256}"
-linux_appimage_sha256 = "{LINUX_APPIMAGE_SHA256}"
+windows_exe_sha256 = get_sha256_checksum(windows_exe)
+macos_zip_sha256 = get_sha256_checksum(macos_zip)
+macos_dmg_sha256 = get_sha256_checksum(macos_dmg)
+linux_appimage_sha256 = get_sha256_checksum(linux_appimage)
 
 checksums = %(
 ### Downloads

--- a/scripts/release-checksums.rb
+++ b/scripts/release-checksums.rb
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+
+tag = ARGV[0]
+puts "generate release checksums for #{tag}"
+
+windows_exe = "https://github.com/nervosnetwork/neuron/releases/download/#{tag}/Neuron-#{tag}-win-installer.exe"
+macos_zip = "https://github.com/nervosnetwork/neuron/releases/download/#{tag}/Neuron-#{tag}-mac.zip"
+macos_dmg = "https://github.com/nervosnetwork/neuron/releases/download/#{tag}/Neuron-#{tag}-mac.dmg"
+linux_appimage = "https://github.com/nervosnetwork/neuron/releases/download/#{tag}/Neuron-#{tag}-linux-x86_64.AppImage"
+
+# TODO: Download binaries and calculate checksums
+
+windows_exe_sha256 = "{WINDOWS_EXE_SHA256}"
+macos_zip_sha256 =  "{MACOS_ZIP_SHA256}"
+macos_dmg_sha256 = "{MACOS_DMG_SHA256}"
+linux_appimage_sha256 = "{LINUX_APPIMAGE_SHA256}"
+
+checksums = %(
+### Downloads
+
+OS | Arch | Package | SHA256 Checksum
+-- | -- | -- | --
+Windows | x64 | [exe](#{windows_exe}) | <code>#{windows_exe_sha256}</code>
+macOS | x64 | [zip](#{macos_zip}) | <code>#{macos_zip_sha256}</code>
+macOS | x64 | [DMG](#{macos_dmg}) | <code>#{macos_dmg_sha256}</code>
+Linux | x64 |  [AppImage](#{linux_appimage}) | <code>#{linux_appimage_sha256}</code>
+)
+
+puts checksums

--- a/scripts/release-checksums.rb
+++ b/scripts/release-checksums.rb
@@ -11,7 +11,7 @@ macos_dmg = "https://github.com/nervosnetwork/neuron/releases/download/#{tag}/Ne
 linux_appimage = "https://github.com/nervosnetwork/neuron/releases/download/#{tag}/Neuron-#{tag}-linux-x86_64.AppImage"
 
 def get_sha256_checksum(url)
-  %x(curl -L -s #{url} | sha256sum).split(" ").first
+  %x(curl -L #{url} | sha256sum).split(" ").first
 end
 
 windows_exe_sha256 = get_sha256_checksum(windows_exe)


### PR DESCRIPTION
and get SHA256 checksums

Ideally we could have this integrated to the CI publish task (that we don't need to download and digest), but not urgent to implement that for the time being.