### PR TITLE
feat: update the style of block number tooltip

### DIFF
--- a/packages/neuron-ui/src/components/NetworkStatus/networkStatus.module.scss
+++ b/packages/neuron-ui/src/components/NetworkStatus/networkStatus.module.scss
@@ -63,8 +63,7 @@ $hover-bg-color: #3cc68a4d;
   background-color: #fff;
   color: #000;
   min-width: 140px;
-  padding: 5px;
-  font-size: inherit;
+  padding: 8px 10px;
   border-radius: 1px;
   box-sizing: border-box;
   box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.22);
@@ -72,11 +71,9 @@ $hover-bg-color: #3cc68a4d;
   opacity: 0;
   user-select: none;
   pointer-events: none;
-  font-size: 0.5625rem;
-  font-weight: 100;
-  line-height: 0.8125rem;
-  color: #666;
-  letter-spacing: 0.45px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.5em;
 
   .tooltipTitle {
     grid-area: title;


### PR DESCRIPTION
1. set the font size 12px
2. set the color #000

![image](https://user-images.githubusercontent.com/7271329/77044123-d7695880-69f9-11ea-8990-8230024bcf00.png)
