### PR TITLE
feat: sort s-udt accounts

### DIFF
--- a/packages/neuron-ui/src/components/SUDTAccountList/index.tsx
+++ b/packages/neuron-ui/src/components/SUDTAccountList/index.tsx
@@ -15,6 +15,7 @@ import isMainnetUtil from 'utils/isMainnet'
 import { MEDIUM_FEE_RATE, Routes, DEFAULT_SUDT_FIELDS, SyncStatus } from 'utils/const'
 import getSyncStatus from 'utils/getSyncStatus'
 import getCurrentUrl from 'utils/getCurrentUrl'
+import sortAccounts from 'utils/sortAccounts'
 
 import styles from './sUDTAccountList.module.scss'
 
@@ -52,6 +53,7 @@ const SUDTAccountList = () => {
         setAccounts(
           list
             .filter(account => account.id !== undefined)
+            .sort(sortAccounts)
             .map(({ id, accountName, tokenName, symbol, tokenID, balance, address, decimal }) => ({
               accountId: id!.toString(),
               accountName,

--- a/packages/neuron-ui/src/tests/sortAccounts/fixtures.json
+++ b/packages/neuron-ui/src/tests/sortAccounts/fixtures.json
@@ -1,0 +1,48 @@
+{
+  "basic": {
+    "accounts": [
+      {
+        "tokenName": "token name",
+        "accountName": "account name"
+      },
+      {
+        "tokenName": "another token name",
+        "accountName": "account name"
+      },
+      {
+        "tokenName": "token name",
+        "accountName": "another account name"
+      },
+      {
+        "tokenName": "",
+        "accountName": ""
+      },
+      {
+        "tokenName": "CKB",
+        "accountName": ""
+      }
+    ],
+    "expected": [
+      {
+        "tokenName": "another token name",
+        "accountName": "account name"
+      },
+      {
+        "tokenName": "CKB",
+        "accountName": ""
+      },
+      {
+        "tokenName": "token name",
+        "accountName": "account name"
+      },
+      {
+        "tokenName": "token name",
+        "accountName": "another account name"
+      },
+      {
+        "tokenName": "",
+        "accountName": ""
+      }
+    ]
+  }
+}

--- a/packages/neuron-ui/src/tests/sortAccounts/index.test.ts
+++ b/packages/neuron-ui/src/tests/sortAccounts/index.test.ts
@@ -1,0 +1,13 @@
+import sortAccounts, { Account } from 'utils/sortAccounts'
+import fixtures from './fixtures.json'
+
+describe('Test sortAccounts', () => {
+  const fixtureTable: [string, { accounts: Account[]; expected: Account[] }][] = Object.entries(
+    fixtures
+  ).map(([name, fixture]) => [name, fixture])
+
+  test.each(fixtureTable)('%s', (_name: string, { accounts, expected }: any) => {
+    const actual = accounts.sort(sortAccounts)
+    expect(actual).toEqual(expected)
+  })
+})

--- a/packages/neuron-ui/src/utils/sortAccounts.ts
+++ b/packages/neuron-ui/src/utils/sortAccounts.ts
@@ -1,0 +1,20 @@
+export interface Account {
+  accountName: string
+  tokenName: string
+}
+
+export const sortAccounts = (prev: Account, next: Account) => {
+  if (!prev.tokenName || !next.tokenName) {
+    return +!prev.tokenName - 0.5
+  }
+  const tokenNameRes = prev.tokenName.localeCompare(next.tokenName)
+  if (tokenNameRes === 0) {
+    if (!prev.accountName || !next.accountName) {
+      return +!prev.accountName - 0.5
+    }
+    return prev.accountName.localeCompare(next.accountName)
+  }
+  return tokenNameRes
+}
+
+export default sortAccounts


### PR DESCRIPTION
1. sort by token name
2. sort by account name
3. empty accounts are placed at the end