### PR TITLE
[ᚬrc/v0.29.0] feat: limit index/length up to 1 on parsing epoch

### DIFF
--- a/packages/neuron-ui/src/components/SpecialAssetList/index.tsx
+++ b/packages/neuron-ui/src/components/SpecialAssetList/index.tsx
@@ -164,7 +164,8 @@ const SpecialAssetList = () => {
       if (cell.customizedAssetInfo.lock === PRESET_SCRIPT.Locktime) {
         const targetEpochInfo = epochParser(ckbCore.utils.toHexInLittleEndian(`0x${cell.lock.args.slice(-16)}`))
         const currentEpochInfo = epochParser(epoch)
-        const targetEpochFraction = Number(targetEpochInfo.index) / Number(targetEpochInfo.length)
+        const targetEpochFraction =
+          Number(targetEpochInfo.length) > 0 ? Number(targetEpochInfo.index) / Number(targetEpochInfo.length) : 1
         epochInfo = {
           target: Number(targetEpochInfo.number) + Math.min(targetEpochFraction, 1),
           current: Number(currentEpochInfo.number) + Number(currentEpochInfo.index) / Number(currentEpochInfo.length),

--- a/packages/neuron-ui/src/components/SpecialAssetList/index.tsx
+++ b/packages/neuron-ui/src/components/SpecialAssetList/index.tsx
@@ -164,8 +164,9 @@ const SpecialAssetList = () => {
       if (cell.customizedAssetInfo.lock === PRESET_SCRIPT.Locktime) {
         const targetEpochInfo = epochParser(ckbCore.utils.toHexInLittleEndian(`0x${cell.lock.args.slice(-16)}`))
         const currentEpochInfo = epochParser(epoch)
+        const targetEpochFraction = Number(targetEpochInfo.index) / Number(targetEpochInfo.length)
         epochInfo = {
-          target: Number(targetEpochInfo.number) + Number(targetEpochInfo.index) / Number(targetEpochInfo.length),
+          target: Number(targetEpochInfo.number) + Math.min(targetEpochFraction, 1),
           current: Number(currentEpochInfo.number) + Number(currentEpochInfo.index) / Number(currentEpochInfo.length),
         }
         if (epochInfo.target - epochInfo.current > 0) {


### PR DESCRIPTION
This PR is for the situation that `epochIndex/epochLength > 1`.

The comparison between epochs starts from epoch number. If the current epoch and target epoch have the same epoch number, the value of `index/length` will be compared.

Say **epoch=579 index=65464 length=239**,

The cell is unavailable on the epoch 579 cuz 65464/234 > 1 while it's available on epoch 580 cuz 580 > 579