### PR TITLE
fix: Genesis block should be scanned when next scan range

### DIFF
--- a/packages/neuron-wallet/src/services/sync/queue.ts
+++ b/packages/neuron-wallet/src/services/sync/queue.ts
@@ -57,7 +57,12 @@ export default class Queue {
         this.inProcess = true
 
         if (this.lockHashes.length !== 0) {
-          const current: bigint = await this.currentBlockNumber.getCurrent()
+          let current: bigint = await this.currentBlockNumber.getCurrent()
+          if (current === BigInt(0)) {
+            // If it scans from genesis block but current block number was already set to 0,
+            // set it to -1 to make sure `startNumber` would be set to 0.
+            current = BigInt(-1)
+          }
           const startNumber: bigint = current + BigInt(1)
           const endNumber: bigint = current + BigInt(this.fetchSize)
           const realEndNumber: bigint = endNumber < this.endBlockNumber ? endNumber : this.endBlockNumber


### PR DESCRIPTION
starts from block #1


This bug is very interesting.

The block `queue` scans a window of blocks in batch. It remembers the last scanned block `N`, and starts from `N + 1` for next round.

`N` was initialized as `-1` then the first round would start from genesis block.

But initially it also reads another DB saved number representing last block number. When Neuron launches without any wallets, that number will be zero and persisted.

Then when a wallet gets imported the queue scans from `1`, not genesis block!

Yet to see if this guard fixes completely. It seems too difficult to change the scan range and remove the `N + 1` operation, though.