### PR TITLE
feat: Update the condition of syncing label

### DIFF
--- a/packages/neuron-ui/src/components/Overview/index.tsx
+++ b/packages/neuron-ui/src/components/Overview/index.tsx
@@ -82,8 +82,8 @@ const Overview = ({
         value: `${shannonToCKBFormatter(balance)} CKB${
           +tipBlockNumber > 0 &&
           BigInt(syncedBlockNumber) >= BigInt(0) &&
-          BigInt(syncedBlockNumber) + BigInt(BUFFER_BLOCK_NUMBER) >= BigInt(tipBlockNumber) &&
-          tipBlockTimestamp + MAX_TIP_BLOCK_DELAY < Date.now()
+          (BigInt(syncedBlockNumber) + BigInt(BUFFER_BLOCK_NUMBER) < BigInt(tipBlockNumber) ||
+            tipBlockTimestamp + MAX_TIP_BLOCK_DELAY < Date.now())
             ? `(${t('overview.syncing')})`
             : ''
         }`,


### PR DESCRIPTION
Display the syncing label when the synced block number is less than tip block number - 10, or the tip block timestamp is less than system time - 3mins.