### PR TITLE
feat: add 10s buffer to display connection error for launching ckb node

### DIFF
--- a/packages/neuron-ui/src/components/NervosDAO/index.tsx
+++ b/packages/neuron-ui/src/components/NervosDAO/index.tsx
@@ -7,7 +7,7 @@ import { useState as useGlobalState, useDispatch } from 'states/stateProvider'
 
 import calculateFee from 'utils/calculateFee'
 import { shannonToCKBFormatter } from 'utils/formatters'
-import { MIN_DEPOSIT_AMOUNT, SyncStatus, ConnectionStatus } from 'utils/const'
+import { MIN_DEPOSIT_AMOUNT, SyncStatus, SyncStatusThatBalanceUpdating, ConnectionStatus } from 'utils/const'
 import { epochParser } from 'utils/parsers'
 import { backToTop } from 'utils/animations'
 import getSyncStatus from 'utils/getSyncStatus'
@@ -273,7 +273,7 @@ const NervosDAO = () => {
         {t('sync.sync-not-start')}
       </span>
     )
-  } else if ([SyncStatus.Syncing, SyncStatus.SyncPending].includes(syncStatus)) {
+  } else if (SyncStatusThatBalanceUpdating.includes(syncStatus) || ConnectionStatus.Connecting === connectionStatus) {
     balancePrompt = <span className={styles.balancePrompt}>{t('sync.syncing-balance')}</span>
   }
 

--- a/packages/neuron-ui/src/components/NervosDAORecord/index.tsx
+++ b/packages/neuron-ui/src/components/NervosDAORecord/index.tsx
@@ -20,7 +20,7 @@ export interface DAORecordProps extends State.NervosDAORecord {
   withdrawCapacity: string | null // capacity that is available for withdraw
   tipBlockTimestamp: number // tip block timestamp, used to calculate apc
   genesisBlockTimestamp: number | undefined // genesis block timestamp, used to calculate apc
-  connectionStatus: 'online' | 'offline' // connection status
+  connectionStatus: 'online' | 'offline' | 'connecting' // connection status
   onClick: React.EventHandler<React.MouseEvent> // on action button click
   onCompensationPeriodExplanationClick: React.EventHandler<any> // on compensation dialog trigger click
 }

--- a/packages/neuron-ui/src/components/Overview/index.tsx
+++ b/packages/neuron-ui/src/components/Overview/index.tsx
@@ -11,7 +11,14 @@ import { updateTransactionList } from 'states/stateProvider/actionCreators'
 import { localNumberFormatter, shannonToCKBFormatter, uniformTimeFormatter } from 'utils/formatters'
 import getSyncStatus from 'utils/getSyncStatus'
 import getCurrentUrl from 'utils/getCurrentUrl'
-import { SyncStatus as SyncStatusEnum, ConnectionStatus, PAGE_SIZE, Routes, CONFIRMATION_THRESHOLD } from 'utils/const'
+import {
+  SyncStatus as SyncStatusEnum,
+  SyncStatusThatBalanceUpdating,
+  ConnectionStatus,
+  PAGE_SIZE,
+  Routes,
+  CONFIRMATION_THRESHOLD,
+} from 'utils/const'
 import { backToTop } from 'utils/animations'
 import styles from './overview.module.scss'
 
@@ -98,7 +105,7 @@ const Overview = () => {
           {t('sync.sync-not-start')}
         </span>
       )
-    } else if ([SyncStatusEnum.Syncing, SyncStatusEnum.SyncPending].includes(syncStatus)) {
+    } else if (SyncStatusThatBalanceUpdating.includes(syncStatus) || ConnectionStatus.Connecting === connectionStatus) {
       prompt = <span className={styles.balancePrompt}>{t('sync.syncing-balance')}</span>
     }
     return [

--- a/packages/neuron-ui/src/components/Send/index.tsx
+++ b/packages/neuron-ui/src/components/Send/index.tsx
@@ -26,6 +26,7 @@ import {
   MAX_DECIMAL_DIGITS,
   MAINNET_TAG,
   SyncStatus,
+  SyncStatusThatBalanceUpdating,
   ConnectionStatus,
   SINCE_FIELD_SIZE,
 } from 'utils/const'
@@ -164,7 +165,7 @@ const Send = () => {
         {t('sync.sync-not-start')}
       </span>
     )
-  } else if ([SyncStatus.Syncing, SyncStatus.SyncPending].includes(syncStatus)) {
+  } else if (SyncStatusThatBalanceUpdating.includes(syncStatus) || ConnectionStatus.Connecting === connectionStatus) {
     balancePrompt = <span className={styles.balancePrompt}>{t('sync.syncing-balance')}</span>
   }
 

--- a/packages/neuron-ui/src/components/SyncStatus/index.tsx
+++ b/packages/neuron-ui/src/components/SyncStatus/index.tsx
@@ -11,12 +11,12 @@ const SyncStatus = ({
 }>) => {
   const [t] = useTranslation()
 
-  if (connectionStatus === ConnectionStatus.Offline) {
-    return <span style={{ color: 'red' }}>{t('sync.sync-failed')}</span>
+  if (ConnectionStatus.Connecting === connectionStatus || SyncStatusEnum.FailToFetchTipBlock === syncStatus) {
+    return <span>{t('navbar.connecting')}</span>
   }
 
-  if (SyncStatusEnum.FailToFetchTipBlock === syncStatus) {
-    return <span>{t('navbar.fail-to-fetch-tip-block-number')}</span>
+  if (connectionStatus === ConnectionStatus.Offline) {
+    return <span style={{ color: 'red' }}>{t('sync.sync-failed')}</span>
   }
 
   if (SyncStatusEnum.SyncNotStart === syncStatus) {

--- a/packages/neuron-ui/src/locales/en.json
+++ b/packages/neuron-ui/src/locales/en.json
@@ -19,8 +19,8 @@
       "settings": "Settings",
       "nervos-dao": "Nervos DAO",
       "special-assets": "Customized Assets",
-      "fail-to-fetch-tip-block-number": "Connection error",
-      "sync-not-start": "Sync not started yet"
+      "sync-not-start": "Sync not started yet",
+      "connecting": "Connecting"
     },
     "network-status": {
       "tooltip": {
@@ -245,7 +245,7 @@
       "backup": {
         "title": "Backup the {{name}} wallet"
       },
-      "unlock":{
+      "unlock": {
         "title": "Please input wallet password to claim the asset"
       }
     },

--- a/packages/neuron-ui/src/locales/zh-tw.json
+++ b/packages/neuron-ui/src/locales/zh-tw.json
@@ -19,8 +19,8 @@
       "settings": "設定",
       "nervos-dao": "Nervos DAO",
       "special-assets": "自定義資產",
-      "fail-to-fetch-tip-block-number": "未連接到節點",
-      "sync-not-start": "同步尚未開始"
+      "sync-not-start": "同步尚未開始",
+      "connecting": "正在連接節點"
     },
     "network-status": {
       "tooltip": {
@@ -344,8 +344,8 @@
       "block-number": "區塊高度",
       "syncing-balance": "區塊同步中, 正在獲取最新余額",
       "slow": "同步緩慢，請檢查網絡",
-      "sync-failed": "连接失败, 请检查网络",
-      "sync-not-start": "同步尚未开始, 请尝试重启"
+      "sync-failed": "連接失敗, 請檢查網絡",
+      "sync-not-start": "同步尚未開始, 請嘗試重啟"
     },
     "pagination": {
       "previous-page": "上一頁",

--- a/packages/neuron-ui/src/locales/zh.json
+++ b/packages/neuron-ui/src/locales/zh.json
@@ -19,8 +19,8 @@
       "settings": "设置",
       "nervos-dao": "Nervos DAO",
       "special-assets": "自定义资产",
-      "fail-to-fetch-tip-block-number": "未连接到节点",
-      "sync-not-start": "同步尚未开始"
+      "sync-not-start": "同步尚未开始",
+      "connecting": "正在连接节点"
     },
     "network-status": {
       "tooltip": {

--- a/packages/neuron-ui/src/states/initStates/chain.ts
+++ b/packages/neuron-ui/src/states/initStates/chain.ts
@@ -23,7 +23,7 @@ export const transactionState: Readonly<State.DetailedTransaction> = {
 
 const chainState: Readonly<State.Chain> = {
   networkID: currentNetworkID.load(),
-  connectionStatus: ConnectionStatus.Offline,
+  connectionStatus: ConnectionStatus.Connecting,
   tipBlockNumber: '',
   transactions: {
     pageNo: 1,

--- a/packages/neuron-ui/src/states/stateProvider/reducer.ts
+++ b/packages/neuron-ui/src/states/stateProvider/reducer.ts
@@ -116,7 +116,7 @@ export const reducer = produce((state: Draft<State.AppWithNeuronWallet>, action:
       Object.assign(state.chain, {
         networkID,
         transactions,
-        connectionStatus: connectionStatus ? ConnectionStatus.Online : ConnectionStatus.Offline,
+        connectionStatus: connectionStatus ? ConnectionStatus.Online : ConnectionStatus.Connecting,
         tipBlockNumber: syncedBlockNumber,
       })
       Object.assign(state.settings, { networks, wallets })

--- a/packages/neuron-ui/src/types/App/index.d.ts
+++ b/packages/neuron-ui/src/types/App/index.d.ts
@@ -137,7 +137,7 @@ declare namespace State {
     readonly balance: string
     readonly addresses: Readonly<Address[]>
   }
-  type ConnectionStatus = 'online' | 'offline'
+  type ConnectionStatus = 'online' | 'offline' | 'connecting'
 
   interface Chain {
     readonly networkID: string

--- a/packages/neuron-ui/src/utils/const.ts
+++ b/packages/neuron-ui/src/utils/const.ts
@@ -24,12 +24,15 @@ export const WITHDRAW_EPOCHS = 180
 export const IMMATURE_EPOCHS = 4
 export const MILLISECONDS_IN_YEAR = 365 * 24 * 3600 * 1000
 
+export const CONNECTING_DEADLINE = Date.now() + 10_000
+
 export const NERVOS_DAO_RFC_URL =
   'https://www.github.com/nervosnetwork/rfcs/blob/master/rfcs/0023-dao-deposit-withdraw/0023-dao-deposit-withdraw.md'
 
 export enum ConnectionStatus {
   Online = 'online',
   Offline = 'offline',
+  Connecting = 'connecting',
 }
 
 export enum Routes {
@@ -120,6 +123,8 @@ export enum SyncStatus {
   Syncing,
   SyncCompleted,
 }
+
+export const SyncStatusThatBalanceUpdating = [SyncStatus.Syncing, SyncStatus.SyncPending]
 
 export enum PRESET_SCRIPT {
   Locktime = 'SingleMultiSign',


### PR DESCRIPTION
ConnectionStatus.Connecting will be displayed in the first 10s since app launchs while the sync in is under error.

This status is for better UX during launching the CKB node.