### PR TITLE
Persist transaction description in leveldb, separate from tx sqlite data

### DIFF
--- a/packages/neuron-ui/src/states/stateProvider/actionCreators/transactions.ts
+++ b/packages/neuron-ui/src/states/stateProvider/actionCreators/transactions.ts
@@ -24,6 +24,7 @@ export const updateTransactionDescription = (params: Controller.UpdateTransactio
   dispatch: StateDispatch
 ) => {
   const descriptionParams = {
+    walletID: params.walletID,
     hash: params.hash,
     description: params.description,
   }

--- a/packages/neuron-ui/src/types/Controller/index.d.ts
+++ b/packages/neuron-ui/src/types/Controller/index.d.ts
@@ -89,6 +89,7 @@ declare namespace Controller {
   }
 
   interface UpdateTransactionDescriptionParams {
+    walletID: string
     hash: string
     description: string
   }

--- a/packages/neuron-ui/src/utils/hooks.ts
+++ b/packages/neuron-ui/src/utils/hooks.ts
@@ -33,6 +33,7 @@ export const useLocalDescription = (type: 'address' | 'transaction', walletID: s
         })
         if (localDescription.key && type === 'transaction') {
           updateTransactionDescription({
+            walletID,
             hash: localDescription.key,
             description: localDescription.description,
           })(dispatch)

--- a/packages/neuron-wallet/src/controllers/api.ts
+++ b/packages/neuron-wallet/src/controllers/api.ts
@@ -100,7 +100,7 @@ export default class ApiController {
         : [])
 
       const transactions = currentWallet
-        ? await this.transactionsController.getAllByKeywords({
+        ? await this.transactionsController.getAll({
             pageNo: 1,
             pageSize: 15,
             keywords: '',
@@ -209,14 +209,14 @@ export default class ApiController {
     // Transactions
 
     handle('get-transaction-list', async (_, params: Controller.Params.TransactionsByKeywords) => {
-      return this.transactionsController.getAllByKeywords(params)
+      return this.transactionsController.getAll(params)
     })
 
     handle('get-transaction', async (_, { walletID, hash }: { walletID: string, hash: string }) => {
       return this.transactionsController.get(walletID, hash)
     })
 
-    handle('update-transaction-description', async (_, params: { hash: string; description: string }) => {
+    handle('update-transaction-description', async (_, params: { walletID: string; hash: string; description: string }) => {
       return this.transactionsController.updateDescription(params)
     })
 

--- a/packages/neuron-wallet/src/controllers/transactions.ts
+++ b/packages/neuron-wallet/src/controllers/transactions.ts
@@ -18,7 +18,13 @@ export default class TransactionsController {
 
     const transactions = await TransactionsService.getAllByAddresses({ pageNo, pageSize, addresses }, keywords.trim())
     transactions.items = await Promise.all(transactions.items.map(async tx => {
-      tx.description = await getDescription(walletID, tx.hash!)
+      const description = await getDescription(walletID, tx.hash!)
+      if (description !== '') {
+        tx.description = description
+      } else if (tx.description !== '') {
+        // Legacy data has description but leveldb doesn't have it.
+        await setDescription(walletID, tx.hash!, tx.description)
+      }
       return tx
     }))
 

--- a/packages/neuron-wallet/src/controllers/transactions.ts
+++ b/packages/neuron-wallet/src/controllers/transactions.ts
@@ -1,69 +1,30 @@
-import { TransactionsService, PaginationResult, TransactionsByLockHashesParam } from 'services/tx'
+import { TransactionsService, PaginationResult } from 'services/tx'
 import AddressesService from 'services/addresses'
 import WalletsService from 'services/wallets'
 
 import { ResponseCode } from 'utils/const'
-import { TransactionNotFound, CurrentWalletNotSet, ServiceHasNoResponse } from 'exceptions'
+import { TransactionNotFound, CurrentWalletNotSet } from 'exceptions'
 import LockUtils from 'models/lock-utils'
 import Transaction from 'models/chain/transaction'
 
+import { set as setDescription, get as getDescription } from 'database/leveldb/transaction-description'
+
 export default class TransactionsController {
-  public async getAll(params: TransactionsByLockHashesParam): Promise<Controller.Response<PaginationResult<Transaction>>> {
-    const transactions = await TransactionsService.getAll(params)
-    if (!transactions) {
-      throw new ServiceHasNoResponse('Transactions')
-    }
-
-    return {
-      status: ResponseCode.Success,
-      result: { ...params, ...transactions }
-    }
-  }
-
-  public async getAllByKeywords(params: Controller.Params.TransactionsByKeywords):
+  public async getAll(params: Controller.Params.TransactionsByKeywords):
     Promise<Controller.Response<PaginationResult<Transaction> & Controller.Params.TransactionsByKeywords>> {
     const { pageNo = 1, pageSize = 15, keywords = '', walletID = '' } = params
 
     const addresses = AddressesService.allAddressesByWalletId(walletID).map(addr => addr.address)
 
-    const transactions = await TransactionsService
-      .getAllByAddresses({ pageNo, pageSize, addresses }, keywords.trim())
-      .catch(() => ({
-        totalCount: 0,
-        items: []
-      }))
+    const transactions = await TransactionsService.getAllByAddresses({ pageNo, pageSize, addresses }, keywords.trim())
+    transactions.items = await Promise.all(transactions.items.map(async tx => {
+      tx.description = await getDescription(walletID, tx.hash!)
+      return tx
+    }))
 
     return {
       status: ResponseCode.Success,
       result: { ...params, ...transactions, keywords, walletID }
-    }
-  }
-
-  public async getAllByAddresses(params: Controller.Params.TransactionsByAddresses):
-    Promise<Controller.Response<PaginationResult<Transaction> & Controller.Params.TransactionsByAddresses>> {
-    const { pageNo, pageSize, addresses = '' } = params
-
-    let searchAddresses = addresses
-      .split(',')
-      .map(addr => addr.trim())
-      .filter(addr => addr !== '')
-
-    if (!searchAddresses.length) {
-      const wallet = WalletsService.getInstance().getCurrent()
-      if (!wallet) {
-        throw new CurrentWalletNotSet()
-      }
-      searchAddresses = AddressesService.allAddressesByWalletId(wallet.id).map(addr => addr.address)
-    }
-
-    const transactions = await TransactionsService.getAllByAddresses({ pageNo, pageSize, addresses: searchAddresses })
-    if (!transactions) {
-      throw new ServiceHasNoResponse('Transactions')
-    }
-
-    return {
-      status: ResponseCode.Success,
-      result: { ...params, ...transactions }
     }
   }
 
@@ -80,7 +41,7 @@ export default class TransactionsController {
       throw new CurrentWalletNotSet()
     }
 
-    const addresses: string[] = (await AddressesService.allAddressesByWalletId(wallet.id)).map(addr => addr.address)
+    const addresses: string[] = AddressesService.allAddressesByWalletId(wallet.id).map(addr => addr.address)
     const lockHashes: string[] = new LockUtils(await LockUtils.systemScript()).addressesToAllLockHashes(addresses)
 
     const outputCapacities: bigint = transaction
@@ -109,14 +70,16 @@ export default class TransactionsController {
         .slice(0, this.cellCountThreshold)
     }
 
+    transaction.description = await getDescription(walletID, hash)
+
     return {
       status: ResponseCode.Success,
       result: { ...transaction, outputsCount, inputsCount } as Transaction & { outputsCount: string; inputsCount: string }
     }
   }
 
-  public async updateDescription({ hash, description }: { hash: string; description: string }) {
-    await TransactionsService.updateDescription(hash, description)
+  public async updateDescription({ walletID, hash, description }: { walletID: string; hash: string; description: string }) {
+    await setDescription(walletID, hash, description)
 
     return {
       status: ResponseCode.Success,

--- a/packages/neuron-wallet/src/database/leveldb/index.ts
+++ b/packages/neuron-wallet/src/database/leveldb/index.ts
@@ -6,8 +6,10 @@ import sub from 'subleveldown'
 import env from 'env'
 
 // Create a database. If prefix is provided the result will be a sublevel db
-// with its own keyspace.
-const leveldb = (dbname: string, prefix: string | null = null): LevelUp => {
+//   with its own keyspace. If valueEncoding is provided it's applied to the
+//   sublevel db.
+const leveldb = (prefix?: string, valueEncoding?: string): LevelUp => {
+  const dbname = "datastore" // Keep as a single database
   const dbpath = path.join(env.fileBasePath, dbname)
   if (!fs.existsSync(dbpath)) {
     fs.mkdirSync(dbpath, { recursive: true })
@@ -15,9 +17,11 @@ const leveldb = (dbname: string, prefix: string | null = null): LevelUp => {
 
   const db = levelup(leveldown(dbpath))
   if (prefix) {
-    return sub(db, prefix, { valueEncoding: 'json' })
+    return sub(db, prefix, { valueEncoding })
   }
   return db
 }
+
+export const txdb = leveldb('transactions')
 
 export default leveldb

--- a/packages/neuron-wallet/src/database/leveldb/transaction-description.ts
+++ b/packages/neuron-wallet/src/database/leveldb/transaction-description.ts
@@ -1,0 +1,18 @@
+// Transaction description is stored in LevelDB separated from Sqlite3 data,
+// to keep persisted. Sqlite3 transaction table gets cleaned when user clears
+// cache or sync rebuilds txs.
+
+import { txdb } from './'
+
+const makeKey = (walletID: string, txHash: string): string => {
+  return `description:${walletID}:${txHash}`
+
+}
+
+export const get = async (walletID: string, txHash: string) => {
+  return txdb.get(makeKey(walletID, txHash)).catch(() => (''))
+}
+
+export const set = (walletID: string, txHash: string, description: string) => {
+  return txdb.put(makeKey(walletID, txHash), description)
+}


### PR DESCRIPTION
The current implementation cleans sqlite transaction table when clearing cache,
but description as user data should be kept.