### PR TITLE
[ᚬsUDT] feat: adjust the layout of transaction history

### DIFF
--- a/packages/neuron-ui/src/components/Transaction/index.tsx
+++ b/packages/neuron-ui/src/components/Transaction/index.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, useMemo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Icon } from 'office-ui-fabric-react'
 import { currentWallet as currentWalletCache } from 'services/localCache'
 import {
   getSystemCodeHash,
@@ -8,7 +7,6 @@ import {
   showErrorMessage,
   getAllNetworks,
   getCurrentNetworkID,
-  openExternal,
 } from 'services/remote'
 import { ckbCore } from 'services/chain'
 
@@ -81,11 +79,6 @@ const Transaction = () => {
   }, [t])
 
   useExitOnWalletChange()
-
-  const onExplorerBtnClick = useCallback(() => {
-    const explorerUrl = isMainnet ? 'https://explorer.nervos.org' : 'https://explorer.nervos.org/aggron'
-    openExternal(`${explorerUrl}/transaction/${transaction.hash}`)
-  }, [transaction.hash, isMainnet])
 
   const basicInfoItems = useMemo(
     () => [
@@ -213,16 +206,6 @@ const Transaction = () => {
         </thead>
         <tbody>{renderList(transaction.outputs)}</tbody>
       </table>
-
-      <button
-        type="button"
-        className={styles.explorerNavButton}
-        title={t('transaction.view-in-explorer-button-title')}
-        onClick={onExplorerBtnClick}
-      >
-        <Icon iconName="Explorer" />
-        <span>{t('transaction.view-in-explorer')}</span>
-      </button>
     </div>
   )
 }

--- a/packages/neuron-ui/src/components/Transaction/transaction.module.scss
+++ b/packages/neuron-ui/src/components/Transaction/transaction.module.scss
@@ -2,8 +2,7 @@
 
 .container {
   display: grid;
-  grid-template:
-    'info-title'auto 'info-detail'auto 'inputs-title'auto 'inputs'auto 'outputs-title'auto 'outputs'auto / 1fr;
+  grid-template: 'info-title' auto 'info-detail' auto 'inputs-title' auto 'inputs' auto 'outputs-title' auto 'outputs' auto / 1fr;
   grid-row-gap: 15px;
 
   table {
@@ -57,8 +56,6 @@
     max-width: calc(90vw - 416px);
     padding-right: 15px;
   }
-
-
 }
 
 .infoTitle,
@@ -82,7 +79,7 @@
   grid-area: info-detail;
   margin-bottom: 21px;
 
-  &>div {
+  & > div {
     display: flex;
     justify-content: space-between;
     pointer-events: none;
@@ -111,46 +108,6 @@
 
 .outputList {
   grid-area: outputs;
-}
-
-.explorerNavButton {
-  position: fixed;
-  right: 15px;
-  bottom: 15px;
-  height: 30px;
-  width: 30px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  font-size: 12px;
-  color: #fff;
-  background: rgba(60, 198, 138, 0.8);
-  border: none;
-  border-radius: 15px;
-  transition: all 0.2s;
-  z-index: 1;
-
-  span {
-    display: none;
-  }
-
-  i {
-    display: flex;
-  }
-
-  &:hover {
-    width: 100px;
-    border-radius: 2px;
-
-    span {
-      display: flex;
-    }
-
-    i {
-      display: none;
-    }
-  }
 }
 
 .error {

--- a/packages/neuron-ui/src/components/TransactionList/index.tsx
+++ b/packages/neuron-ui/src/components/TransactionList/index.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Icon } from 'office-ui-fabric-react'
+import { ReactComponent as Detail } from 'widgets/Icons/Detail.svg'
 import TextField from 'widgets/TextField'
 
 import { StateDispatch } from 'states/stateProvider/reducer'
@@ -83,14 +85,28 @@ const TransactionList = ({
     [isMainnet, t]
   )
 
-  const onDoubleClick = useCallback((e: React.SyntheticEvent<HTMLDivElement>) => {
-    const {
-      dataset: { hash },
-    } = e.target as HTMLDivElement
-    if (hash) {
-      showTransactionDetails(hash)
-    }
-  }, [])
+  const onActionBtnClick = useCallback(
+    (e: React.SyntheticEvent<HTMLButtonElement>) => {
+      const btn = (e.target as HTMLButtonElement)?.closest('button')
+      if (btn?.dataset?.hash && btn?.dataset?.action) {
+        switch (btn.dataset.action) {
+          case 'explorer': {
+            const explorerUrl = isMainnet ? 'https://explorer.nervos.org' : 'https://explorer.nervos.org/aggron'
+            openExternal(`${explorerUrl}/transaction/${btn.dataset.hash}`)
+            break
+          }
+          case 'detail': {
+            showTransactionDetails(btn.dataset.hash)
+            break
+          }
+          default: {
+            // ignore
+          }
+        }
+      }
+    },
+    [isMainnet]
+  )
 
   return (
     <>
@@ -117,7 +133,6 @@ const TransactionList = ({
               data-status={status}
               onClick={onTxClick}
               onContextMenu={onContextMenu}
-              onDoubleClick={onDoubleClick}
               onKeyPress={() => {}}
             >
               <time title={tx.timestamp}>{timeFormatter(tx.timestamp)}</time>
@@ -148,22 +163,44 @@ const TransactionList = ({
               </div>
               <div title={tx.description} className={styles.description}>
                 <span>{t('history.description')}</span>
-                <span>
-                  <TextField
-                    field="description"
-                    data-description-key={tx.hash}
-                    data-description-value={tx.description}
-                    title={tx.description}
-                    value={isSelected ? localDescription.description : tx.description || ''}
-                    onBlur={isSelected ? onDescriptionFieldBlur : undefined}
-                    onKeyPress={isSelected ? onDescriptionPress : undefined}
-                    onChange={isSelected ? onDescriptionChange : undefined}
-                    readOnly={!isSelected}
-                    onClick={onDescriptionSelected}
-                    className={styles.descriptionField}
-                    placeholder={t('common.click-to-edit')}
-                  />
-                </span>
+                <TextField
+                  field="description"
+                  data-description-key={tx.hash}
+                  data-description-value={tx.description}
+                  title={tx.description}
+                  value={isSelected ? localDescription.description : tx.description || ''}
+                  onBlur={isSelected ? onDescriptionFieldBlur : undefined}
+                  onKeyPress={isSelected ? onDescriptionPress : undefined}
+                  onChange={isSelected ? onDescriptionChange : undefined}
+                  readOnly={!isSelected}
+                  onClick={onDescriptionSelected}
+                  className={styles.descriptionField}
+                  placeholder={t('common.click-to-edit')}
+                />
+              </div>
+              <div className={styles.footer}>
+                <button
+                  type="button"
+                  className={styles.detailNavButton}
+                  title={t('history.view-detail-button-title')}
+                  onClick={onActionBtnClick}
+                  data-hash={tx.hash}
+                  data-action="detail"
+                >
+                  <Detail />
+                  <span>{t('history.view-detail')}</span>
+                </button>
+                <button
+                  type="button"
+                  className={styles.explorerNavButton}
+                  title={t('history.view-in-explorer-button-title')}
+                  onClick={onActionBtnClick}
+                  data-hash={tx.hash}
+                  data-action="explorer"
+                >
+                  <Icon iconName="Explorer" />
+                  <span>{t('history.view-in-explorer')}</span>
+                </button>
               </div>
             </div>
           </div>

--- a/packages/neuron-ui/src/components/TransactionList/transactionList.module.scss
+++ b/packages/neuron-ui/src/components/TransactionList/transactionList.module.scss
@@ -21,8 +21,7 @@ $pending-color: #b3b3b3;
     @include MediumText;
     position: relative;
     display: grid;
-    grid-template:
-      'time status'auto 'amount confirmations'auto/ 1fr 130px;
+    grid-template: 'time status' auto 'amount confirmations' auto/ 1fr 130px;
     justify-items: start;
     grid-gap: 3px;
     padding: 15px 0 15px 33px;
@@ -88,7 +87,6 @@ $pending-color: #b3b3b3;
     }
 
     &[data-status='success']:after {
-
       background-color: $success-color;
     }
 
@@ -97,24 +95,23 @@ $pending-color: #b3b3b3;
     }
   }
 
-
   .detail {
     padding: 0 33px;
     display: none;
     color: #434343;
 
-    &>div {
+    & > div {
       display: flex;
       justify-content: space-between;
-      margin-bottom: 15px;
+      margin-bottom: 10px;
 
-      &>span:first-of-type {
+      & > span:first-of-type {
         @include MediumText;
       }
     }
 
     .txHash {
-      &>div {
+      & > div {
         display: flex;
 
         .hashOverflow {
@@ -135,7 +132,7 @@ $pending-color: #b3b3b3;
           }
 
           .ellipsis {
-            display: inline
+            display: inline;
           }
         }
 
@@ -149,40 +146,98 @@ $pending-color: #b3b3b3;
 
     .description {
       display: flex;
+      flex-direction: column;
       justify-content: space-between;
-      align-items: center;
+      align-items: flex-start;
     }
 
     .descriptionField {
       @include descriptionField;
+      width: 100%;
 
-      &>div {
+      & > div {
+        margin-top: 10px;
         border-top: none !important;
         border-left: none !important;
         border-right: none !important;
+        border-bottom: 1px solid #aaaaaa !important;
+        padding-bottom: 3px;
+        width: 100%;
       }
 
       input {
         font-size: 0.875rem;
-        text-align: right;
         padding: 0;
         border: none;
+        color: #434343;
 
         &:not(:focus)::-webkit-input-placeholder {
           font-size: 0.75rem;
-          text-align: right;
         }
       }
     }
   }
 
-  &[data-is-open="true"] {
+  &[data-is-open='true'] {
     .summary:before {
       transform: translateY(-50%) rotate(90deg);
     }
 
     .detail {
       display: block;
+    }
+  }
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end !important;
+  @mixin navButton {
+    height: 30px;
+    width: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    font-size: 12px;
+    color: #fff;
+    border: none;
+    border-radius: 15px;
+    transition: all 0.2s;
+    margin-left: 10px;
+
+    span {
+      display: none;
+    }
+
+    i,
+    svg {
+      display: flex;
+    }
+
+    &:hover {
+      width: 100px;
+      border-radius: 2px;
+
+      span {
+        display: flex;
+      }
+
+      i,
+      svg {
+        display: none;
+      }
+    }
+  }
+  .explorerNavButton {
+    @include navButton;
+    background: rgba(60, 198, 138, 0.8);
+  }
+  .detailNavButton {
+    @include navButton;
+    background: #5353c9;
+    svg {
+      height: 16px;
     }
   }
 }

--- a/packages/neuron-ui/src/locales/en.json
+++ b/packages/neuron-ui/src/locales/en.json
@@ -161,7 +161,11 @@
       "confirming-with-count": "{{confirmations}} Confirmations",
       "view-on-explorer": "View on Explorer",
       "copy-transaction-hash": "Copy Transaction Hash",
-      "no-txs": "No Transaction History"
+      "no-txs": "No Transaction History",
+      "view-in-explorer": "Explorer",
+      "view-in-explorer-button-title": "View on explorer",
+      "view-detail": "Detail",
+      "view-detail-button-title": "View Detail"
     },
     "transaction": {
       "date": "Date",
@@ -174,8 +178,6 @@
       "amount": "Amount",
       "inputs": "Inputs",
       "outputs": "Outputs",
-      "view-in-explorer": "Explorer",
-      "view-in-explorer-button-title": "View on explorer",
       "cell-from-cellbase": "From cellbase"
     },
     "addresses": {

--- a/packages/neuron-ui/src/locales/zh-tw.json
+++ b/packages/neuron-ui/src/locales/zh-tw.json
@@ -161,7 +161,11 @@
       "confirming-with-count": "已確認 {{confirmations}} 次",
       "view-on-explorer": "在瀏覽器中查看",
       "copy-transaction-hash": "複製交易雜湊",
-      "no-txs": "沒有交易記錄"
+      "no-txs": "沒有交易記錄",
+      "view-in-explorer": "瀏覽器",
+      "view-in-explorer-button-title": "瀏覽器中查看詳情",
+      "view-detail": "詳情",
+      "view-detail-button-title": "查看詳情"
     },
     "transaction": {
       "date": "時間",
@@ -174,8 +178,6 @@
       "amount": "數量",
       "inputs": "輸入",
       "outputs": "輸出",
-      "view-in-explorer": "瀏覽器",
-      "view-in-explorer-button-title": "瀏覽器中查看詳情",
       "cell-from-cellbase": "來自 Cellbase"
     },
     "addresses": {

--- a/packages/neuron-ui/src/locales/zh.json
+++ b/packages/neuron-ui/src/locales/zh.json
@@ -161,7 +161,11 @@
       "confirming-with-count": " 已确认 {{confirmations}} 次",
       "view-on-explorer": "在浏览器中查看",
       "copy-transaction-hash": "复制交易哈希",
-      "no-txs": "没有交易记录"
+      "no-txs": "没有交易记录",
+      "view-in-explorer": "浏览器",
+      "view-in-explorer-button-title": "浏览器中查看详情",
+      "view-detail": "详情",
+      "view-detail-button-title": "查看详情"
     },
     "transaction": {
       "date": "时间",
@@ -174,8 +178,6 @@
       "amount": "数量",
       "inputs": "输入",
       "outputs": "输出",
-      "view-in-explorer": "浏览器",
-      "view-in-explorer-button-title": "浏览器中查看详情",
       "cell-from-cellbase": "来自 Cellbase"
     },
     "addresses": {

--- a/packages/neuron-ui/src/stories/styles.scss
+++ b/packages/neuron-ui/src/stories/styles.scss
@@ -8,4 +8,5 @@ body {
     linear-gradient(rgba(255, 255, 255, 0.3) 1px, transparent 1px),
     linear-gradient(90deg, rgba(255, 255, 255, 0.3) 1px, transparent 1px);
   background-size: 100px 100px, 100px 100px, 20px 20px, 20px 20px;
+  display: block !important;
 }

--- a/packages/neuron-ui/src/widgets/Icons/Detail.svg
+++ b/packages/neuron-ui/src/widgets/Icons/Detail.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="60px" height="60px" viewBox="0 0 60 60" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 62 (91390) - https://sketch.com -->
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <path d="M49,0 C51.209139,0 53,1.790861 53,4 L53,56 C53,58.209139 51.209139,60 49,60 L11,60 C8.790861,60 7,58.209139 7,56 L7,4 C7,1.790861 8.790861,0 11,0 L49,0 Z M48,4 L12,4 C11.4871642,4 11.0644928,4.38604019 11.0067277,4.88337887 L11,5 L11,55 C11,55.5128358 11.3860402,55.9355072 11.8833789,55.9932723 L12,56 L48,56 C48.5128358,56 48.9355072,55.6139598 48.9932723,55.1166211 L49,55 L49,5 C49,4.44771525 48.5522847,4 48,4 Z M35,37 L35,41 L15,41 L15,37 L35,37 Z M45,24 L45,28 L15,28 L15,24 L45,24 Z M45,11 L45,15 L15,15 L15,11 L45,11 Z" id="path-detail"></path>
+    </defs>
+    <g id="detail" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <mask id="mask-2" fill="white">
+            <use xlink:href="#path-1"></use>
+        </mask>
+        <use id="Combined-Shape" fill="#fff" fill-rule="nonzero" xlink:href="#path-detail"></use>
+    </g>
+</svg>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7271329/79485823-6cd32900-8048-11ea-851c-7f3ec2fc8cf5.png)
1. add the view-detail and view-in-explorer buttons in the transaction list and remove them from the transaction detail
2. make the description field 100% wide