### PR TITLE
[ᚬrc/v0.26.0] fix: Sending all transaction should be updated on price changes

### DIFF
--- a/packages/neuron-ui/src/components/Send/hooks.ts
+++ b/packages/neuron-ui/src/components/Send/hooks.ts
@@ -291,7 +291,7 @@ export const useInitialize = (
     if (isSendMax) {
       updateSendingAllTransaction()
     }
-  }, [isSendMax, updateSendingAllTransaction])
+  }, [isSendMax, price])
 
   useEffect(() => {
     clear(dispatch)

--- a/packages/neuron-ui/src/components/Send/hooks.ts
+++ b/packages/neuron-ui/src/components/Send/hooks.ts
@@ -5,7 +5,7 @@ import { generateTx, generateSendingAllTx } from 'services/remote/wallets'
 
 import { outputsToTotalAmount, CKBToShannonFormatter, shannonToCKBFormatter } from 'utils/formatters'
 import { verifyAddress, verifyAmount, verifyAmountRange, verifyTransactionOutputs } from 'utils/validators'
-import { ErrorCode, Price, MAX_DECIMAL_DIGITS } from 'utils/const'
+import { ErrorCode, MAX_DECIMAL_DIGITS } from 'utils/const'
 import calculateFee from 'utils/calculateFee'
 
 import { TransactionOutput } from '.'
@@ -233,6 +233,7 @@ export const useInitialize = (
   walletID: string,
   items: TransactionOutput[],
   generatedTx: any | null,
+  price: string,
   sending: boolean,
   dispatch: React.Dispatch<any>,
   t: any
@@ -257,40 +258,40 @@ export const useInitialize = (
   const onDescriptionChange = useSendDescriptionChange(dispatch)
   const onSubmit = useOnSubmit(items, dispatch)
   const onClear = useClear(dispatch)
+
+  const updateSendingAllTransaction = useCallback(() => {
+    updateTransactionWith(generateSendingAllTx)({
+      walletID,
+      items,
+      price,
+      setTotalAmount,
+      setErrorMessage,
+      updateTransactionOutput,
+      dispatch,
+    }).then(tx => {
+      if (!tx) {
+        setIsSendMax(false)
+      }
+    })
+  }, [walletID, updateTransactionOutput, price, items, dispatch])
+
   const onSendMaxClick = useCallback(() => {
     if (!isSendMax) {
       setIsSendMax(true)
-      updateTransactionWith(generateSendingAllTx)({
-        walletID,
-        items,
-        price: Price.Immediately,
-        setTotalAmount,
-        setErrorMessage,
-        updateTransactionOutput,
-        dispatch,
-      }).then(tx => {
-        if (!tx) {
-          setIsSendMax(false)
-        }
-      })
-
-      updateTransactionPrice(undefined as any, Price.Immediately)
+      updateSendingAllTransaction()
     } else {
       setIsSendMax(false)
       updateTransactionOutput('amount')(outputs.length - 1)('')
       const total = outputsToTotalAmount(items.filter(item => item.amount))
       setTotalAmount(total)
     }
-  }, [
-    setIsSendMax,
-    isSendMax,
-    outputs.length,
-    updateTransactionOutput,
-    updateTransactionPrice,
-    dispatch,
-    items,
-    walletID,
-  ])
+  }, [updateSendingAllTransaction, setIsSendMax, isSendMax, outputs.length, updateTransactionOutput, items])
+
+  useEffect(() => {
+    if (isSendMax) {
+      updateSendingAllTransaction()
+    }
+  }, [isSendMax, updateSendingAllTransaction])
 
   useEffect(() => {
     clear(dispatch)

--- a/packages/neuron-ui/src/components/Send/index.tsx
+++ b/packages/neuron-ui/src/components/Send/index.tsx
@@ -246,7 +246,7 @@ const Send = ({
       </Stack>
 
       <Stack horizontal horizontalAlign="end" tokens={{ childrenGap: 10 }}>
-        <DefaultButton type="reset" onClick={onClear}>
+        <DefaultButton type="reset" onClick={onClear} disabled={isSendMax}>
           {t('send.clear')}
         </DefaultButton>
         {sending ? (

--- a/packages/neuron-ui/src/components/Send/index.tsx
+++ b/packages/neuron-ui/src/components/Send/index.tsx
@@ -62,7 +62,7 @@ const Send = ({
     setErrorMessage,
     isSendMax,
     onSendMaxClick,
-  } = useInitialize(walletID, send.outputs, send.generatedTx, sending, dispatch, t)
+  } = useInitialize(walletID, send.outputs, send.generatedTx, send.price, sending, dispatch, t)
   useOnTransactionChange(walletID, outputs, send.price, dispatch, isSendMax, setTotalAmount, setErrorMessage)
   const leftStackWidth = '70%'
   const labelWidth = '140px'


### PR DESCRIPTION
Update the sending-all transaction when the price is changed.