### PR TITLE
feat: add the following cases of network status

### DIFF
--- a/packages/neuron-ui/src/components/NetworkStatus/index.tsx
+++ b/packages/neuron-ui/src/components/NetworkStatus/index.tsx
@@ -23,6 +23,12 @@ const NetworkStatus = ({
   syncStatus = SyncStatus.SyncNotStart,
 }: NetworkStatusProps) => {
   const [t] = useTranslation()
+
+  let synced = syncedBlockNumber
+  if (tipBlockNumber && BigInt(tipBlockNumber) < BigInt(syncedBlockNumber)) {
+    synced = tipBlockNumber
+  }
+
   return (
     <div
       role="link"
@@ -32,7 +38,7 @@ const NetworkStatus = ({
       onKeyPress={onAction}
       tabIndex={0}
     >
-      {networkName ? (
+      {networkName && (tipBlockNumber || +synced >= 0) ? (
         <div className={styles.tooltip}>
           <span className={styles.tooltipTitle}>{t('network-status.tooltip.block-number')}</span>
           {tipBlockNumber ? (
@@ -41,10 +47,10 @@ const NetworkStatus = ({
               <span className={styles.blockNumber}>{localNumberFormatter(tipBlockNumber)}</span>
             </>
           ) : null}
-          {+syncedBlockNumber >= 0 ? (
+          {+synced >= 0 ? (
             <>
               <span>{t('network-status.tooltip.synced')}</span>
-              <span className={styles.blockNumber}>{localNumberFormatter(syncedBlockNumber)}</span>
+              <span className={styles.blockNumber}>{localNumberFormatter(synced)}</span>
             </>
           ) : null}
         </div>

--- a/packages/neuron-ui/src/stories/NetworkStatus.stories.tsx
+++ b/packages/neuron-ui/src/stories/NetworkStatus.stories.tsx
@@ -21,6 +21,38 @@ const states: { [index: string]: NetworkStatusProps } = {
     syncStatus: SyncStatus.Syncing,
     onAction: () => {},
   },
+  '100 synced and 0 tip': {
+    networkName: 'network',
+    tipBlockNumber: '0',
+    syncedBlockNumber: '100',
+    connectionStatus: 'offline' as any,
+    syncStatus: SyncStatus.Syncing,
+    onAction: () => {},
+  },
+  '100 synced and empty tip': {
+    networkName: 'network',
+    tipBlockNumber: '',
+    syncedBlockNumber: '100',
+    connectionStatus: 'offline' as any,
+    syncStatus: SyncStatus.Syncing,
+    onAction: () => {},
+  },
+  'not sycned and 100 tip': {
+    networkName: 'network',
+    tipBlockNumber: '100',
+    syncedBlockNumber: '-1',
+    connectionStatus: 'offline' as any,
+    syncStatus: SyncStatus.Syncing,
+    onAction: () => {},
+  },
+  'not synced and empty tip': {
+    networkName: 'network',
+    tipBlockNumber: '',
+    syncedBlockNumber: '-1',
+    connectionStatus: 'offline' as any,
+    syncStatus: SyncStatus.Syncing,
+    onAction: () => {},
+  },
 }
 
 const stories = storiesOf('Connection Status', module).addDecorator(withKnobs)


### PR DESCRIPTION
1. synced block number > tip block number and tip block number is not empty => synced block number should up to tip block number
2. sycned block number > tip block number and tip block number is empty => keep synced block number its own value
3. synced block number is -1 and tip block number is empty => do not show the tooltip