### PR TITLE
[ᚬrc/v0.29.0] fix: Fix the validation on network update

### DIFF
--- a/packages/neuron-ui/src/components/NetworkEditor/index.tsx
+++ b/packages/neuron-ui/src/components/NetworkEditor/index.tsx
@@ -113,7 +113,7 @@ const NetworkEditor = () => {
             !!(
               editor.nameError ||
               editor.urlError ||
-              (cachedNetwork && editor.name === cachedNetwork.name) ||
+              (cachedNetwork && editor.name === cachedNetwork.name && editor.url === cachedNetwork.remote) ||
               isUpdating
             )
           }


### PR DESCRIPTION
Disable the submit button if both of network name and its url are not modified.

Before this PR, the validation only checks the network name.

If only the network url is changed, the validation fails, which is not expected.