### PR TITLE
feat: update the tooltip message of immature for withdraw stage

### DIFF
--- a/packages/neuron-ui/src/components/CompensationPeriodTooltip/compensationPeriodTooltip.module.scss
+++ b/packages/neuron-ui/src/components/CompensationPeriodTooltip/compensationPeriodTooltip.module.scss
@@ -42,6 +42,7 @@ $arrow-size: 10px;
       color: #000;
     }
 
+    .immature,
     .normal,
     .suggested,
     .ending {
@@ -60,8 +61,11 @@ $arrow-size: 10px;
         height: 13px;
       }
     }
+    .immature{
+      font-weight: 900;
+    }
 
-    .normal::before {
+    .normal::before,.immature::before {
       background-color: $tile-grey;
     }
 
@@ -93,7 +97,6 @@ $arrow-size: 10px;
   }
 
   &[data-stage='ending'] {
-
     .normal,
     .suggested {
       display: none;
@@ -117,6 +120,6 @@ $arrow-size: 10px;
     height: 0;
     border: $arrow-size solid transparent;
     border-bottom-color: #fff;
-    filter: drop-shadow(0px -1px 1px rgba(0, 0, 0, 0.1))
+    filter: drop-shadow(0px -1px 1px rgba(0, 0, 0, 0.1));
   }
 }

--- a/packages/neuron-ui/src/components/CompensationPeriodTooltip/index.tsx
+++ b/packages/neuron-ui/src/components/CompensationPeriodTooltip/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import getCompensationPeriod from 'utils/getCompensationPeriod'
 import getCompensatedTime from 'utils/getCompensatedTime'
-import { WITHDRAW_EPOCHS, CompensationPeriod } from 'utils/const'
+import { WITHDRAW_EPOCHS, CompensationPeriod, IMMATURE_EPOCHS } from 'utils/const'
 import { uniformTimeFormatter } from 'utils/formatters'
 import styles from './compensationPeriodTooltip.module.scss'
 
@@ -46,13 +46,31 @@ const CompensationPeriodTooltip = ({
     endEpochTimestamp - (1 - CompensationPeriod.SUGGEST_START) * WITHDRAW_EPOCHS * HOURS_PER_EPOCH
   const endingStartEpochTimestamp =
     endEpochTimestamp - (1 - CompensationPeriod.REQUEST_START) * WITHDRAW_EPOCHS * HOURS_PER_EPOCH
+
+  const { days, hours } = getCompensatedTime({ currentEpochValue: baseEpochValue, depositEpochValue })
+  const isImmature = baseEpochValue < depositEpochValue + IMMATURE_EPOCHS
+
+  if (isImmature) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.compensated}>
+          <span>{t('nervos-dao.compensation-period.tooltip.compensated-period')}</span>
+          <span>{t('nervos-dao.compensation-period.tooltip.days-hours', { days, hours })}</span>
+        </div>
+        <div className={styles.divider} />
+        <div className={styles.times}>
+          <div className={styles.immature}>{t('nervos-dao.compensation-period.tooltip.immature-for-withdraw')}</div>
+        </div>
+      </div>
+    )
+  }
+
   let stage = 'normal'
   if (baseEpochTimestamp > endingStartEpochTimestamp) {
     stage = 'ending'
   } else if (baseEpochTimestamp > suggestStartEpochTimestamp) {
     stage = 'suggested'
   }
-  const { days, hours } = getCompensatedTime({ currentEpochValue: baseEpochValue, depositEpochValue })
 
   if (isWithdrawn) {
     return (

--- a/packages/neuron-ui/src/locales/en.json
+++ b/packages/neuron-ui/src/locales/en.json
@@ -396,6 +396,7 @@
         "tooltip": {
           "compensated-period": "Compensated Period",
           "days-hours": "{{days}} days {{hours}} hours",
+          "immature-for-withdraw": "It takes at least about 16 hours (4epochs) to proceed the next action",
           "normal": "Compensation amount is low, withdraw action is not recommended",
           "suggested": "Suggested withdraw period for maximized compensation",
           "ending": "Requested withdraw may be postponed and locked for an extra cycle of 30 days",

--- a/packages/neuron-ui/src/locales/zh-tw.json
+++ b/packages/neuron-ui/src/locales/zh-tw.json
@@ -396,6 +396,7 @@
         "tooltip": {
           "compensated-period": "已鎖定時間",
           "days-hours": "{{days}} 天 {{hours}} 小時",
+          "immature-for-withdraw": "Nervos DAO 要求至少約 16 小時 (4 個 Epochs) 才能進行下一步操作",
           "normal": "補償數量較低，不建議發起提現交易",
           "suggested": "建議在此區間提取以獲得最大化補償",
           "ending": "提取請求可能被推遲並鎖定 30 天",

--- a/packages/neuron-ui/src/locales/zh.json
+++ b/packages/neuron-ui/src/locales/zh.json
@@ -396,6 +396,7 @@
         "tooltip": {
           "compensated-period": "已锁定时间",
           "days-hours": "{{days}} 天 {{hours}} 小时",
+          "immature-for-withdraw": "Nervos DAO 要求至少约 16 小时 (4 个 Epochs) 才能进行下一步操作",
           "normal": "补偿数量较低，不建议发起提现交易",
           "suggested": "建议在此区间提取以获得最大化补偿",
           "ending": "提取请求可能被推迟并锁定 30 天",

--- a/packages/neuron-ui/src/stories/CompensationPeriodTooltip.stories.tsx
+++ b/packages/neuron-ui/src/stories/CompensationPeriodTooltip.stories.tsx
@@ -8,7 +8,7 @@ const props: { [index: string]: CompensationPeriodTooltipProps } = {
   normalStart: {
     depositEpochValue: 0,
     baseEpochTimestamp: Date.now(),
-    baseEpochValue: 0,
+    baseEpochValue: 4,
     endEpochValue: 180,
   },
   normalEnd: {
@@ -55,6 +55,12 @@ const props: { [index: string]: CompensationPeriodTooltipProps } = {
     baseEpochValue: 174.25,
     endEpochValue: 180,
     isWithdrawn: true,
+  },
+  'immature for withdraw': {
+    depositEpochValue: 1,
+    baseEpochTimestamp: Date.now(),
+    baseEpochValue: 4.9,
+    endEpochValue: 181,
   },
   'base less than deposit': {
     depositEpochValue: 1,


### PR DESCRIPTION
When it's in 16h since deposition, the tooltip of Nervos DAO Record should be "It takes at least about 16 hours (4epochs) to proceed the next action"