### PR TITLE
fix: Fix the network pending status after network changes

### DIFF
--- a/packages/neuron-ui/src/components/NervosDAO/index.tsx
+++ b/packages/neuron-ui/src/components/NervosDAO/index.tsx
@@ -11,6 +11,7 @@ import { MIN_DEPOSIT_AMOUNT, SyncStatus, ConnectionStatus } from 'utils/const'
 import { epochParser } from 'utils/parsers'
 import { backToTop } from 'utils/animations'
 import getSyncStatus from 'utils/getSyncStatus'
+import getCurrentUrl from 'utils/getCurrentUrl'
 
 import DepositDialog from 'components/DepositDialog'
 import WithdrawDialog from 'components/WithdrawDialog'
@@ -35,7 +36,8 @@ const NervosDAO = () => {
     },
     wallet,
     nervosDAO: { records },
-    chain: { connectionStatus, tipBlockNumber: syncedBlockNumber },
+    chain: { connectionStatus, tipBlockNumber: syncedBlockNumber, networkID },
+    settings: { networks },
   } = useGlobalState()
   const dispatch = useDispatch()
   const [t] = useTranslation()
@@ -124,6 +126,7 @@ const NervosDAO = () => {
     tipBlockTimestamp,
     syncedBlockNumber,
     currentTimestamp: Date.now(),
+    url: getCurrentUrl(networkID, networks),
   })
 
   const MemoizedRecords = useMemo(() => {

--- a/packages/neuron-ui/src/components/Overview/index.tsx
+++ b/packages/neuron-ui/src/components/Overview/index.tsx
@@ -16,6 +16,7 @@ import {
 } from 'utils/formatters'
 import { epochParser } from 'utils/parsers'
 import getSyncStatus from 'utils/getSyncStatus'
+import getCurrentUrl from 'utils/getCurrentUrl'
 import { SyncStatus as SyncStatusEnum, ConnectionStatus, PAGE_SIZE, Routes, CONFIRMATION_THRESHOLD } from 'utils/const'
 import { backToTop } from 'utils/animations'
 import styles from './overview.module.scss'
@@ -54,7 +55,9 @@ const Overview = () => {
       tipBlockNumber: syncedBlockNumber,
       transactions: { items = [] },
       connectionStatus,
+      networkID,
     },
+    settings: { networks },
   } = useGlobalState()
   const dispatch = useDispatch()
   const [t] = useTranslation()
@@ -66,6 +69,7 @@ const Overview = () => {
     tipBlockNumber,
     tipBlockTimestamp,
     currentTimestamp: Date.now(),
+    url: getCurrentUrl(networkID, networks),
   })
 
   useEffect(() => {

--- a/packages/neuron-ui/src/components/Send/index.tsx
+++ b/packages/neuron-ui/src/components/Send/index.tsx
@@ -30,6 +30,7 @@ import {
   SINCE_FIELD_SIZE,
 } from 'utils/const'
 import getSyncStatus from 'utils/getSyncStatus'
+import getCurrentUrl from 'utils/getCurrentUrl'
 import { shannonToCKBFormatter, localNumberFormatter } from 'utils/formatters'
 import {
   verifyTotalAmount,
@@ -111,6 +112,7 @@ const Send = () => {
     syncedBlockNumber,
     tipBlockTimestamp,
     currentTimestamp: Date.now(),
+    url: getCurrentUrl(networkID, networks),
   })
 
   const outputErrors = useMemo(() => {

--- a/packages/neuron-ui/src/containers/Navbar/index.tsx
+++ b/packages/neuron-ui/src/containers/Navbar/index.tsx
@@ -8,6 +8,7 @@ import NetworkStatus from 'components/NetworkStatus'
 import SyncStatus from 'components/SyncStatus'
 
 import getSyncStatus from 'utils/getSyncStatus'
+import getCurrentUrl from 'utils/getCurrentUrl'
 import { Routes, FULL_SCREENS } from 'utils/const'
 
 import styles from './navbar.module.scss'
@@ -43,6 +44,7 @@ const Navbar = () => {
     tipBlockNumber,
     tipBlockTimestamp,
     currentTimestamp: Date.now(),
+    url: getCurrentUrl(networkID, networks),
   })
 
   if (!wallets.length || FULL_SCREENS.find(url => pathname.startsWith(url))) {

--- a/packages/neuron-ui/src/utils/getCurrentUrl.ts
+++ b/packages/neuron-ui/src/utils/getCurrentUrl.ts
@@ -1,0 +1,4 @@
+export default (id: string, networks: Readonly<State.Network[]>) => {
+  const network = networks.find(n => n.id === id)
+  return network?.remote
+}

--- a/packages/neuron-ui/src/utils/getSyncStatus.ts
+++ b/packages/neuron-ui/src/utils/getSyncStatus.ts
@@ -3,21 +3,25 @@ import { SyncStatus, BUFFER_BLOCK_NUMBER, MAX_TIP_BLOCK_DELAY } from 'utils/cons
 const TEN_MINS = 10 * 60 * 1000
 let blockNumber10MinAgo: string = ''
 let timestamp10MinAgo: number | undefined
+let prevUrl: string | undefined
 
 export default ({
   syncedBlockNumber,
   tipBlockNumber,
   tipBlockTimestamp,
   currentTimestamp,
+  url,
 }: {
   syncedBlockNumber: string
   tipBlockNumber: string
   tipBlockTimestamp: number
   currentTimestamp: number
+  url: string | undefined
 }) => {
-  if (!timestamp10MinAgo && tipBlockNumber !== '') {
+  if ((!timestamp10MinAgo && tipBlockNumber !== '') || (prevUrl && url !== prevUrl && tipBlockNumber !== '')) {
     timestamp10MinAgo = currentTimestamp
     blockNumber10MinAgo = tipBlockNumber
+    prevUrl = url
   }
 
   const now = Math.floor(currentTimestamp / 1000) * 1000


### PR DESCRIPTION
Update the cached timestamp and block number if the url is changed to avoid the comparison on data from different chains.