### PR TITLE
[ᚬrc/v0.26.1] feat: Refine History and Address List

### DIFF
--- a/packages/neuron-ui/src/components/Addresses/addresses.module.scss
+++ b/packages/neuron-ui/src/components/Addresses/addresses.module.scss
@@ -59,8 +59,7 @@ $change-color: #6666cc;
 
 
   .type {
-    min-width: 150px;
-    width: 150px;
+    width: 100px;
     word-wrap: none;
   }
 
@@ -85,6 +84,25 @@ $change-color: #6666cc;
       display: flex;
       position: relative;
 
+      .addressOverflow {
+        word-break: break-all;
+        text-align: right;
+        height: 1rem;
+        overflow: hidden;
+        text-align: right;
+      }
+
+      .ellipsis {
+        display: none;
+      }
+
+      @media screen and (max-width: 1365px) {
+
+        .ellipsis {
+          display: inline;
+        }
+      }
+
       @media screen and (max-width: 1680px) {
         width: 30vw;
 
@@ -108,9 +126,6 @@ $change-color: #6666cc;
         width: 20vw;
       }
 
-      @media screen and (max-width: 1160px) {
-        width: 10vw;
-      }
 
     }
   }

--- a/packages/neuron-ui/src/components/Addresses/index.tsx
+++ b/packages/neuron-ui/src/components/Addresses/index.tsx
@@ -86,7 +86,8 @@ const Addresses = ({
                 </td>
                 <td className={`${styles.address} monospacedFont`}>
                   <div data-address={addr.address}>
-                    <span className="textOverflow">{addr.address.slice(0, -6)}</span>
+                    <span className={styles.addressOverflow}>{addr.address.slice(0, -6)}</span>
+                    <span className={styles.ellipsis}>...</span>
                     <span>{addr.address.slice(-6)}</span>
                   </div>
                 </td>

--- a/packages/neuron-ui/src/components/TransactionList/index.tsx
+++ b/packages/neuron-ui/src/components/TransactionList/index.tsx
@@ -139,7 +139,8 @@ const TransactionList = ({
               <div title={tx.hash} className={styles.txHash}>
                 <span>{t('history.transaction-hash')}</span>
                 <div className="monospacedFont">
-                  <span className="textOverflow">{tx.hash.slice(0, -6)}</span>
+                  <span className={styles.hashOverflow}>{tx.hash.slice(0, -6)}</span>
+                  <span className={styles.ellipsis}>...</span>
                   <span>{tx.hash.slice(-6)}</span>
                 </div>
               </div>

--- a/packages/neuron-ui/src/components/TransactionList/transactionList.module.scss
+++ b/packages/neuron-ui/src/components/TransactionList/transactionList.module.scss
@@ -117,18 +117,30 @@ $pending-color: #b3b3b3;
       &>div {
         display: flex;
 
-        span:first-of-type {
+        .hashOverflow {
+          word-break: break-all;
+          text-align: right;
+          height: 1rem;
+          overflow: hidden;
           text-align: right;
         }
 
+        .ellipsis {
+          display: none;
+        }
+
         @media screen and (max-width: 1200px) {
-          span:first-of-type {
+          .hashOverflow {
             width: 40vw;
+          }
+
+          .ellipsis {
+            display: inline
           }
         }
 
         @media screen and (max-width: 1080px) {
-          span:first-of-type {
+          .hashOverflow {
             width: 30vw;
           }
         }

--- a/packages/neuron-ui/src/locales/en.json
+++ b/packages/neuron-ui/src/locales/en.json
@@ -173,8 +173,8 @@
       "description": "Description",
       "balance": "Balance",
       "transactions": "Transactions",
-      "receiving-address": "Receiving Address",
-      "change-address": "Change Address",
+      "receiving-address": "Receiving",
+      "change-address": "Change",
       "copy-address": "Copy Address",
       "request-payment": "Request Payment",
       "view-on-explorer": "View on Explorer"


### PR DESCRIPTION
1. use a custom ellipsis
2. simplify the type of address label
Before
![image](https://user-images.githubusercontent.com/7271329/71709644-7044fa80-2e33-11ea-81d4-3d4304ccb4ba.png)
After
![image](https://user-images.githubusercontent.com/7271329/71709550-cebda900-2e32-11ea-88da-2b2908737579.png)

Before
![image](https://user-images.githubusercontent.com/7271329/71709652-7d61e980-2e33-11ea-857d-71179df41a31.png)
After
![image](https://user-images.githubusercontent.com/7271329/71709553-d0876c80-2e32-11ea-93f9-3924a33a0617.png)
