### PR TITLE
Remove how to run ckb node message

### DIFF
--- a/packages/neuron-ui/src/containers/Notification/index.tsx
+++ b/packages/neuron-ui/src/containers/Notification/index.tsx
@@ -2,7 +2,6 @@ import React, { useMemo, useCallback, MouseEventHandler } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { Stack, MessageBar, MessageBarType, IconButton, Panel, PanelType, Text } from 'office-ui-fabric-react'
-import { openExternal } from 'services/remote'
 import { useState as useGlobalState, useDispatch } from 'states/stateProvider'
 import { StateDispatch } from 'states/stateProvider/reducer'
 import {
@@ -11,7 +10,6 @@ import {
   dismissNotification,
 } from 'states/stateProvider/actionCreators'
 import AlertDialog from 'widgets/AlertDialog'
-import { ErrorCode, RUN_NODE_GUIDE_URL } from 'utils/const'
 import styles from './Notification.module.scss'
 
 const notificationType = (type: 'success' | 'warning' | 'alert') => {
@@ -84,10 +82,6 @@ export const NoticeContent = () => {
     [dispatch]
   )
 
-  const onGuideLinkClick = useCallback(() => {
-    openExternal(RUN_NODE_GUIDE_URL)
-  }, [])
-
   return (
     <div>
       {showTopAlert && notification ? (
@@ -109,11 +103,6 @@ export const NoticeContent = () => {
           {notification.code
             ? t(`messages.codes.${notification.code}`, notification.meta)
             : notification.content || t('messages.unknown-error')}
-          {notification.code === ErrorCode.NodeDisconnected ? (
-            <Text as="span" variant="xSmall" className={styles.guide} onClick={onGuideLinkClick}>
-              {t('messages.run-ckb-guide')}
-            </Text>
-          ) : null}
         </MessageBar>
       ) : null}
 

--- a/packages/neuron-ui/src/locales/en.json
+++ b/packages/neuron-ui/src/locales/en.json
@@ -301,7 +301,6 @@
         "keystore-password": "Password",
         "deposit": "Deposit"
       },
-      "run-ckb-guide": "How to run a CKB node?",
       "codes": {
         "-3": "",
         "100": "Amount is not enough.",

--- a/packages/neuron-ui/src/locales/zh-tw.json
+++ b/packages/neuron-ui/src/locales/zh-tw.json
@@ -301,7 +301,6 @@
         "keystore-password": "密碼",
         "deposit": "存入金額"
       },
-      "run-ckb-guide": "如何運行一個 CKB 節點？",
       "codes": {
         "-3": "",
         "100": "餘額不足。",

--- a/packages/neuron-ui/src/locales/zh.json
+++ b/packages/neuron-ui/src/locales/zh.json
@@ -301,7 +301,6 @@
         "keystore-password": "密码",
         "deposit": "存入金额"
       },
-      "run-ckb-guide": "如何运行一个 CKB 节点?",
       "codes": {
         "-3": "",
         "100": "余额不足。",

--- a/packages/neuron-ui/src/utils/const.ts
+++ b/packages/neuron-ui/src/utils/const.ts
@@ -22,7 +22,6 @@ export const MEDIUM_FEE_RATE = 6000
 export const WITHDRAW_EPOCHS = 180
 export const MILLISECONDS_IN_YEAR = 365 * 24 * 3600 * 1000
 
-export const RUN_NODE_GUIDE_URL = 'https://docs.nervos.org/references/neuron-wallet-guide.html#1-run-a-ckb-mainnet-node'
 export const NERVOS_DAO_RFC_URL =
   'https://www.github.com/nervosnetwork/rfcs/blob/master/rfcs/0023-dao-deposit-withdraw/0023-dao-deposit-withdraw.md'
 


### PR DESCRIPTION
Now that we have CKB node bundled, this message has become unnecessary.