### PR TITLE
fix: remove redundant handler on setting network id

### DIFF
--- a/packages/neuron-ui/src/components/NetworkSetting/index.tsx
+++ b/packages/neuron-ui/src/components/NetworkSetting/index.tsx
@@ -77,7 +77,6 @@ const NetworkSetting = ({ chain = chainState, settings: { networks = [] } }: Sta
                   role="presentation"
                   className={`ms-ChoiceFieldLabel ${styles.choiceLabel}`}
                   data-id={network.id}
-                  data-action="select"
                   onClick={onHandleNetwork}
                   title={`${text}: ${network.remote}`}
                 >

--- a/packages/neuron-ui/src/utils/hooks.ts
+++ b/packages/neuron-ui/src/utils/hooks.ts
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback, useEffect } from 'react'
 import { useHistory } from 'react-router-dom'
 import { TFunction, i18n as i18nType } from 'i18next'
-import { openContextMenu, requestPassword, setCurrentNetowrk, deleteNetwork } from 'services/remote'
+import { openContextMenu, requestPassword, deleteNetwork } from 'services/remote'
 import { SetLocale as SetLocaleSubject } from 'services/subjects'
 import {
   StateDispatch,
@@ -323,10 +323,6 @@ export const useOnHandleNetwork = ({ history }: { history: ReturnType<typeof use
         }
         case 'delete': {
           deleteNetwork(id)
-          break
-        }
-        case 'select': {
-          setCurrentNetowrk(id)
           break
         }
         default: {


### PR DESCRIPTION
It's already handled by the onChange handler of the ChoiceGroup component

ref: https://github.com/nervosnetwork/neuron/blob/rc/v0.31.0/packages/neuron-ui/src/components/NetworkSetting/index.tsx#L108