### PR TITLE
Downgrade to Electron 7.1.2 to fix the update failure issue

### DIFF
--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -64,7 +64,7 @@
     "@types/webdriverio": "4.13.0",
     "axios": "0.19.0",
     "devtron": "1.4.0",
-    "electron": "7.1.3",
+    "electron": "7.1.2",
     "electron-builder": "22.2.0",
     "electron-devtools-installer": "2.2.4",
     "electron-notarize": "0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7300,10 +7300,10 @@ electron-window-state@5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@7.1.3:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-7.1.3.tgz#9f6779846ced5b145b6303f10dcf4bf7f84e7f27"
-  integrity sha512-FdzGNR/tX0kC53lQnL7K+ZrxwrxKHf9i8KdL+O2LF5yXHJ3M8oZWc0OM1+nfqQUWCBoBV+7UblMF0+6E/tplEg==
+electron@7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-7.1.2.tgz#d1726b9e50b29e97f5f12b52feb225ba87e0640f"
+  integrity sha512-7hjONYt2GlQfKuKgQrhhUL1P9lbGWLBfMUq+2QFU3yeLtCvM0ROfPJCRP4OF5pVp3KDyfFp4DtmhuVzAnxV3jA==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
The issue was due to a redirect bug from Electron 7.1.3 and above.

We'd have to stick with `7.1.2` until there's a new release with the fix (which is already in electron master).