### PR TITLE
Language loading

### DIFF
--- a/packages/neuron-ui/src/utils/i18n.ts
+++ b/packages/neuron-ui/src/utils/i18n.ts
@@ -4,16 +4,19 @@ import { getLocale } from 'services/remote'
 
 import zh from 'locales/zh.json'
 import en from 'locales/en.json'
-
-const locale = getLocale()
-const lng = ['zh', 'zh-CN'].includes(locale) ? 'zh' : 'en'
+import zhTW from 'locales/zh-tw.json'
 
 i18n.use(initReactI18next).init({
   resources: {
     en,
     zh,
+    'zh-TW': zhTW,
   },
-  fallbackLng: lng,
+  lng: getLocale(),
+  fallbackLng: {
+    'zh-CN': ['zh'],
+    default: ['en'],
+  },
   interpolation: {
     escapeValue: false,
   },

--- a/packages/neuron-wallet/electron-builder.yml
+++ b/packages/neuron-wallet/electron-builder.yml
@@ -55,7 +55,7 @@ mac:
   gatekeeperAssess: false
   entitlements: assets/entitlements.plist
   entitlementsInherit: assets/entitlements.plist
-  electronLanguages: ["en", "zh", "zh_CN"]
+  electronLanguages: ["en", "zh", "zh_CN", "zh_TW"]
   target:
     - dmg
     - zip

--- a/packages/neuron-wallet/src/locales/i18n.ts
+++ b/packages/neuron-wallet/src/locales/i18n.ts
@@ -1,21 +1,25 @@
 import i18n from 'i18next'
 import zh from './zh'
 import en from './en'
+import zhTW from './zh-tw'
 
 i18n.init({
   resources: {
     en,
     zh,
+    "zh-TW": zhTW
   },
-  fallbackLng: 'en',
+  fallbackLng: {
+    'zh-CN': ['zh'],
+    default: ['en']
+  },
   interpolation: {
     escapeValue: false,
-  },
+  }
 })
 
 export const changeLanguage = (lng = 'en') => {
-  const language = ['zh', 'zh-CN'].includes(lng) ? 'zh' : 'en'
-  i18n.changeLanguage(language)
+  i18n.changeLanguage(lng)
 }
 
 export default i18n


### PR DESCRIPTION
* Add `zh-TW`
* Fallback `zh-CN` to `zh`
* Make `zh-TW` available to macOS language list

## Note

Current implementation doesn't support switching language on the fly yet. For one thing, Electron doesn't have `app.setLocale`, for another, if we store user selected language in the app and skip `app.getLocale`, per-app language preferences on macOS might not work any more (haven't test this though).

## Release

This WON'T go into [`v0.27.0`](https://github.com/nervosnetwork/neuron/pull/1336).