### PR TITLE
[ᚬrc/v0.28.1] fix: Fix the link to customized cell

### DIFF
--- a/packages/neuron-ui/src/components/SpecialAsset/index.tsx
+++ b/packages/neuron-ui/src/components/SpecialAsset/index.tsx
@@ -50,7 +50,7 @@ const SpecialAsset = ({
 
   const onViewDetail = useCallback(() => {
     const explorerUrl = getExplorerUrl(isMainnet)
-    openExternal(`${explorerUrl}/transaction/${txHash}/${index}`)
+    openExternal(`${explorerUrl}/transaction/${txHash}#${index}`)
   }, [isMainnet, txHash, index])
 
   return (


### PR DESCRIPTION
Use `transaction#index` instead of 
![image](https://user-images.githubusercontent.com/7271329/75241147-8aca9d00-5800-11ea-8495-bdda0d406e73.png)
