### PR TITLE
[ᚬrc/v0.29.0] fix: Remove the height limitation of messages

### DIFF
--- a/packages/neuron-ui/src/components/WithdrawDialog/withdrawDialog.module.scss
+++ b/packages/neuron-ui/src/components/WithdrawDialog/withdrawDialog.module.scss
@@ -25,7 +25,6 @@
 .errorMessage {
   display: flex;
   align-items: center;
-  height: 0.75rem;
   font-size: 0.625rem;
 }
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7271329/75747825-ea70fd00-5d58-11ea-9aaa-c5eb142f5542.png)
After:
![image](https://user-images.githubusercontent.com/7271329/75747829-ee048400-5d58-11ea-956b-85c6803c5691.png)
