### PR TITLE
Only save tx description for the wallet to which it belongs

### DIFF
--- a/packages/neuron-wallet/src/controllers/wallets.ts
+++ b/packages/neuron-wallet/src/controllers/wallets.ts
@@ -26,6 +26,7 @@ import { MainnetAddressRequired, TestnetAddressRequired } from 'exceptions/addre
 import TransactionSender from 'services/transaction-sender'
 import Transaction from 'models/chain/transaction'
 import logger from 'utils/logger'
+import { set as setDescription } from 'database/leveldb/transaction-description'
 
 export default class WalletsController {
   public async getAll(): Promise<Controller.Response<Pick<Wallet, 'id' | 'name'>[]>> {
@@ -337,9 +338,13 @@ export default class WalletsController {
     const hash = await new TransactionSender().sendTx(
       params.walletID,
       Transaction.fromObject(params.tx),
-      params.password,
-      params.description
+      params.password
     )
+    const description = params.description ?? ''
+    if (description !== '') {
+      await setDescription(params.walletID, hash, description)
+    }
+
     return {
       status: ResponseCode.Success,
       result: hash,

--- a/packages/neuron-wallet/src/database/leveldb/index.ts
+++ b/packages/neuron-wallet/src/database/leveldb/index.ts
@@ -2,26 +2,19 @@ import fs from 'fs'
 import path from 'path'
 import levelup, { LevelUp } from 'levelup'
 import leveldown from 'leveldown'
-import sub from 'subleveldown'
 import env from 'env'
 
-// Create a database. If prefix is provided the result will be a sublevel db
-//   with its own keyspace. If valueEncoding is provided it's applied to the
-//   sublevel db.
-const leveldb = (prefix?: string, valueEncoding?: string): LevelUp => {
-  const dbname = "datastore" // Keep as a single database
-  const dbpath = path.join(env.fileBasePath, dbname)
-  if (!fs.existsSync(dbpath)) {
-    fs.mkdirSync(dbpath, { recursive: true })
+const leveldb = (dbname: string): LevelUp => {
+  const dir = env.fileBasePath
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true })
   }
 
+  const dbpath = path.join(dir, dbname)
   const db = levelup(leveldown(dbpath))
-  if (prefix) {
-    return sub(db, prefix, { valueEncoding })
-  }
   return db
 }
 
-export const txdb = leveldb('transactions')
+export const maindb = leveldb("datastore")
 
 export default leveldb

--- a/packages/neuron-wallet/src/database/leveldb/index.ts
+++ b/packages/neuron-wallet/src/database/leveldb/index.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import levelup, { LevelUp } from 'levelup'
 import leveldown from 'leveldown'
 import env from 'env'
+import logger from 'utils/logger'
 
 const leveldb = (dbname: string): LevelUp => {
   const dir = env.fileBasePath
@@ -11,8 +12,10 @@ const leveldb = (dbname: string): LevelUp => {
   }
 
   const dbpath = path.join(dir, dbname)
-  const db = levelup(leveldown(dbpath))
-  return db
+  return levelup(leveldown(dbpath), (err: Error | undefined) => {
+    logger.error(`Database:\tfail to open leveldb ${dbname}:`, err?.toString())
+
+  })
 }
 
 export const maindb = leveldb("datastore")

--- a/packages/neuron-wallet/src/database/leveldb/transaction-description.ts
+++ b/packages/neuron-wallet/src/database/leveldb/transaction-description.ts
@@ -2,17 +2,16 @@
 // to keep persisted. Sqlite3 transaction table gets cleaned when user clears
 // cache or sync rebuilds txs.
 
-import { txdb } from './'
+import { maindb } from './'
 
 const makeKey = (walletID: string, txHash: string): string => {
-  return `description:${walletID}:${txHash}`
-
+  return `tx_desc:${walletID}:${txHash}`
 }
 
 export const get = async (walletID: string, txHash: string) => {
-  return txdb.get(makeKey(walletID, txHash)).catch(() => (''))
+  return maindb.get(makeKey(walletID, txHash)).catch(() => (''))
 }
 
 export const set = (walletID: string, txHash: string, description: string) => {
-  return txdb.put(makeKey(walletID, txHash), description)
+  return maindb.put(makeKey(walletID, txHash), description)
 }

--- a/packages/neuron-wallet/src/services/transaction-sender.ts
+++ b/packages/neuron-wallet/src/services/transaction-sender.ts
@@ -9,7 +9,6 @@ import { AddressPrefix } from 'models/keys/address'
 import LockUtils from 'models/lock-utils'
 import AddressService from './addresses'
 import { Address } from 'database/address/address-dao'
-import { set as setDescription } from 'database/leveldb/transaction-description'
 import { PathAndPrivateKey } from 'models/keys/key'
 import AddressesService from 'services/addresses'
 import { CellIsNotYetLive, TransactionIsNotCommittedYet } from 'exceptions/dao'
@@ -48,7 +47,7 @@ export default class TransactionSender {
     this.walletService = WalletsService.getInstance()
   }
 
-  public async sendTx(walletID: string = '', transaction: Transaction, password: string = '', description: string = '') {
+  public async sendTx(walletID: string = '', transaction: Transaction, password: string = '') {
     const tx = this.sign(walletID, transaction, password)
 
     const { ckb } = NodeService.getInstance()
@@ -56,9 +55,6 @@ export default class TransactionSender {
     const txHash = tx.hash!
 
     await TransactionPersistor.saveSentTx(tx, txHash)
-    if (description !== '') {
-      await setDescription(walletID, txHash, description)
-    }
 
     // update addresses txCount and balance
     const blake160s = TransactionsService.blake160sOfTx(tx)

--- a/packages/neuron-wallet/src/services/transaction-sender.ts
+++ b/packages/neuron-wallet/src/services/transaction-sender.ts
@@ -57,7 +57,7 @@ export default class TransactionSender {
 
     await TransactionPersistor.saveSentTx(tx, txHash)
     if (description !== '') {
-      setDescription(walletID, txHash, description)
+      await setDescription(walletID, txHash, description)
     }
 
     // update addresses txCount and balance

--- a/packages/neuron-wallet/src/services/transaction-sender.ts
+++ b/packages/neuron-wallet/src/services/transaction-sender.ts
@@ -9,6 +9,7 @@ import { AddressPrefix } from 'models/keys/address'
 import LockUtils from 'models/lock-utils'
 import AddressService from './addresses'
 import { Address } from 'database/address/address-dao'
+import { set as setDescription } from 'database/leveldb/transaction-description'
 import { PathAndPrivateKey } from 'models/keys/key'
 import AddressesService from 'services/addresses'
 import { CellIsNotYetLive, TransactionIsNotCommittedYet } from 'exceptions/dao'
@@ -54,8 +55,10 @@ export default class TransactionSender {
     await ckb.rpc.sendTransaction(tx.toSDKRawTransaction(), 'passthrough')
     const txHash = tx.hash!
 
-    tx.description = description
     await TransactionPersistor.saveSentTx(tx, txHash)
+    if (description !== '') {
+      setDescription(walletID, txHash, description)
+    }
 
     // update addresses txCount and balance
     const blake160s = TransactionsService.blake160sOfTx(tx)

--- a/packages/neuron-wallet/src/services/tx/transaction-persistor.ts
+++ b/packages/neuron-wallet/src/services/tx/transaction-persistor.ts
@@ -19,7 +19,7 @@ export class TransactionPersistor {
   // After the tx is sent:
   // 1. If the tx is not persisted before sending, output = sent, input = pending
   // 2. If the tx is already persisted before sending, do nothing
-  public static saveWithSent = async (transaction: Transaction): Promise<TransactionEntity> => {
+  private static saveWithSent = async (transaction: Transaction): Promise<TransactionEntity> => {
     const txEntity: TransactionEntity | undefined = await getConnection()
       .getRepository(TransactionEntity)
       .findOne(transaction.hash)
@@ -42,7 +42,7 @@ export class TransactionPersistor {
   // After the tx is fetched:
   // 1. If the tx is not persisted before fetching, output = live, input = dead
   // 2. If the tx is already persisted before fetching, output = live, input = dead
-  public static saveWithFetch = async (transaction: Transaction): Promise<TransactionEntity> => {
+  private static saveWithFetch = async (transaction: Transaction): Promise<TransactionEntity> => {
     const connection = getConnection()
     const txEntity: TransactionEntity | undefined = await connection
       .getRepository(TransactionEntity)
@@ -201,7 +201,7 @@ export class TransactionPersistor {
     tx.blockHash = transaction.blockHash!
     tx.blockNumber = transaction.blockNumber!
     tx.witnesses = transaction.witnessesAsString()
-    tx.description = transaction.description
+    tx.description = '' // tx desc is saved in leveldb as wallet property
     // update tx status here
     tx.status = outputStatus === OutputStatus.Sent ? TransactionStatus.Pending : TransactionStatus.Success
     tx.inputs = []

--- a/packages/neuron-wallet/tests/services/tx/transaction-persistor.test.ts
+++ b/packages/neuron-wallet/tests/services/tx/transaction-persistor.test.ts
@@ -134,10 +134,13 @@ describe('TransactionPersistor', () => {
   describe('saveWithFetch', () => {
     it('multiSignBlake160', async () => {
       const multiSignBlake160 = '0x' + '6'.repeat(40)
+      // @ts-ignore: Private method
       await TransactionPersistor.saveWithFetch(tx)
+      // @ts-ignore: Private method
       await TransactionPersistor.saveWithFetch(tx2)
       const txDup = Transaction.fromObject({ ...tx })
       txDup.outputs[1].setMultiSignBlake160(multiSignBlake160)
+      // @ts-ignore: Private method
       await TransactionPersistor.saveWithFetch(txDup)
       const loadedTx = await getConnection()
         .getRepository(TransactionEntity)


### PR DESCRIPTION
Different wallets having the same transaction should not share the description.