### PR TITLE
feat: add a padding to the desc field

### DIFF
--- a/packages/neuron-ui/src/components/SUDTSend/sUDTSend.module.scss
+++ b/packages/neuron-ui/src/components/SUDTSend/sUDTSend.module.scss
@@ -73,7 +73,7 @@
     'address .' auto
     'amount send-all' auto
     'fee fee' auto
-    'description description' auto /
+    'description .' auto /
     1fr 70px;
   padding: 15px 30px 20px;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7271329/81789245-4795e580-9536-11ea-8934-5147cea0268c.png)
Align the right side of the description field to other inputs