### PR TITLE
feat(neuron-ui): use the same style of activity record on deposit rec…

### DIFF
--- a/packages/neuron-ui/src/components/CustomRows/daoRecordRow.module.scss
+++ b/packages/neuron-ui/src/components/CustomRows/daoRecordRow.module.scss
@@ -1,11 +1,13 @@
 .daoRecord {
   display: flex;
   flex-direction: column;
-  border: 1px solid #000;
   border-radius: 2px;
-  margin: 10px 0;
-  padding: 5px 15px;
+  margin: 15px 0;
+  border-right: 1px solid #eee;
   border-left: 5px solid green;
+  box-sizing: border-box;
+  padding: 5px 10px;
+  box-shadow: 0 1px 5px 1px rgba(0, 0, 0, 0.14);
 
   .primaryInfo,
   .secondaryInfo {


### PR DESCRIPTION
…ord.
![image](https://user-images.githubusercontent.com/7271329/68762236-c033ec00-0650-11ea-9c3b-0eada5cafff9.png)
