### PR TITLE
Ignore CKB child process's stdin and stdout fd

### DIFF
--- a/packages/neuron-wallet/src/services/ckb-runner.ts
+++ b/packages/neuron-wallet/src/services/ckb-runner.ts
@@ -63,9 +63,10 @@ const initCkb = async () => {
 export const startCkbNode = async () => {
   initCkb().then(async () => {
     logger.info('Starting CKB...')
-    ckb = spawn(ckbBinary(), ['run', '-C', ckbDataPath()])
+    ckb = spawn(ckbBinary(), ['run', '-C', ckbDataPath()], { stdio: ['ignore', 'ignore', 'pipe'] })
     ckb.stderr && ckb.stderr.on('data', data => {
       logger.error('CKB run fail:', data.toString())
+      ckb = null
     })
 
     ckb.on('error', error => {


### PR DESCRIPTION
This probably will fix the issue that after around 10 minutes of spawning
the bundled CKB would stop writing log to run.log file