### PR TITLE
Improve bundled CKB startup process

### DIFF
--- a/packages/neuron-wallet/src/controllers/app/index.ts
+++ b/packages/neuron-wallet/src/controllers/app/index.ts
@@ -8,6 +8,8 @@ import logger from 'utils/logger'
 import { subscribe } from './subscribe'
 import { register as registerListeners } from 'listeners/main'
 import WalletsService from 'services/wallets'
+import RpcService from 'services/rpc-service'
+import NetworksService from 'services/networks'
 import ApiController from 'controllers/api'
 import NodeController from 'controllers/node'
 import SyncApiController from 'controllers/sync-api'
@@ -25,7 +27,14 @@ export default class AppController {
 
   public start = async () => {
     if (!env.isTestMode) {
-      await new NodeController().startNode()
+      const rpcService = new RpcService(NetworksService.getInstance().defaultOne().remote)
+      const chain = await rpcService.getChain().catch(() => '')
+      if (chain === '') {
+        // Pinging default network fail; assume no external CKB is running.
+        await new NodeController().startNode()
+      } else {
+        logger.info('CKB:\texternal RPC detected, skip starting bundled CKB node.')
+      }
     }
 
     registerListeners()


### PR DESCRIPTION
* If external CKB is running (by guessing from RPC call), do NOT spawn the bundled CKB.
* If `ckb.toml` under the bundled CKB's data folder exists, do NOT run `ckb init`.