### PR TITLE
fix: use custom date formatter

### DIFF
--- a/packages/neuron-ui/src/components/Send/index.tsx
+++ b/packages/neuron-ui/src/components/Send/index.tsx
@@ -38,7 +38,7 @@ import {
   verifyAddress,
 } from 'utils'
 
-import DatetimePicker from 'widgets/DatetimePicker'
+import DatetimePicker, { formatDate } from 'widgets/DatetimePicker'
 import { useInitialize } from './hooks'
 import styles from './send.module.scss'
 
@@ -304,7 +304,7 @@ const Send = () => {
                   <div className={styles.locktime} data-status={item.date ? 'set' : 'unset'}>
                     <img data-status="inactive" className={styles.icon} src={Calendar} alt="calendar" />
                     <img data-status="active" className={styles.icon} src={ActiveCalendar} alt="active-calendar" />
-                    {item.date ? `${t('send.release-on')}: ${new Date(+item.date).toLocaleDateString()}` : null}
+                    {item.date ? `${t('send.release-on')}: ${formatDate(new Date(+item.date))}` : null}
                     <button type="button" data-index={idx} onClick={onLocktimeClick}>
                       {item.date ? (
                         <>

--- a/packages/neuron-ui/src/widgets/DatetimePicker/index.tsx
+++ b/packages/neuron-ui/src/widgets/DatetimePicker/index.tsx
@@ -12,6 +12,16 @@ if (UTC > 0) {
   UTC = `UTC${UTC}`
 }
 
+export const formatDate = (datetime: Date) => {
+  const month = (datetime.getMonth() + 1).toString().padStart(2, '0')
+  const date = datetime
+    .getDate()
+    .toString()
+    .padStart(2, '0')
+  const year = datetime.getFullYear()
+  return `${month}/${date}/${year}`
+}
+
 export interface DatetimePickerProps {
   title?: string
   preset?: Date | string | number | null
@@ -29,7 +39,7 @@ const DatetimePicker = ({
   const [t] = useTranslation()
   const [status, setStatus] = useState<'done' | 'edit'>('done')
   const [datetime, setDatetime] = useState<any>(preset ? new Date(+preset) : null)
-  const [display, setDisplay] = useState<any>(new Date(datetime).toLocaleDateString())
+  const [display, setDisplay] = useState<any>(formatDate(new Date(datetime)))
 
   const locale: any = {
     firstDayOfWeek: 0,
@@ -72,7 +82,7 @@ const DatetimePicker = ({
   const onSelected = useCallback(
     e => {
       if (e.target.tagName === 'SPAN' && e.target.className !== 'p-disabled') {
-        setDisplay(new Date(datetime).toLocaleDateString())
+        setDisplay(formatDate(new Date(datetime)))
         setStatus('done')
       }
     },


### PR DESCRIPTION
Use custom date formatter instead of toLocaleDateString to avoid confusion from dd/mm/YYYY