### PR TITLE
Mainnet network

### DIFF
--- a/packages/neuron-ui/package.json
+++ b/packages/neuron-ui/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "start": "react-app-rewired start",
     "lint": "eslint --fix --ext .tsx,.ts,.js src",
-    "test": "react-app-rewired test --env=jsdom --color --watchAll=false",
+    "test": "react-app-rewired test --env=jsdom --watchAll=false",
     "build": "react-app-rewired build",
     "clean": "rimraf build/*",
     "precommit": "lint-staged",

--- a/packages/neuron-ui/src/services/remote/app.ts
+++ b/packages/neuron-ui/src/services/remote/app.ts
@@ -1,13 +1,9 @@
 import { apiMethodWrapper } from './apiMethodWrapper'
 
-export const getNeuronWalletState = apiMethodWrapper<void>(controller => () => controller.loadInitData())
+export const getNeuronWalletState = apiMethodWrapper<void>(api => () => api.loadInitData())
 
-export const handleViewError = apiMethodWrapper<string>(controller => errorMessage =>
-  controller.handleViewError(errorMessage)
-)
-export const contextMenu = apiMethodWrapper<{ type: string; id: string }>(controller => params =>
-  controller.contextMenu(params)
-)
+export const handleViewError = apiMethodWrapper<string>(api => errorMessage => api.handleViewError(errorMessage))
+export const contextMenu = apiMethodWrapper<{ type: string; id: string }>(api => params => api.contextMenu(params))
 
 export default {
   getNeuronWalletState,

--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -21,8 +21,8 @@
     "start:dev": "yarn run build && electron .",
     "build": "ttsc && ncp ./src/startup/sync-block-task/index.html ./dist/startup/sync-block-task/index.html",
     "clean": "rimraf dist/*",
-    "test": "jest --color --runInBand",
-    "test:e2e": "jest --config jest.e2e.config.js --color",
+    "test": "jest --runInBand",
+    "test:e2e": "jest --config jest.e2e.config.js",
     "lint": "eslint --fix --ext .ts,.js src",
     "precommit": "lint-staged",
     "rebuild:nativemodules": "electron-builder install-app-deps"

--- a/packages/neuron-wallet/src/controllers/api.ts
+++ b/packages/neuron-wallet/src/controllers/api.ts
@@ -80,7 +80,7 @@ export default class ApiController {
       : []
 
     const initState = {
-      currentWallet,
+      currentWallet: currentWallet || null,
       wallets: wallets,
       currentNetworkID,
       networks,

--- a/packages/neuron-wallet/src/controllers/api.ts
+++ b/packages/neuron-wallet/src/controllers/api.ts
@@ -246,8 +246,8 @@ export default class ApiController {
   }
 
   @MapApiResponse
-  public static async createNetwork({ name, remote, type = NetworkType.Normal, chain = 'ckb' }: Network) {
-    return NetworksController.create({ name, remote, type, chain })
+  public static async createNetwork({ name, remote, type = NetworkType.Normal, genesisHash = '0x', chain = 'ckb' }: Network) {
+    return NetworksController.create({ name, remote, type, genesisHash, chain })
   }
 
   @MapApiResponse

--- a/packages/neuron-wallet/src/controllers/api.ts
+++ b/packages/neuron-wallet/src/controllers/api.ts
@@ -26,17 +26,17 @@ export default class ApiController {
   public static async loadInitData() {
     const walletsService = WalletsService.getInstance()
     const networksService = NetworksService.getInstance()
+
+    const currentWallet = walletsService.getCurrent()
+    const wallets = walletsService.getAll()
+
     const [
-      currentWallet = null,
-      wallets = [],
       currentNetworkID = '',
       networks = [],
       syncedBlockNumber = '0',
       connectionStatus = false,
       codeHash = '',
     ] = await Promise.all([
-      walletsService.getCurrent(),
-      walletsService.getAll(),
       networksService.getCurrentID(),
       networksService.getAll(),
 
@@ -48,18 +48,21 @@ export default class ApiController {
           return '0'
         })
         .catch(() => '0'),
+
       new Promise(resolve => {
         ConnectionStatusSubject.pipe(take(1)).subscribe(
-          status => {
-            resolve(status)
-          },
-          () => {
-            resolve(false)
-          },
+          status => { resolve(status) },
+          () => { resolve(false) },
+          () => { resolve(false) }
         )
       }),
+
       new Promise(resolve => {
-        SystemScriptSubject.pipe(take(1)).subscribe(({ codeHash: currentCodeHash }) => resolve(currentCodeHash))
+        SystemScriptSubject.pipe(take(1)).subscribe(
+          ({ codeHash: currentCodeHash }) => resolve(currentCodeHash),
+          () => { resolve('') },
+          () => { resolve('') }
+        )
       }),
     ])
 
@@ -78,7 +81,7 @@ export default class ApiController {
 
     const initState = {
       currentWallet,
-      wallets: [...wallets.map(({ name, id }) => ({ id, name }))],
+      wallets: wallets,
       currentNetworkID,
       networks,
       addresses,
@@ -268,9 +271,7 @@ export default class ApiController {
   // Transactions
 
   @MapApiResponse
-  public static async getTransactionList(
-    params: Controller.Params.TransactionsByKeywords
-  ) {
+  public static async getTransactionList(params: Controller.Params.TransactionsByKeywords) {
     return TransactionsController.getAllByKeywords(params)
   }
 

--- a/packages/neuron-wallet/src/controllers/transactions.ts
+++ b/packages/neuron-wallet/src/controllers/transactions.ts
@@ -31,13 +31,15 @@ export default class TransactionsController {
   ): Promise<Controller.Response<PaginationResult<Transaction> & Controller.Params.TransactionsByKeywords>> {
     const { pageNo = 1, pageSize = 15, keywords = '', walletID = '' } = params
 
-    const addresses = (await AddressesService.allAddressesByWalletId(walletID)).map(addr => addr.address)
+    const addresses = AddressesService.allAddressesByWalletId(walletID).map(addr => addr.address)
 
-    const transactions = await TransactionsService.getAllByAddresses({ pageNo, pageSize, addresses }, keywords.trim())
+    const transactions = await TransactionsService
+      .getAllByAddresses({ pageNo, pageSize, addresses }, keywords.trim())
+      .catch(() => ({
+        totalCount: 0,
+        items: []
+      }))
 
-    if (!transactions) {
-      throw new ServiceHasNoResponse('Transactions')
-    }
     return {
       status: ResponseCode.Success,
       result: {
@@ -64,7 +66,7 @@ export default class TransactionsController {
       if (!wallet) {
         throw new CurrentWalletNotSet()
       }
-      searchAddresses = (await AddressesService.allAddressesByWalletId(wallet.id)).map(addr => addr.address)
+      searchAddresses = AddressesService.allAddressesByWalletId(wallet.id).map(addr => addr.address)
     }
 
     const transactions = await TransactionsService.getAllByAddresses({ pageNo, pageSize, addresses: searchAddresses })

--- a/packages/neuron-wallet/src/env.ts
+++ b/packages/neuron-wallet/src/env.ts
@@ -1,7 +1,6 @@
 import { app as electronApp, remote } from 'electron'
 import os from 'os'
 import * as path from 'path'
-import { NetworkWithID } from 'types/network'
 
 const app = electronApp || (remote && remote.app) || {
   getPath(aPath: string): string {
@@ -35,10 +34,6 @@ interface ENV {
   fileBasePath: string
   mainURL: string
   remote: string
-  presetNetworks: {
-    current: 'testnet'
-    list: NetworkWithID[]
-  }
   isTestMode: boolean
 }
 const env: ENV = {
@@ -46,25 +41,6 @@ const env: ENV = {
   fileBasePath: path.resolve(app.getPath('userData'), fileBase),
   mainURL: isDevMode ? 'http://localhost:3000' : `file://${path.join(__dirname, '../dist/neuron-ui/index.html')}`,
   remote: 'http://localhost:8114',
-  presetNetworks: {
-    current: 'testnet',
-    list: [
-      {
-        id: 'testnet',
-        name: 'Testnet',
-        remote: 'http://localhost:8114',
-        type: 0,
-        chain: '',
-      },
-      {
-        id: 'local',
-        name: 'Local',
-        remote: 'http://localhost:8114',
-        type: 1,
-        chain: '',
-      },
-    ],
-  },
   isTestMode,
 }
 

--- a/packages/neuron-wallet/src/services/networks.ts
+++ b/packages/neuron-wallet/src/services/networks.ts
@@ -46,15 +46,19 @@ export default class NetworksService extends Store {
           currentNetworkList,
         })
         Promise.all(currentNetworkList.map(n => {
-          const core = new Core(n.remote)
-          return core.rpc
-            .getBlockchainInfo()
-            .then(info => info.chain)
-            .catch(() => '')
-            .then(chain => ({
+          if (n.type == NetworkType.Default) {
+            return n
+          } else {
+            const core = new Core(n.remote)
+            return Promise.all([
+              core.rpc.getBlockchainInfo(),
+              core.rpc.getBlockHash('0x0')
+            ]).then(([info, genesisHash]) => ({
               ...n,
-              chain,
+              chain: info.chain,
+              genesisHash
             }))
+          }
         })).then(networkList => {
           this.updateAll(networkList)
         }).catch((err: Error) => {

--- a/packages/neuron-wallet/src/services/networks.ts
+++ b/packages/neuron-wallet/src/services/networks.ts
@@ -4,15 +4,28 @@ import { BehaviorSubject } from 'rxjs'
 import { LackOfDefaultNetwork, DefaultNetworkUnremovable } from 'exceptions/network'
 
 import Store from 'models/store'
-import env from 'env'
 
 import { Validate, Required } from 'decorators'
 import { UsedName, NetworkNotFound, InvalidFormat } from 'exceptions'
 import { NetworkListSubject, CurrentNetworkIDSubject } from 'models/subjects/networks'
-import { NetworkID, NetworkName, NetworkRemote, NetworksKey, NetworkType, Network, NetworkWithID } from 'types/network'
+import { MAINNET_GENESIS_HASH, NetworkID, NetworkName, NetworkRemote, NetworksKey, NetworkType, Network, NetworkWithID } from 'types/network'
 import logger from 'utils/logger'
 
 export const networkSwitchSubject = new BehaviorSubject<undefined | NetworkWithID>(undefined)
+
+const presetNetworks: { selected: string, networks: NetworkWithID[] } = {
+  selected: 'mainnet',
+  networks: [
+    {
+      id: 'mainnet',
+      name: 'Mainnet',
+      remote: 'http://localhost:8114',
+      genesisHash: MAINNET_GENESIS_HASH,
+      type: NetworkType.Default,
+      chain: 'ckb',
+    }
+  ]
+}
 
 export default class NetworksService extends Store {
   private static instance: NetworksService
@@ -25,7 +38,7 @@ export default class NetworksService extends Store {
   }
 
   constructor() {
-    super('networks', 'index.json', JSON.stringify(env.presetNetworks))
+    super('networks', 'index.json', JSON.stringify(presetNetworks))
 
     this.getAll().then(currentNetworkList => {
       if (currentNetworkList) {
@@ -88,7 +101,7 @@ export default class NetworksService extends Store {
 
   public getAll = async () => {
     const list = await this.read<NetworkWithID[]>(NetworksKey.List)
-    return list || []
+    return list || presetNetworks.networks
   }
 
   @Validate
@@ -102,15 +115,11 @@ export default class NetworksService extends Store {
     if (!Array.isArray(networks)) {
       throw new InvalidFormat('Networks')
     }
-    await this.writeSync(NetworksKey.List, networks)
+    this.writeSync(NetworksKey.List, networks)
   }
 
   @Validate
-  public async create(
-    @Required name: NetworkName,
-    @Required remote: NetworkRemote,
-    type: NetworkType = NetworkType.Normal,
-  ) {
+  public async create(@Required name: NetworkName, @Required remote: NetworkRemote, type: NetworkType = NetworkType.Normal) {
     const list = await this.getAll()
     if (list.some(item => item.name === name)) {
       throw new UsedName('Network')
@@ -122,11 +131,15 @@ export default class NetworksService extends Store {
       .getBlockchainInfo()
       .then(info => info.chain)
       .catch(() => '')
+    const genesisHash = await core.rpc
+      .getBlockHash('0x0')
+      .catch(() => '0x')
 
     const newOne = {
       id: uuid(),
       name,
       remote,
+      genesisHash,
       type,
       chain,
     }
@@ -146,11 +159,17 @@ export default class NetworksService extends Store {
     Object.assign(network, options)
     if (!options.chain) {
       const core = new Core(network.remote)
+
       const chain = await core.rpc
         .getBlockchainInfo()
         .then(info => info.chain)
         .catch(() => '')
       network.chain = chain
+
+      const genesisHash = await core.rpc
+        .getBlockHash('0x0')
+        .catch(() => '0x')
+      network.genesisHash = genesisHash
     }
 
     this.updateAll(list)
@@ -183,6 +202,11 @@ export default class NetworksService extends Store {
     }
     this.writeSync(NetworksKey.Current, id)
 
+    // No need to update the default mainnet
+    if (network.type === NetworkType.Default) {
+      return
+    }
+
     const core = new Core(network.remote)
 
     const chain = await core.rpc
@@ -190,8 +214,12 @@ export default class NetworksService extends Store {
       .then(info => info.chain)
       .catch(() => '')
 
-    if (chain && chain !== network.chain) {
-      this.update(id, { chain })
+      const genesisHash = await core.rpc
+        .getBlockHash('0x0')
+        .catch(() => '0x')
+
+    if (chain && chain !== network.chain && genesisHash && genesisHash !== network.genesisHash) {
+      this.update(id, { chain, genesisHash })
     }
   }
 

--- a/packages/neuron-wallet/src/services/networks.ts
+++ b/packages/neuron-wallet/src/services/networks.ts
@@ -134,7 +134,7 @@ export default class NetworksService extends Store {
     const chain = await core.rpc
       .getBlockchainInfo()
       .then(info => info.chain)
-      .catch(() => '')
+      .catch(() => 'ckb_dev')
     const genesisHash = await core.rpc
       .getBlockHash('0x0')
       .catch(() => '0x')
@@ -167,7 +167,7 @@ export default class NetworksService extends Store {
       const chain = await core.rpc
         .getBlockchainInfo()
         .then(info => info.chain)
-        .catch(() => '')
+        .catch(() => 'ckb_dev')
       network.chain = chain
 
       const genesisHash = await core.rpc

--- a/packages/neuron-wallet/src/services/networks.ts
+++ b/packages/neuron-wallet/src/services/networks.ts
@@ -8,7 +8,7 @@ import Store from 'models/store'
 import { Validate, Required } from 'decorators'
 import { UsedName, NetworkNotFound, InvalidFormat } from 'exceptions'
 import { NetworkListSubject, CurrentNetworkIDSubject } from 'models/subjects/networks'
-import { MAINNET_GENESIS_HASH, NetworkID, NetworkName, NetworkRemote, NetworksKey, NetworkType, Network, NetworkWithID } from 'types/network'
+import { MAINNET_GENESIS_HASH, EMPTY_GENESIS_HASH, NetworkID, NetworkName, NetworkRemote, NetworksKey, NetworkType, Network, NetworkWithID } from 'types/network'
 import logger from 'utils/logger'
 
 export const networkSwitchSubject = new BehaviorSubject<undefined | NetworkWithID>(undefined)
@@ -137,7 +137,7 @@ export default class NetworksService extends Store {
       .catch(() => 'ckb_dev')
     const genesisHash = await core.rpc
       .getBlockHash('0x0')
-      .catch(() => '0x')
+      .catch(() => EMPTY_GENESIS_HASH)
 
     const newOne = {
       id: uuid(),
@@ -172,7 +172,7 @@ export default class NetworksService extends Store {
 
       const genesisHash = await core.rpc
         .getBlockHash('0x0')
-        .catch(() => '0x')
+        .catch(() => EMPTY_GENESIS_HASH)
       network.genesisHash = genesisHash
     }
 
@@ -220,7 +220,7 @@ export default class NetworksService extends Store {
 
       const genesisHash = await core.rpc
         .getBlockHash('0x0')
-        .catch(() => '0x')
+        .catch(() => EMPTY_GENESIS_HASH)
 
     if (chain && chain !== network.chain && genesisHash && genesisHash !== network.genesisHash) {
       this.update(id, { chain, genesisHash })

--- a/packages/neuron-wallet/src/startup/sync-block-task/create.ts
+++ b/packages/neuron-wallet/src/startup/sync-block-task/create.ts
@@ -29,7 +29,7 @@ networkSwitchSubject.subscribe(async (network: NetworkWithID | undefined) => {
     // TODO: only switch if genesisHash is different
 
     await InitDatabase.getInstance().stopAndWait()
-    const info = await InitDatabase.getInstance().init(network.remote)
+    const info = await InitDatabase.getInstance().init(network)
 
     DataUpdateSubject.next({
       dataType: 'transaction',

--- a/packages/neuron-wallet/src/types/network.ts
+++ b/packages/neuron-wallet/src/types/network.ts
@@ -1,22 +1,28 @@
 export type NetworkID = string
 export type NetworkName = string
 export type NetworkRemote = string
+export type NetworkGenesisHash = string
+
 export enum NetworksKey {
-  List = 'list',
-  Current = 'current',
+  List = 'networks',
+  Current = 'selected',
 }
 
 export enum NetworkType {
-  Default,
+  Default, // Preset mainnet node
   Normal,
 }
+
+export const MAINNET_GENESIS_HASH = "0x" // TODO: set this when mainnet launches!
 
 export interface Network {
   name: NetworkName
   remote: NetworkRemote
   type: NetworkType
+  genesisHash: NetworkGenesisHash
   chain: 'ckb' | 'ckb_testnet' | 'ckb_dev' | string // returned by rpc.getBlockchainInfo
 }
+
 export interface NetworkWithID extends Network {
   id: NetworkID
 }

--- a/packages/neuron-wallet/src/types/network.ts
+++ b/packages/neuron-wallet/src/types/network.ts
@@ -13,7 +13,8 @@ export enum NetworkType {
   Normal,
 }
 
-export const MAINNET_GENESIS_HASH = "0x" // TODO: set this when mainnet launches!
+export const MAINNET_GENESIS_HASH = "0xeeee" // TODO: set this when mainnet launches!
+export const EMPTY_GENESIS_HASH = "0x"
 
 export interface Network {
   name: NetworkName

--- a/packages/neuron-wallet/tests-e2e/tests/network.ts
+++ b/packages/neuron-wallet/tests-e2e/tests/network.ts
@@ -1,7 +1,5 @@
 import Application from '../application';
 
-// Start: Overview page
-// End: Overview page
 export default (app: Application) => {
   app.test('add network', async () => {
     const { client } = app.spectron
@@ -38,21 +36,21 @@ export default (app: Application) => {
     await app.waitUntilLoaded()
 
     // Check network name
-    const newNetworkItemElement = await app.element('//MAIN/DIV/DIV[3]/DIV/DIV/DIV/DIV/DIV[3]/DIV/LABEL/DIV')
-    expect(newNetworkItemElement).not.toBeNull()
-    const netowrkItemTitle = await client.elementIdAttribute(newNetworkItemElement.value.ELEMENT, 'title')
-    expect(netowrkItemTitle.value).toBe(`${newNodeName}: ${newNodeRpcUrl}`)
-    console.log(`netowrkItemTitle - ${netowrkItemTitle.value}`);
+    const title = `${newNodeName}: ${newNodeRpcUrl}`
+    const newNetworkItemElement = await app.element("//MAIN//LABEL/DIV[@title='" + title + "']")
+    expect(newNetworkItemElement.value).not.toBeNull()
+    console.log(`netowrkItemTitle - ${title}`);
   })
 
   app.test('edit network', async () => {
     const { client } = app.spectron
 
     // Get network id
-    const networkItemElement = await app.element('//MAIN/DIV/DIV[3]/DIV/DIV/DIV/DIV/DIV[3]/DIV/INPUT')
-    expect(networkItemElement.value).not.toBeNull()
-    const networkItemElementId = await client.elementIdAttribute(networkItemElement.value.ELEMENT, 'id')
-    const networkItemElementName = await client.elementIdAttribute(networkItemElement.value.ELEMENT, 'name')
+    const inputs = await app.elements("//MAIN//INPUT")
+    const networkItemElement = inputs.value[1]
+    expect(networkItemElement).not.toBeNull()
+    const networkItemElementId = await client.elementIdAttribute(networkItemElement.ELEMENT, 'id')
+    const networkItemElementName = await client.elementIdAttribute(networkItemElement.ELEMENT, 'name')
     const networkId = networkItemElementId.value.slice(networkItemElementName.value.length + 1)
     console.log(`networkId = ${networkId}`);
 
@@ -79,26 +77,26 @@ export default (app: Application) => {
     await app.waitUntilLoaded()
 
     // Check network name
-    const newNetworkItemElement = await app.element('//MAIN/DIV/DIV[3]/DIV/DIV/DIV/DIV/DIV[3]/DIV/LABEL/DIV')
-    expect(newNetworkItemElement).not.toBeNull()
-    const netowrkItemTitle = await client.elementIdAttribute(newNetworkItemElement.value.ELEMENT, 'title')
-    expect(netowrkItemTitle.value).toBe(`${newName}: ${newRpcUrl}`)
-    console.log(`netowrkItemTitle - ${netowrkItemTitle.value}`);
+    const title = `${newName}: ${newRpcUrl}`
+    const newNetworkItemElement = await app.element("//MAIN//LABEL/DIV[@title='" + title + "']")
+    expect(newNetworkItemElement.value).not.toBeNull()
+    console.log(`netowrkItemTitle - ${title}`);
   })
 
   app.test('switch network', async () => {
     const { client } = app.spectron
 
     // Get target network name
-    const targetNetworkNameElement = await app.element('//MAIN/DIV/DIV[3]/DIV/DIV/DIV/DIV/DIV[3]/DIV/LABEL/DIV/SPAN')
+    const labels = await app.elements('//MAIN//LABEL//SPAN')
+    const targetNetworkNameElement = labels.value[3]
     expect(targetNetworkNameElement).not.toBeNull()
-    const targetNetowrkName = await client.elementIdText(targetNetworkNameElement.value.ELEMENT)
+    const targetNetowrkName = await client.elementIdText(targetNetworkNameElement.ELEMENT)
     console.log(`targetNetowrkName = ${targetNetowrkName.value}`);
 
     // switch network
-    const targetNetworkElement = await app.element('//MAIN/DIV/DIV[3]/DIV/DIV/DIV/DIV/DIV[3]')
-    expect(targetNetworkElement.value).not.toBeNull()
-    await client.elementIdClick(targetNetworkElement.value.ELEMENT)
+    const inputs = await app.elements("//MAIN//INPUT")
+    const targetNetworkElement = inputs.value[1].ELEMENT
+    await client.elementIdClick(targetNetworkElement)
     await app.waitUntilLoaded()
 
     // back
@@ -129,16 +127,18 @@ export default (app: Application) => {
     await app.waitUntilLoaded()
 
     // Get network name
-    const networkNameElement = await app.element('//MAIN/DIV/DIV[3]/DIV/DIV/DIV/DIV/DIV[3]/DIV/LABEL/DIV/SPAN')
+    const labels = await app.elements('//MAIN//LABEL//SPAN')
+    const networkNameElement = labels.value[3]
     expect(networkNameElement).not.toBeNull()
-    const netowrkName = await client.elementIdText(networkNameElement.value.ELEMENT)
+    const netowrkName = await client.elementIdText(networkNameElement.ELEMENT)
     console.log(`netowrkName = ${netowrkName.value}`);
 
     // Get network id
-    const networkItemElement = await app.element('//MAIN/DIV/DIV[3]/DIV/DIV/DIV/DIV/DIV[3]/DIV/INPUT')
-    expect(networkItemElement.value).not.toBeNull()
-    const networkItemElementId = await client.elementIdAttribute(networkItemElement.value.ELEMENT, 'id')
-    const networkItemElementName = await client.elementIdAttribute(networkItemElement.value.ELEMENT, 'name')
+    const inputs = await app.elements("//MAIN//INPUT")
+    const networkItemElement = inputs.value[1].ELEMENT
+    expect(networkItemElement).not.toBeNull()
+    const networkItemElementId = await client.elementIdAttribute(networkItemElement, 'id')
+    const networkItemElementName = await client.elementIdAttribute(networkItemElement, 'name')
     const networkId = networkItemElementId.value.slice(networkItemElementName.value.length + 1)
     console.log(`networkId = ${networkId}`);
 

--- a/packages/neuron-wallet/tests-e2e/tests/sendTransaction.ts
+++ b/packages/neuron-wallet/tests-e2e/tests/sendTransaction.ts
@@ -67,7 +67,7 @@ export default (app: Application) => {
   })
 
   describe('Test amount field boundary validation', () => {
-    const validAddress = 'ckt1qyq0cwanfaf2t2cwmuxd8ujv2ww6kjv7n53sfwv2l0'
+    const validAddress = 'ckb1qyqrdsefa43s6m882pcj53m4gdnj4k440axqdt9rtd'
     app.test('Amount 60.99999999 is too small, 61 CKB is required', async () => {
       const smallAmount = '60.99999999'
       const { client } = app.spectron
@@ -95,7 +95,7 @@ export default (app: Application) => {
   })
 
   describe('Amount is not enough', () => {
-    const validAddress = 'ckt1qyq0cwanfaf2t2cwmuxd8ujv2ww6kjv7n53sfwv2l0'
+    const validAddress = 'ckb1qyqrdsefa43s6m882pcj53m4gdnj4k440axqdt9rtd'
     const validAmount = '61'
     app.test('Amount is not enough', async () => {
       const { client } = app.spectron

--- a/packages/neuron-wallet/tests/services/networks.test.ts
+++ b/packages/neuron-wallet/tests/services/networks.test.ts
@@ -15,7 +15,7 @@ describe(`Unit tests of networks service`, () => {
     type: 0,
     genesisHash: '0x',
     id: '',
-    chain: '',
+    chain: 'ckb_dev',
   }
 
   const newNetworkWithDefaultTypeOf1 = {

--- a/packages/neuron-wallet/tests/services/networks.test.ts
+++ b/packages/neuron-wallet/tests/services/networks.test.ts
@@ -13,7 +13,7 @@ describe(`Unit tests of networks service`, () => {
     name: `new network`,
     remote: `http://localhost:8114`,
     type: 0,
-    genesisHash: '',
+    genesisHash: '0x',
     id: '',
     chain: '',
   }
@@ -121,7 +121,7 @@ describe(`Unit tests of networks service`, () => {
       const prevCurrentID = await service.getCurrentID()
       const prevNetworks = await service.getAll()
       expect(prevCurrentID).toBe(network.id)
-      expect(prevNetworks.map(n => n.id)).toEqual(['Mainnet', network.id])
+      expect(prevNetworks.map(n => n.id)).toEqual(['mainnet', network.id])
       await service.delete(prevCurrentID || '')
       const currentNetworks = await service.getAll()
       expect(currentNetworks.map(n => n.id)).toEqual(prevNetworks.filter(n => n.id !== prevCurrentID).map(n => n.id))

--- a/packages/neuron-wallet/tests/services/networks.test.ts
+++ b/packages/neuron-wallet/tests/services/networks.test.ts
@@ -1,6 +1,5 @@
 import NetworksService from '../../src/services/networks'
 import { NetworkWithID } from '../../src/types/network'
-import env from '../../src/env'
 import i18n from '../../src/utils/i18n'
 
 const ERROR_MESSAGE = {
@@ -9,23 +8,19 @@ const ERROR_MESSAGE = {
   NETWORK_ID_NOT_FOUND: `messages.network-not-found`,
 }
 
-const {
-  presetNetworks: { current, list },
-} = env
-const [testnetNetwork, localNetwork] = list
-
 describe(`Unit tests of networks service`, () => {
   const newNetwork: NetworkWithID = {
     name: `new network`,
-    remote: `http://new-network.localhost.com`,
+    remote: `http://localhost:8114`,
     type: 0,
+    genesisHash: '',
     id: '',
     chain: '',
   }
 
   const newNetworkWithDefaultTypeOf1 = {
     name: `new network with the default type of 1`,
-    remote: `http://test.localhost.com`,
+    remote: `http://localhost:8114`,
     id: '',
   }
 
@@ -52,7 +47,8 @@ describe(`Unit tests of networks service`, () => {
 
     it(`has preset networks`, async () => {
       const networks = await service.getAll()
-      expect(networks).toEqual(list)
+      expect(networks.length).toBe(1)
+      expect(networks[0].id).toEqual('mainnet')
     })
 
     it(`get the default network`, async () => {
@@ -60,20 +56,9 @@ describe(`Unit tests of networks service`, () => {
       expect(network && network.type).toBe(0)
     })
 
-    it(`testnet should be type of default network`, async () => {
-      const defaultNetwork = await service.defaultOne()
-      expect(defaultNetwork).toEqual(testnetNetwork)
-    })
-
-    it(`testnet should be the current one by default`, async () => {
+    it(`mainnet should be the current one by default`, async () => {
       const currentNetworkID = await service.getCurrentID()
-      expect(currentNetworkID).toBe(current)
-      expect(currentNetworkID).toBe(testnetNetwork.id)
-    })
-
-    it(`get network by id ${current}`, async () => {
-      const currentNetwork = await service.get(current)
-      expect(currentNetwork).toEqual(list.find(network => network.id === current))
+      expect(currentNetworkID).toBe('mainnet')
     })
 
     it(`getting a non-exsiting network should return null`, async () => {
@@ -94,35 +79,31 @@ describe(`Unit tests of networks service`, () => {
       expect(res.type).toBe(1)
     })
 
-    it(`update the local networks's name`, async () => {
-      const name = `new local network name`
-      await service.update(localNetwork.id, { name })
-      const network = await service.get(localNetwork.id)
-      expect(network && network.name).toBe(name)
+    it(`update the networks's name`, async () => {
+      const network = await service.create(newNetworkWithDefaultTypeOf1.name, newNetworkWithDefaultTypeOf1.remote)
+      const name = `new network name`
+      await service.update(network.id, { name })
+      const updated = await service.get(network.id)
+      expect(updated && updated.name).toBe(name)
     })
 
-    it(`update the local network address`, async () => {
-      const addr = `http://updated-address.com`
-      await service.update(localNetwork.id, { remote: addr })
-      const network = await service.get(localNetwork.id)
-      expect(network && network.remote).toBe(addr)
+    it(`update the network' address`, async () => {
+      const network = await service.create(newNetworkWithDefaultTypeOf1.name, newNetworkWithDefaultTypeOf1.remote)
+      const address = `http://localhost:8115`
+      await service.update(network.id, { remote: address })
+      const updated = await service.get(network.id)
+      expect(updated && updated.remote).toBe(address)
     })
 
-    it(`update the local network type to 1`, async () => {
-      const type = 1
-      await service.update(localNetwork.id, { type })
-      const network = await service.get(localNetwork.id)
-      expect(network && network.type).toBe(type)
-    })
-
-    it(`set the local network to be the current one`, async () => {
-      await service.activate(localNetwork.id)
+    it(`set the network to be the current one`, async () => {
+      const network = await service.create(newNetworkWithDefaultTypeOf1.name, newNetworkWithDefaultTypeOf1.remote)
+      await service.activate(network.id)
       const currentNetworkID = await service.getCurrentID()
-      expect(currentNetworkID).toBe(localNetwork.id)
+      expect(currentNetworkID).toBe(network.id)
     })
 
     it(`delete an inactive network`, async () => {
-      const inactiveNetwork = localNetwork
+      const inactiveNetwork = await service.create(newNetworkWithDefaultTypeOf1.name, newNetworkWithDefaultTypeOf1.remote)
       const prevCurrentID = (await service.getCurrentID()) || ''
       const prevNetworks = await service.getAll()
       await service.delete(inactiveNetwork.id)
@@ -134,12 +115,13 @@ describe(`Unit tests of networks service`, () => {
       expect(currentID).toBe(prevCurrentID)
     })
 
-    it(`activate the local network and delete it, the current networks should switch to the testnet network`, async () => {
-      await service.activate(localNetwork.id)
+    it(`activate a network and delete it, the current networks should switch to the default network`, async () => {
+      const network = await service.create(newNetworkWithDefaultTypeOf1.name, newNetworkWithDefaultTypeOf1.remote)
+      await service.activate(network.id)
       const prevCurrentID = await service.getCurrentID()
       const prevNetworks = await service.getAll()
-      expect(prevCurrentID).toBe(localNetwork.id)
-      expect(prevNetworks.map(n => n.id)).toEqual(list.map(n => n.id))
+      expect(prevCurrentID).toBe(network.id)
+      expect(prevNetworks.map(n => n.id)).toEqual(['Mainnet', network.id])
       await service.delete(prevCurrentID || '')
       const currentNetworks = await service.getAll()
       expect(currentNetworks.map(n => n.id)).toEqual(prevNetworks.filter(n => n.id !== prevCurrentID).map(n => n.id))
@@ -148,16 +130,16 @@ describe(`Unit tests of networks service`, () => {
           service.getCurrentID().then(cID => resolve(cID))
         }, 500)
       })
-      expect(currentID).toBe(testnetNetwork.id)
+      expect(currentID).toBe('mainnet')
     })
 
     it(`reset the netowrks`, async () => {
       await service.create(newNetwork.name, newNetwork.remote)
       const newNetworkList = await service.getAll()
-      expect(newNetworkList.length).toBe(list.length + 1)
+      expect(newNetworkList.length).toBe(2)
       service.clear()
       const networks = await service.getAll()
-      expect(networks.length).toBe(list.length)
+      expect(networks.length).toBe(1)
     })
   })
 
@@ -192,8 +174,8 @@ describe(`Unit tests of networks service`, () => {
   })
 
   describe(`validation on network existence`, () => {
-    it(`create network with existing name of ${list[0].name}`, () => {
-      expect(service.create(list[0].name, list[0].remote)).rejects.toThrowError(i18n.t(ERROR_MESSAGE.NAME_USED))
+    it(`create network with existing name of Mainnet`, () => {
+      expect(service.create('Mainnet', 'http://localhost:8114')).rejects.toThrowError(i18n.t(ERROR_MESSAGE.NAME_USED))
     })
 
     it(`update network which is not existing`, () => {


### PR DESCRIPTION
* Always return data when requesting `initData`
* `Network` now contains genesis hash
* Default mainnet network will have hardcoded genesis hash
* Sync database initialization uses `Network` instead of network URL