### PR TITLE
Prevent multiple instances

### DIFF
--- a/packages/neuron-wallet/src/controllers/app/index.ts
+++ b/packages/neuron-wallet/src/controllers/app/index.ts
@@ -64,6 +64,17 @@ export default class AppController {
     this.createWindow()
   }
 
+  public restoreWindow = () => {
+    if (!this.mainWindow) {
+      return
+    }
+
+    if (this.mainWindow.isMinimized()) {
+      this.mainWindow.restore()
+    }
+    this.mainWindow.focus()
+  }
+
   createWindow = () => {
     const windowState = windowStateKeeper({
       defaultWidth: 1366,

--- a/packages/neuron-wallet/src/main.ts
+++ b/packages/neuron-wallet/src/main.ts
@@ -5,14 +5,23 @@ import { changeLanguage } from 'locales/i18n'
 
 const appController = new AppController()
 
-app.on('ready', async () => {
-  changeLanguage(app.getLocale())
+const singleInstanceLock = app.requestSingleInstanceLock()
+if (singleInstanceLock) {
+  app.on('ready', async () => {
+    changeLanguage(app.getLocale())
 
-  appController.start()
-})
+    appController.start()
+  })
 
-app.on('before-quit', async () => {
-  appController.end()
-})
+  app.on('before-quit', async () => {
+    appController.end()
+  })
 
-app.on('activate', appController.openWindow)
+  app.on('activate', appController.openWindow)
+
+  app.on('second-instance', () => {
+    appController.restoreWindow()
+  })
+} else {
+  app.quit()
+}


### PR DESCRIPTION
It's always running a single instance on macOS (unless launched from command line). This makes sure Neuron only runs one instance on Linux/Windows.