### PR TITLE
feat: align the block number tooltip closer to the side

### DIFF
--- a/packages/neuron-ui/src/components/NetworkStatus/networkStatus.module.scss
+++ b/packages/neuron-ui/src/components/NetworkStatus/networkStatus.module.scss
@@ -56,13 +56,14 @@ $hover-bg-color: #3cc68a4d;
   display: none;
   position: absolute;
   bottom: calc(100% + 10px);
-  left: 30px;
+  left: 12px;
   display: grid;
   grid-template:
-    'title title'auto 'label value'auto/ 100px 1fr;
+    'title title'auto 'label value'auto/ auto 1fr;
+  column-gap: 5px;
   background-color: #fff;
   color: #000;
-  min-width: 140px;
+  min-width: 176px;
   padding: 8px 10px;
   border-radius: 1px;
   box-sizing: border-box;
@@ -74,6 +75,7 @@ $hover-bg-color: #3cc68a4d;
   font-size: 0.75rem;
   font-weight: 500;
   line-height: 1.5em;
+  white-space: nowrap;
 
   .tooltipTitle {
     grid-area: title;


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/7271329/77078427-870ded00-6a31-11ea-99bf-fa1330fa6d83.png)
After
![image](https://user-images.githubusercontent.com/7271329/77078430-89704700-6a31-11ea-80a8-8a4ea0e160c2.png)
