### PR TITLE
Allow to connect to any chain from the default Mainnet network

### DIFF
--- a/packages/neuron-ui/src/components/NetworkSetting/index.tsx
+++ b/packages/neuron-ui/src/components/NetworkSetting/index.tsx
@@ -59,7 +59,7 @@ const NetworkSetting = ({ chain = chainState, settings: { networks = [] } }: Sta
           },
           {
             label: t('common.edit'),
-            enabled: !isDefault,
+            enabled: true,
             click: () => {
               history.push(`${Routes.NetworkEditor}/${item.id}`)
             },

--- a/packages/neuron-wallet/src/services/networks.ts
+++ b/packages/neuron-wallet/src/services/networks.ts
@@ -41,9 +41,7 @@ export default class NetworksService extends Store {
     super('networks', 'index.json', JSON.stringify(presetNetworks))
 
     const currentNetwork = this.getCurrent()
-    if (currentNetwork.type !== NetworkType.Default) {
-      this.update(currentNetwork.id, {}) // Update to trigger chain/genesis hash refresh
-    }
+    this.update(currentNetwork.id, {}) // Update to trigger chain/genesis hash refresh
   }
 
   public getAll = () => {
@@ -151,11 +149,6 @@ export default class NetworksService extends Store {
 
   // Refresh a network's genesis and chain info
   private async refreshChainInfo(network: Network): Promise<Network> {
-    if (network.type === NetworkType.Default) {
-      // Default mainnet network is not editable
-      return network
-    }
-
     const ckb = new CKB(network.remote)
 
     const genesisHash = await ckb.rpc


### PR DESCRIPTION
The default network `Mainnet` was not editable, but if some one brings up another chain other than the mainnet, it should connect to that (genesis hash and chain would update automatically, while the name will be kept as `Mainnet`.

This change also allows to edit(rename) the default network, but keeps it from being deleted.
