### PR TITLE
fix: only resetEndBlockNumber if number > 0

### DIFF
--- a/packages/neuron-wallet/src/services/sync/block-listener.ts
+++ b/packages/neuron-wallet/src/services/sync/block-listener.ts
@@ -123,7 +123,9 @@ export default class BlockListener {
     const endBlockNumber: string = this.tipBlockNumber.toString()
 
     if (this.queue) {
-      this.queue.resetEndBlockNumber(endBlockNumber)
+      if (this.tipBlockNumber > BigInt(0)) {
+        this.queue.resetEndBlockNumber(endBlockNumber)
+      }
     } else {
       const startBlockNumber: string = await this.getStartBlockNumber()
       this.queue = new Queue(


### PR DESCRIPTION
Sometimes when switch network , the subject will send a 0 number, and sync will stopped until tip number updated.