### PR TITLE
feat: Fill the transaction list in the history view

### DIFF
--- a/packages/neuron-ui/src/components/History/history.module.scss
+++ b/packages/neuron-ui/src/components/History/history.module.scss
@@ -1,0 +1,10 @@
+.history {
+  min-height: calc(100vh - 100px);
+
+  .pagination {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    justify-content: flex-end
+  }
+}

--- a/packages/neuron-ui/src/components/History/index.tsx
+++ b/packages/neuron-ui/src/components/History/index.tsx
@@ -10,6 +10,7 @@ import { StateWithDispatch } from 'states/stateProvider/reducer'
 import { Routes, MAINNET_TAG } from 'utils/const'
 
 import { useSearch } from './hooks'
+import * as styles from './history.module.scss'
 
 const History = ({
   app: {
@@ -47,7 +48,7 @@ const History = ({
 
   const List = useMemo(() => {
     return (
-      <Stack>
+      <Stack className={styles.history}>
         <Stack horizontal horizontalAlign="end" tokens={{ childrenGap: 15 }}>
           <SearchBox
             value={keywords}
@@ -66,26 +67,28 @@ const History = ({
           isMainnet={isMainnet}
           dispatch={dispatch}
         />
-        <Pagination
-          selectedPageIndex={pageNo - 1}
-          pageCount={Math.ceil(totalCount / pageSize)}
-          itemsPerPage={pageSize}
-          totalItemCount={totalCount}
-          previousPageAriaLabel={t('pagination.previous-page')}
-          nextPageAriaLabel={t('pagination.next-page')}
-          firstPageAriaLabel={t('pagination.first-page')}
-          lastPageAriaLabel={t('pagination.last-page')}
-          pageAriaLabel={t('pagination.page')}
-          selectedAriaLabel={t('pagination.selected')}
-          firstPageIconProps={{ iconName: 'FirstPage' }}
-          previousPageIconProps={{ iconName: 'PrevPage' }}
-          nextPageIconProps={{ iconName: 'NextPage' }}
-          lastPageIconProps={{ iconName: 'LastPage' }}
-          format="buttons"
-          onPageChange={(idx: number) => {
-            history.push(`${Routes.History}?pageNo=${idx + 1}&keywords=${keywords}`)
-          }}
-        />
+        <div className={styles.pagination}>
+          <Pagination
+            selectedPageIndex={pageNo - 1}
+            pageCount={Math.ceil(totalCount / pageSize)}
+            itemsPerPage={pageSize}
+            totalItemCount={totalCount}
+            previousPageAriaLabel={t('pagination.previous-page')}
+            nextPageAriaLabel={t('pagination.next-page')}
+            firstPageAriaLabel={t('pagination.first-page')}
+            lastPageAriaLabel={t('pagination.last-page')}
+            pageAriaLabel={t('pagination.page')}
+            selectedAriaLabel={t('pagination.selected')}
+            firstPageIconProps={{ iconName: 'FirstPage' }}
+            previousPageIconProps={{ iconName: 'PrevPage' }}
+            nextPageIconProps={{ iconName: 'NextPage' }}
+            lastPageIconProps={{ iconName: 'LastPage' }}
+            format="buttons"
+            onPageChange={(idx: number) => {
+              history.push(`${Routes.History}?pageNo=${idx + 1}&keywords=${keywords}`)
+            }}
+          />
+        </div>
       </Stack>
     )
   }, [


### PR DESCRIPTION
Before this PR
![image](https://user-images.githubusercontent.com/7271329/70594163-9a334480-1c1a-11ea-98f2-6653445f3259.png)
After this PR
![image](https://user-images.githubusercontent.com/7271329/70594166-9ef7f880-1c1a-11ea-9f74-cb6a7173f1e5.png)
![image](https://user-images.githubusercontent.com/7271329/70595262-e59b2200-1c1d-11ea-8a7a-b02e2db80193.png)
