### PR TITLE
feat: Shorter binary file names

### DIFF
--- a/packages/neuron-wallet/electron-builder.yml
+++ b/packages/neuron-wallet/electron-builder.yml
@@ -40,10 +40,11 @@ nsis:
 
 dmg:
   sign: false
+  artifactName: "${productName}-v${version}.${ext}"
 
 win:
   verifyUpdateCodeSignature: false
-  artifactName: "${productName}-v${version}-${os}-${arch}-installer.${ext}"
+  artifactName: "${productName}-v${version}-setup.${ext}"
   icon: assets/icons/icon.ico
   target:
     - target: nsis
@@ -64,7 +65,7 @@ mac:
     - zip
 
 linux:
-  artifactName: "${productName}-v${version}-${os}-${arch}.${ext}"
+  artifactName: "${productName}-v${version}-${arch}.${ext}"
   category: Finance
   icon: assets/icons/
   target:


### PR DESCRIPTION
Remove unnecessary part, e.g.:
* `linux` for AppImage
* `mac` for dmg
* `win` for exe
