### PR TITLE
fix: Only integer should be accepted on inputting price.

### DIFF
--- a/packages/neuron-ui/src/components/Send/hooks.ts
+++ b/packages/neuron-ui/src/components/Send/hooks.ts
@@ -198,7 +198,7 @@ const useUpdateTransactionPrice = (dispatch: StateDispatch) =>
   useCallback(
     (_e: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value?: string) => {
       if (undefined !== value) {
-        const price = value.replace(/[^\d]/g, '')
+        const price = value.split('.')[0].replace(/[^\d]/g, '')
         dispatch({
           type: AppActions.UpdateSendPrice,
           payload: price.replace(/,/g, ''),


### PR DESCRIPTION
`1,789` will be used on pasting `1,789.35`