### PR TITLE
feat: remove the sync status of failing to get tip block number

### DIFF
--- a/packages/neuron-ui/src/components/SyncStatus/index.tsx
+++ b/packages/neuron-ui/src/components/SyncStatus/index.tsx
@@ -11,7 +11,7 @@ const SyncStatus = ({
 }>) => {
   const [t] = useTranslation()
 
-  if (ConnectionStatus.Connecting === connectionStatus || SyncStatusEnum.FailToFetchTipBlock === syncStatus) {
+  if (ConnectionStatus.Connecting === connectionStatus) {
     return <span>{t('navbar.connecting')}</span>
   }
 

--- a/packages/neuron-ui/src/utils/const.ts
+++ b/packages/neuron-ui/src/utils/const.ts
@@ -117,7 +117,6 @@ export enum ErrorCode {
 }
 
 export enum SyncStatus {
-  FailToFetchTipBlock,
   SyncNotStart,
   SyncPending,
   Syncing,

--- a/packages/neuron-ui/src/utils/getSyncStatus.ts
+++ b/packages/neuron-ui/src/utils/getSyncStatus.ts
@@ -25,10 +25,7 @@ export default ({
   }
 
   const now = Math.floor(currentTimestamp / 1000) * 1000
-  if (tipBlockNumber === '') {
-    return SyncStatus.FailToFetchTipBlock
-  }
-  if (BigInt(syncedBlockNumber) < BigInt(0) || tipBlockNumber === '0') {
+  if (BigInt(syncedBlockNumber) < BigInt(0) || tipBlockNumber === '0' || tipBlockNumber === '') {
     return SyncStatus.SyncNotStart
   }
 


### PR DESCRIPTION
It's a technical status and was used to avoid errors in the progress bar.  In most cases it is non-sense to users and is covered by ConnectionStatus.Offline.