### PR TITLE
Fix synced block number offset one bug

### DIFF
--- a/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
@@ -203,7 +203,7 @@ export default class Queue {
 
   private updateCurrentBlockNumber(blockNumber: BigInt) {
     this.currentBlockNumber = BigInt(blockNumber)
-    ipcRenderer.invoke('synced-block-number-updated', this.currentBlockNumber.toString())
+    ipcRenderer.invoke('synced-block-number-updated', (this.currentBlockNumber - BigInt(1)).toString())
   }
 
   private async expandToTip(tipNumber: string) {


### PR DESCRIPTION
`Queue.currentBlockNumber` is the block number to process, thus when notifying synced block number the value should be `currentBlockNumber - 1`.