### PR TITLE
fix: Fix the problem that balance not right if switch network from de…

### DIFF
--- a/packages/neuron-wallet/src/models/subjects/wallet-created-subject.ts
+++ b/packages/neuron-wallet/src/models/subjects/wallet-created-subject.ts
@@ -1,13 +1,13 @@
-import { ReplaySubject } from 'rxjs'
+import { Subject } from 'rxjs'
 
 export class WalletCreatedSubject {
-  static subject = new ReplaySubject<string>(1)
+  static subject = new Subject<string>()
 
   static getSubject() {
     return this.subject
   }
 
-  static setSubject(subject: ReplaySubject<string>) {
+  static setSubject(subject: Subject<string>) {
     this.subject = subject
   }
 }


### PR DESCRIPTION
…fault network

Change WalletCreatedSubject from ReplaySubject to Subject, when switch network from default network, WalletCreatedSubject will start subscribe and replay the old created event which happend in default network, so two queue will started and balance will be incorrect