### PR TITLE
refactor: declarative update messages on the sending view.

### DIFF
--- a/packages/neuron-ui/src/states/initStates/app.ts
+++ b/packages/neuron-ui/src/states/initStates/app.ts
@@ -11,8 +11,8 @@ const appState: Readonly<State.App> = {
     txID: '',
     outputs: [
       {
-        address: '',
-        amount: '',
+        address: undefined,
+        amount: undefined,
         unit: CapacityUnit.CKB,
       },
     ],

--- a/packages/neuron-ui/src/types/App/index.d.ts
+++ b/packages/neuron-ui/src/types/App/index.d.ts
@@ -48,8 +48,8 @@ declare namespace State {
     readonly witnesses: string[]
   }
   interface Output {
-    readonly address: string
-    readonly amount: string
+    readonly address: string | undefined
+    readonly amount: string | undefined
     readonly unit: any
   }
   type MessageType = 'success' | 'warning' | 'alert'

--- a/packages/neuron-ui/src/utils/formatters.ts
+++ b/packages/neuron-ui/src/utils/formatters.ts
@@ -167,7 +167,7 @@ export const addressesToBalance = (addresses: State.Address[] = []) => {
 
 export const outputsToTotalAmount = (outputs: Readonly<State.Output[]>) => {
   const totalCapacity = outputs.reduce((total, cur) => {
-    if (Number.isNaN(+cur.amount)) {
+    if (Number.isNaN(+(cur.amount || ''))) {
       return total
     }
     return total + BigInt(CKBToShannonFormatter(cur.amount, cur.unit))

--- a/packages/neuron-ui/src/utils/validators.ts
+++ b/packages/neuron-ui/src/utils/validators.ts
@@ -89,7 +89,7 @@ export const verifyPasswordComplexity = (password: string) => {
 
 export const verifyTransactionOutputs = (items: Readonly<State.Output[]> = [], ignoreLastAmount: boolean = false) => {
   return !items.some((item, i) => {
-    if (item.address === '' || verifyAddress(item.address) !== true) {
+    if (!item.address || verifyAddress(item.address) !== true) {
       return true
     }
     if (ignoreLastAmount && i === items.length - 1) {


### PR DESCRIPTION
Remove the `set errors` out of the `onItemChange` hook and update it before each render.