### PR TITLE
Move network notifications sending out of NetworkService constructor

### DIFF
--- a/packages/neuron-wallet/src/main.ts
+++ b/packages/neuron-wallet/src/main.ts
@@ -1,6 +1,7 @@
 import { app } from 'electron'
 
 import WalletService from 'services/wallets'
+import NetworksService from 'services/networks'
 import NodeController from 'controllers/node'
 import SyncController from 'controllers/sync'
 import AppController from 'controllers/app'
@@ -12,6 +13,7 @@ const appController = new AppController()
 app.on('ready', async () => {
   changeLanguage(app.getLocale())
 
+  NetworksService.getInstance().notifyAll()
   WalletService.getInstance().generateAddressesIfNecessary()
   if (!env.isTestMode) {
     await NodeController.startNode()

--- a/packages/neuron-wallet/src/services/networks.ts
+++ b/packages/neuron-wallet/src/services/networks.ts
@@ -39,23 +39,6 @@ export default class NetworksService extends Store {
   constructor() {
     super('networks', 'index.json', JSON.stringify(presetNetworks))
 
-    const currentNetworkList = this.getAll()
-    if (isMainProcess) {
-      NetworkListSubject.next({ currentNetworkList })
-    }
-
-    const currentNetwork = this.getCurrent()
-    if (currentNetwork) {
-      if (currentNetwork.type !== NetworkType.Default) {
-        this.update(currentNetwork.id, {}) // Update to trigger chain/genesis hash refresh
-      }
-
-      if (isMainProcess) {
-        CurrentNetworkIDSubject.next({ currentNetworkID: currentNetwork.id })
-        NetworkSwitchSubject.getSubject().next(currentNetwork)
-      }
-    }
-
     this.on(NetworksKey.List, async (_, currentNetworkList: NetworkWithID[] = []) => {
       if (isMainProcess) {
         NetworkListSubject.next({ currentNetworkList })
@@ -83,6 +66,25 @@ export default class NetworksService extends Store {
         NetworkSwitchSubject.getSubject().next(currentNetwork)
       }
     })
+  }
+
+  public notifyAll = () => {
+    const currentNetworkList = this.getAll()
+    if (isMainProcess) {
+      NetworkListSubject.next({ currentNetworkList })
+    }
+
+    const currentNetwork = this.getCurrent()
+    if (currentNetwork) {
+      if (currentNetwork.type !== NetworkType.Default) {
+        this.update(currentNetwork.id, {}) // Update to trigger chain/genesis hash refresh
+      }
+
+      if (isMainProcess) {
+        CurrentNetworkIDSubject.next({ currentNetworkID: currentNetwork.id })
+        NetworkSwitchSubject.getSubject().next(currentNetwork)
+      }
+    }
   }
 
   public getAll = () => {

--- a/packages/neuron-wallet/src/services/node.ts
+++ b/packages/neuron-wallet/src/services/node.ts
@@ -30,7 +30,7 @@ class NodeService {
     this.start()
     this.syncConnectionStatus()
     CurrentNetworkIDSubject.subscribe(async ({ currentNetworkID }) => {
-      const currentNetwork = await NetworksService.getInstance().get(currentNetworkID)
+      const currentNetwork = NetworksService.getInstance().get(currentNetworkID)
       if (currentNetwork) {
         this.setNetwork(currentNetwork.remote)
       }


### PR DESCRIPTION
This fixes the maximum call stack size exceeded issue on launch.
When the app starts many parts call NetworkService.get/getAll, at which time
NetworkService get initialized and send notifications, which in turn makes
these subscribers call get/getAll again.

On Windows this has made the app unable to launch.