### PR TITLE
feat: enable exporting debug info from helper menu

### DIFF
--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@nervosnetwork/ckb-sdk-core": "0.27.1",
     "@nervosnetwork/ckb-sdk-utils": "0.27.1",
+    "archiver": "3.1.1",
     "bn.js": "4.11.8",
     "chalk": "3.0.0",
     "electron-log": "4.0.0",
@@ -55,6 +56,7 @@
   },
   "devDependencies": {
     "@nervosnetwork/ckb-types": "0.27.1",
+    "@types/archiver": "3.1.0",
     "@types/electron-devtools-installer": "2.2.0",
     "@types/elliptic": "6.4.9",
     "@types/leveldown": "4.0.2",

--- a/packages/neuron-wallet/src/controllers/app/menu.ts
+++ b/packages/neuron-wallet/src/controllers/app/menu.ts
@@ -9,6 +9,7 @@ import {
 import i18n from 'locales/i18n'
 import env from 'env'
 import UpdateController from 'controllers/update'
+import ExportDebugController from 'controllers/export-debug'
 import { showWindow } from 'controllers/app/show-window'
 import WalletsService from 'services/wallets'
 import CommandSubject from 'models/subjects/command'
@@ -269,6 +270,10 @@ const updateApplicationMenu = (mainWindow: BrowserWindow | null) => {
       label: i18n.t('application-menu.help.report-issue'),
       click: () => { shell.openExternal(ExternalURL.Issues) }
     },
+    {
+      label: i18n.t("application-menu.help.export-debug-info"),
+      click: () => { new ExportDebugController().export() }
+    }
   ]
   if (!isMac) {
     helpSubmenu.push(separator)

--- a/packages/neuron-wallet/src/controllers/export-debug.ts
+++ b/packages/neuron-wallet/src/controllers/export-debug.ts
@@ -1,0 +1,88 @@
+import fs from 'fs'
+import path from 'path'
+import archiver from 'archiver'
+import CKB from '@nervosnetwork/ckb-sdk-core'
+import { app, dialog } from 'electron'
+import logger from 'electron-log'
+import i18n from 'locales/i18n'
+import NetworksService from 'services/networks'
+import SyncedBlockNumber from 'models/synced-block-number'
+
+export default class ExportDebugController {
+  archive: archiver.Archiver
+  constructor() {
+    this.archive = archiver('zip', {
+      zlib: { level: 9 }
+    })
+    this.archive.on('error', err => {
+      dialog.showErrorBox(i18n.t('common.error'), err.message)
+    })
+  }
+
+  public async export() {
+    try {
+      const { canceled, filePath } = await dialog.showSaveDialog({
+        title: i18n.t('export-debug-info.export-debug-info'),
+        defaultPath: `neuron_debug_${Date.now()}.zip`
+      })
+      if (canceled || !filePath) {
+        return
+      }
+      this.archive.pipe(fs.createWriteStream(filePath))
+      await this.addStatusFile()
+      this.addLogFiles()
+      await this.archive.finalize()
+      dialog.showMessageBox({
+        type: 'info',
+        message: i18n.t('export-debug-info.debug-info-exported', { file: filePath })
+      })
+    } catch (err) {
+      dialog.showErrorBox(i18n.t('common.error'), err.message)
+    }
+  }
+
+  private addStatusFile = async () => {
+    const neuronVersion = app.getVersion()
+    const url = NetworksService.getInstance().getCurrent().remote
+    const ckb = new CKB(url)
+
+    const [syncedBlockNumber, ckbVersion, tipBlockNumber] = await Promise.all([
+      new SyncedBlockNumber()
+        .getNextBlock()
+        .then(n => n.toString())
+        .catch(() => ''),
+      ckb.rpc
+        .localNodeInfo()
+        .then(res => res.version)
+        .catch(() => ''),
+      ckb.rpc
+        .getTipBlockNumber()
+        .then(n => BigInt(n).toString())
+        .catch(() => '')
+    ])
+    const status = {
+      neuron: {
+        version: neuronVersion,
+        blockNumber: syncedBlockNumber
+      },
+      ckb: {
+        url,
+        version: ckbVersion,
+        blockNumber: tipBlockNumber
+      }
+    }
+    this.archive.append(JSON.stringify(status), {
+      name: 'status.json'
+    })
+  }
+
+  private addLogFiles = (files = ['main.log', 'renderer.log']) => {
+    const logFile = logger.transports.file.getFile()
+    if (!logFile?.path) {
+      return
+    }
+    files.forEach(file => {
+      this.archive.file(path.join(logFile.path, '..', file), { name: file })
+    })
+  }
+}

--- a/packages/neuron-wallet/src/locales/en.ts
+++ b/packages/neuron-wallet/src/locales/en.ts
@@ -49,6 +49,7 @@ export default {
         documentation: 'Documentation',
         faq: 'Neuron FAQ',
         settings: 'Settings',
+        'export-debug-info': 'Export Debug Information'
       },
       develop: {
         develop: 'Develop',
@@ -144,6 +145,11 @@ export default {
       yes: 'Yes',
       no: 'No',
       ok: 'OK',
+      error: 'Error',
     },
+    'export-debug-info':{
+      'export-debug-info': 'Export Debug Information',
+      'debug-info-exported': 'Debug information has been exported to {{ file }}'
+    }
   },
 }

--- a/packages/neuron-wallet/src/locales/zh-tw.ts
+++ b/packages/neuron-wallet/src/locales/zh-tw.ts
@@ -49,6 +49,7 @@ export default {
         documentation: '使用文檔',
         faq: 'Neuron FAQ',
         settings: '設定',
+        'export-debug-info': '導出調試信息',
       },
       develop: {
         develop: '開發',
@@ -142,6 +143,11 @@ export default {
       yes: '是',
       no: '否',
       ok: '確定',
+      error: '錯誤'
     },
   },
+  'export-debug-info':{
+    'export-debug-info': '導出調試信息',
+    'debug-info-exported': '調試信息已被導出至 {{ file }}'
+  }
 }

--- a/packages/neuron-wallet/src/locales/zh.ts
+++ b/packages/neuron-wallet/src/locales/zh.ts
@@ -49,6 +49,7 @@ export default {
         documentation: '使用文档',
         faq: 'Neuron FAQ',
         settings: '设置',
+        'export-debug-info': '导出调试信息',
       },
       develop: {
         develop: '开发',
@@ -143,6 +144,11 @@ export default {
       yes: '是',
       no: '否',
       ok: '确定',
+      error: '错误'
     },
+    'export-debug-info':{
+      'export-debug-info': '导出调试信息',
+      'debug-info-exported': '调试信息已被导出至 {{ file }}'
+    }
   },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3255,6 +3255,13 @@
   resolved "https://registry.yarnpkg.com/@types/abstract-leveldown/-/abstract-leveldown-5.0.1.tgz#3c7750d0186b954c7f2d2f6acc8c3c7ba0c3412e"
   integrity sha512-wYxU3kp5zItbxKmeRYCEplS2MW7DzyBnxPGj+GJVHZEUZiK/nn5Ei1sUFgURDh+X051+zsGe28iud3oHjrYWQQ==
 
+"@types/archiver@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/archiver/-/archiver-3.1.0.tgz#0d5bd922ba5cf06e137cd6793db7942439b1805e"
+  integrity sha512-nTvHwgWONL+iXG+9CX+gnQ/tTOV+qucAjwpXqeUn4OCRMxP42T29FFP/7XaOo0EqqO3TlENhObeZEe7RUJAriw==
+  dependencies:
+    "@types/glob" "*"
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -3357,7 +3364,7 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
-"@types/glob@^7.1.1":
+"@types/glob@*", "@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
   integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
@@ -4398,6 +4405,35 @@ archiver-utils@^1.3.0:
     normalize-path "^2.0.0"
     readable-stream "^2.0.0"
 
+archiver-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/archiver-utils/-/archiver-utils-2.1.0.tgz#e8a460e94b693c3e3da182a098ca6285ba9249e2"
+  integrity sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==
+  dependencies:
+    glob "^7.1.4"
+    graceful-fs "^4.2.0"
+    lazystream "^1.0.0"
+    lodash.defaults "^4.2.0"
+    lodash.difference "^4.5.0"
+    lodash.flatten "^4.4.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.union "^4.6.0"
+    normalize-path "^3.0.0"
+    readable-stream "^2.0.0"
+
+archiver@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/archiver/-/archiver-3.1.1.tgz#9db7819d4daf60aec10fe86b16cb9258ced66ea0"
+  integrity sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==
+  dependencies:
+    archiver-utils "^2.1.0"
+    async "^2.6.3"
+    buffer-crc32 "^0.2.1"
+    glob "^7.1.4"
+    readable-stream "^3.4.0"
+    tar-stream "^2.1.0"
+    zip-stream "^2.1.2"
+
 archiver@~2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/archiver/-/archiver-2.1.1.tgz#ff662b4a78201494a3ee544d3a33fe7496509ebc"
@@ -4657,7 +4693,7 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
-async@^2.0.0, async@^2.1.4, async@^2.6.2:
+async@^2.0.0, async@^2.1.4, async@^2.6.2, async@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
   integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
@@ -5270,6 +5306,13 @@ bl@^1.0.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
+bl@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.1.tgz#8c9b4fb754e80cc86463077722be7b88b4af3f42"
+  integrity sha512-FL/TdvchukRCuWVxT0YMO/7+L5TNeNrVFvRU2IY63aUyv9mpt8splf2NEr6qXtPo5fya5a66YohQKvGNmLrWNA==
+  dependencies:
+    readable-stream "^3.4.0"
+
 blake2b-wasm@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/blake2b-wasm/-/blake2b-wasm-2.1.0.tgz#aa90ed687b8a92e1c01d1643db86bcf21caa2ab7"
@@ -5537,7 +5580,7 @@ buffer-alloc@^1.2.0:
     buffer-alloc-unsafe "^1.1.0"
     buffer-fill "^1.0.0"
 
-buffer-crc32@^0.2.1:
+buffer-crc32@^0.2.1, buffer-crc32@^0.2.13:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
@@ -6368,6 +6411,16 @@ compress-commons@^1.2.0:
     normalize-path "^2.0.0"
     readable-stream "^2.0.0"
 
+compress-commons@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-2.1.1.tgz#9410d9a534cf8435e3fbbb7c6ce48de2dc2f0610"
+  integrity sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==
+  dependencies:
+    buffer-crc32 "^0.2.13"
+    crc32-stream "^3.0.1"
+    normalize-path "^3.0.0"
+    readable-stream "^2.3.6"
+
 compressible@~2.0.16:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"
@@ -6695,6 +6748,14 @@ crc32-stream@^2.0.0:
   dependencies:
     crc "^3.4.4"
     readable-stream "^2.0.0"
+
+crc32-stream@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-3.0.1.tgz#cae6eeed003b0e44d739d279de5ae63b171b4e85"
+  integrity sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==
+  dependencies:
+    crc "^3.4.4"
+    readable-stream "^3.4.0"
 
 crc@^3.4.4:
   version "3.8.0"
@@ -7911,7 +7972,7 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -12364,10 +12425,25 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
+
+lodash.difference@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
+  integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
+
 lodash.escape@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
   integrity sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=
+
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
@@ -12388,6 +12464,11 @@ lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
   integrity sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
 
 lodash.memoize@^4.1.2:
   version "4.1.2"
@@ -12423,6 +12504,11 @@ lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
+
+lodash.union@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
+  integrity sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=
 
 lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   version "4.5.0"
@@ -18211,6 +18297,17 @@ tar-stream@^1.5.0:
     to-buffer "^1.1.1"
     xtend "^4.0.0"
 
+tar-stream@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.2.tgz#6d5ef1a7e5783a95ff70b69b97455a5968dc1325"
+  integrity sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==
+  dependencies:
+    bl "^4.0.1"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+
 tar@^2.0.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.2.tgz#0ca8848562c7299b8b446ff6a4d60cdbb23edc40"
@@ -20118,6 +20215,15 @@ zip-stream@^1.2.0:
     compress-commons "^1.2.0"
     lodash "^4.8.0"
     readable-stream "^2.0.0"
+
+zip-stream@^2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/zip-stream/-/zip-stream-2.1.3.tgz#26cc4bdb93641a8590dd07112e1f77af1758865b"
+  integrity sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==
+  dependencies:
+    archiver-utils "^2.1.0"
+    compress-commons "^2.1.1"
+    readable-stream "^3.4.0"
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
This PR adds a menu item in `help` to export information for debugging.

The information includes `status.json`, `main.log`, `renderer.log` and the `status.json` has the following content.

```json
{
  "neuron": { "version": "0.29.0-rc2", "blockNumber": "4024" },
  "ckb": { "url": "http://localhost:8114", "version": "", "blockNumber": "" }
}
```