### PR TITLE
feat: conceal real node address if it's not localhost for privacy

### DIFF
--- a/packages/neuron-wallet/src/controllers/export-debug.ts
+++ b/packages/neuron-wallet/src/controllers/export-debug.ts
@@ -66,7 +66,7 @@ export default class ExportDebugController {
         blockNumber: syncedBlockNumber
       },
       ckb: {
-        url: /https?:\/\/localhost/.test(url) ? url : 'http://****:port',
+        url: /https?:\/\/(localhost|127.0.0.1)/.test(url) ? url : 'http://****:port',
         version: ckbVersion,
         blockNumber: tipBlockNumber
       }

--- a/packages/neuron-wallet/src/controllers/export-debug.ts
+++ b/packages/neuron-wallet/src/controllers/export-debug.ts
@@ -66,7 +66,7 @@ export default class ExportDebugController {
         blockNumber: syncedBlockNumber
       },
       ckb: {
-        url,
+        url: /https?:\/\/localhost/.test(url) ? url : 'http://****:port',
         version: ckbVersion,
         blockNumber: tipBlockNumber
       }


### PR DESCRIPTION
URL not starts with `http://localhost` or `https://localhost` will be replaced with `http://****:port` in the status.json