### PR TITLE
fix: Fix the dismission of dialog by escape

### DIFF
--- a/packages/neuron-ui/src/components/CompensationPeriodDialog/index.tsx
+++ b/packages/neuron-ui/src/components/CompensationPeriodDialog/index.tsx
@@ -18,7 +18,7 @@ interface CompensationPeriodDialogProps {
 const CompensationPeriodDialog = ({ onDismiss, compensationPeriod }: CompensationPeriodDialogProps) => {
   const [t] = useTranslation()
   const dialogRef = useRef<HTMLDialogElement | null>(null)
-  useDialog({ show: compensationPeriod, dialogRef })
+  useDialog({ show: compensationPeriod, dialogRef, onClose: onDismiss })
 
   let pastEpochs = 0
   if (compensationPeriod) {

--- a/packages/neuron-ui/src/components/DepositDialog/index.tsx
+++ b/packages/neuron-ui/src/components/DepositDialog/index.tsx
@@ -39,7 +39,7 @@ const DepositDialog = ({
 }: DepositDialogProps) => {
   const [t] = useTranslation()
   const dialogRef = useRef<HTMLDialogElement | null>(null)
-  useDialog({ show, dialogRef })
+  useDialog({ show, dialogRef, onClose: onDismiss })
 
   const rfcLink = useMemo(
     () => (

--- a/packages/neuron-ui/src/components/NervosDAO/index.tsx
+++ b/packages/neuron-ui/src/components/NervosDAO/index.tsx
@@ -296,6 +296,6 @@ const NervosDAO = ({
   )
 }
 
-NervosDAO.displayName = 'NervosDAOao'
+NervosDAO.displayName = 'NervosDAO'
 
 export default NervosDAO

--- a/packages/neuron-ui/src/components/PasswordRequest/index.tsx
+++ b/packages/neuron-ui/src/components/PasswordRequest/index.tsx
@@ -20,14 +20,14 @@ const PasswordRequest = ({
 }: React.PropsWithoutRef<StateWithDispatch & RouteComponentProps>) => {
   const [t] = useTranslation()
   const dialogRef = useRef<HTMLDialogElement | null>(null)
-  useDialog({ show: actionType, dialogRef })
-
-  const wallet = useMemo(() => wallets.find(w => w.id === walletID), [walletID, wallets])
   const onDismiss = useCallback(() => {
     dispatch({
       type: AppActions.DismissPasswordRequest,
     })
   }, [dispatch])
+  useDialog({ show: actionType, dialogRef, onClose: onDismiss })
+
+  const wallet = useMemo(() => wallets.find(w => w.id === walletID), [walletID, wallets])
 
   const onConfirm = useCallback(() => {
     switch (actionType) {

--- a/packages/neuron-ui/src/components/WithdrawDialog/index.tsx
+++ b/packages/neuron-ui/src/components/WithdrawDialog/index.tsx
@@ -25,7 +25,7 @@ const WithdrawDialog = ({
   const [withdrawValue, setWithdrawValue] = useState('')
 
   const dialogRef = useRef<HTMLDialogElement | null>(null)
-  useDialog({ show: record, dialogRef })
+  useDialog({ show: record, dialogRef, onClose: onDismiss })
 
   useEffect(() => {
     if (record) {

--- a/packages/neuron-ui/src/utils/hooks.ts
+++ b/packages/neuron-ui/src/utils/hooks.ts
@@ -118,9 +118,11 @@ export const useCalculateEpochs = ({ depositEpoch, currentEpoch }: { depositEpoc
 export const useDialog = ({
   show,
   dialogRef,
+  onClose,
 }: {
   show: any
   dialogRef: React.MutableRefObject<HTMLDialogElement | null>
+  onClose: () => void
 }) => {
   useEffect(() => {
     if (dialogRef.current) {
@@ -131,8 +133,14 @@ export const useDialog = ({
       } else {
         dialogRef.current.close()
       }
+      dialogRef.current.addEventListener('close', onClose)
     }
-  }, [show, dialogRef])
+    return () => {
+      if (dialogRef.current) {
+        dialogRef.current.removeEventListener('close', onClose)
+      }
+    }
+  }, [show, dialogRef, onClose])
 }
 
 export default { useGoBack, useLocalDescription, useCalculateEpochs, useDialog }

--- a/packages/neuron-ui/src/widgets/AlertDialog/index.tsx
+++ b/packages/neuron-ui/src/widgets/AlertDialog/index.tsx
@@ -16,11 +16,10 @@ const AlertDialog = ({
   const [t] = useTranslation()
   const dialogRef = useRef<HTMLDialogElement | null>(null)
 
-  useDialog({ show: content, dialogRef })
-
   const onDismiss = useCallback(() => {
     dismissAlertDialog()(dispatch)
   }, [dispatch])
+  useDialog({ show: content, dialogRef, onClose: onDismiss })
 
   return (
     <dialog ref={dialogRef} className={styles.alertDialog}>


### PR DESCRIPTION
Add an event listener to invoke the onDismiss method when the dialog is closed.