### PR TITLE
refactor: move loading state of network editor internal

### DIFF
--- a/packages/neuron-ui/src/components/NetworkEditor/hooks.ts
+++ b/packages/neuron-ui/src/components/NetworkEditor/hooks.ts
@@ -6,15 +6,25 @@ import { createNetwork, updateNetwork, addNotification } from 'states/stateProvi
 
 import { MAX_NETWORK_NAME_LENGTH, ErrorCode } from 'utils/const'
 
-export const useOnSubmit = (
-  id: string = '',
-  name: string = '',
-  remote: string = '',
-  networks: Readonly<State.Network[]> = [],
-  history: ReturnType<typeof useHistory>,
-  dispatch: StateDispatch,
+export const useOnSubmit = ({
+  id = '',
+  name = '',
+  remote = '',
+  networks = [],
+  history,
+  dispatch,
+  disabled,
+  setIsUpdating,
+}: {
+  id: string
+  name: string
+  remote: string
+  networks: Readonly<State.Network[]>
+  history: ReturnType<typeof useHistory>
+  dispatch: StateDispatch
   disabled: boolean
-) =>
+  setIsUpdating: React.Dispatch<boolean>
+}) =>
   useCallback(
     (e: React.FormEvent): void => {
       e.preventDefault()
@@ -110,15 +120,16 @@ export const useOnSubmit = (
         addNotification(errorMessage)(dispatch)
         return
       }
+      setIsUpdating(true)
       updateNetwork({
         networkID: id!,
         options: {
           name,
           remote,
         },
-      })(dispatch, history)
+      })(dispatch, history).then(() => setIsUpdating(false))
     },
-    [id, name, remote, networks, history, dispatch, disabled]
+    [id, name, remote, networks, history, dispatch, disabled, setIsUpdating]
   )
 
 export default {

--- a/packages/neuron-ui/src/components/NetworkEditor/index.tsx
+++ b/packages/neuron-ui/src/components/NetworkEditor/index.tsx
@@ -15,9 +15,6 @@ import styles from './networkEditor.module.scss'
 
 const NetworkEditor = () => {
   const {
-    app: {
-      loadings: { network: isUpdating = false },
-    },
     settings: { networks = [] },
   } = useGlobalState()
   const dispatch = useDispatch()
@@ -36,6 +33,7 @@ const NetworkEditor = () => {
     url: '',
     urlError: '',
   })
+  const [isUpdating, setIsUpdating] = useState(false)
 
   const disabled = !!(
     !editor.name ||
@@ -89,7 +87,16 @@ const NetworkEditor = () => {
   )
   const goBack = useGoBack(history)
 
-  const onSubmit = useOnSubmit(id, editor.name, editor.url, networks, history, dispatch, disabled)
+  const onSubmit = useOnSubmit({
+    id: id!,
+    name: editor.name,
+    remote: editor.url,
+    networks,
+    history,
+    dispatch,
+    disabled,
+    setIsUpdating,
+  })
 
   return (
     <Stack tokens={{ childrenGap: 15 }}>

--- a/packages/neuron-ui/src/states/initStates/app.ts
+++ b/packages/neuron-ui/src/states/initStates/app.ts
@@ -41,7 +41,6 @@ const appState: Readonly<State.App> = {
     sending: false,
     addressList: false,
     transactionList: false,
-    network: false,
   },
   showTopAlert: false,
   showAllNotifications: false,

--- a/packages/neuron-ui/src/states/stateProvider/actionCreators/settings.ts
+++ b/packages/neuron-ui/src/states/stateProvider/actionCreators/settings.ts
@@ -32,29 +32,15 @@ export const createNetwork = (params: Controller.CreateNetworkParams) => (dispat
 }
 
 export const updateNetwork = (params: Controller.UpdateNetworkParams) => (dispatch: StateDispatch, history: any) => {
-  dispatch({
-    type: AppActions.UpdateLoadings,
-    payload: {
-      network: true,
-    },
+  return updateRemoteNetwork(params).then(res => {
+    if (res.status === 1) {
+      addPopup('update-network-successfully')(dispatch)
+      history.push(Routes.SettingsNetworks)
+    } else {
+      addNotification(failureResToNotification(res))(dispatch)
+    }
+    return res.status
   })
-  updateRemoteNetwork(params)
-    .then(res => {
-      if (res.status === 1) {
-        addPopup('update-network-successfully')(dispatch)
-        history.push(Routes.SettingsNetworks)
-      } else {
-        addNotification(failureResToNotification(res))(dispatch)
-      }
-    })
-    .finally(() => {
-      dispatch({
-        type: AppActions.UpdateLoadings,
-        payload: {
-          network: false,
-        },
-      })
-    })
 }
 
 export default {

--- a/packages/neuron-ui/src/types/App/index.d.ts
+++ b/packages/neuron-ui/src/types/App/index.d.ts
@@ -100,7 +100,6 @@ declare namespace State {
       sending: boolean
       addressList: boolean
       transactionList: boolean
-      network: boolean
     }>
     readonly showTopAlert: boolean
     readonly showAllNotifications: boolean


### PR DESCRIPTION
remove the loading status from global context and hold it in the component by itself.