### PR TITLE
Handle invalid sUDT data

### DIFF
--- a/packages/neuron-wallet/src/services/asset-account-service.ts
+++ b/packages/neuron-wallet/src/services/asset-account-service.ts
@@ -63,7 +63,7 @@ export default class AssetAccountService {
       } else {
         const sumOfAmount = (output.dataArray as string)
           .split(',')
-          .map(data => BufferUtils.readBigUInt128LE(data.trim()))
+          .map(data => BufferUtils.parseAmountFromSUDTData(data.trim()))
           .reduce((result, c) => result + c, BigInt(0))
         sumOfAmountMap.set(key, old + sumOfAmount)
       }
@@ -121,7 +121,7 @@ export default class AssetAccountService {
       BigInt(output.sumOfCapacity) :
       (output.dataArray as string)
         .split(',')
-        .map(data => BufferUtils.readBigUInt128LE(data.trim()))
+        .map(data => BufferUtils.parseAmountFromSUDTData(data.trim()))
         .reduce((result, c) => result + c, BigInt(0))
 
     assetAccount.balance = sumOfAmount.toString()

--- a/packages/neuron-wallet/src/services/cells.ts
+++ b/packages/neuron-wallet/src/services/cells.ts
@@ -655,7 +655,9 @@ export default class CellsService {
       })
     const anyoneCanPayLockLiveCells: LiveCell[] = anyoneCanPayLockLiveCellEntities.map(entity => LiveCell.fromEntity(entity))
 
-    const allAmount: bigint = anyoneCanPayLockLiveCells.map(c => BufferUtils.readBigUInt128LE(c.data)).reduce((result, c) => result + c, BigInt(0))
+    const allAmount: bigint = anyoneCanPayLockLiveCells.map(
+      c => BufferUtils.parseAmountFromSUDTData(c.data)).reduce((result, c) => result + c, BigInt(0)
+    )
     const amountInt = amount === 'all' ? allAmount : BigInt(amount)
 
     if (anyoneCanPayLockLiveCellEntities.length === 0) {
@@ -691,7 +693,7 @@ export default class CellsService {
       }
       inputs.push(input)
 
-      inputAmount += BufferUtils.readBigUInt128LE(cell.data)
+      inputAmount += BufferUtils.parseAmountFromSUDTData(cell.data)
 
       needFee = mode.isFeeRateMode() ? TransactionFee.fee(totalSize, feeRateInt) : feeInt
 

--- a/packages/neuron-wallet/src/services/tx/transaction-generator.ts
+++ b/packages/neuron-wallet/src/services/tx/transaction-generator.ts
@@ -694,7 +694,7 @@ export class TransactionGenerator {
     const assetAccountInfo = new AssetAccountInfo()
     const sudtCellDep = assetAccountInfo.sudtCellDep
     const anyoneCanPayDep = assetAccountInfo.anyoneCanPayCellDep
-    const targetAmount: bigint = amount === 'all' ? BigInt(0) : BufferUtils.readBigUInt128LE(targetOutput.data) + BigInt(amount)
+    const targetAmount: bigint = amount === 'all' ? BigInt(0) : BufferUtils.parseAmountFromSUDTData(targetOutput.data) + BigInt(amount)
     const output = Output.fromObject({
       ...targetOutput,
       data: BufferUtils.writeBigUInt128LE(targetAmount),
@@ -733,7 +733,7 @@ export class TransactionGenerator {
     )
 
     if (amount === 'all') {
-      tx.outputs[0].data = BufferUtils.writeBigUInt128LE(BigInt(result.amount) + BufferUtils.readBigUInt128LE(targetOutput.data))
+      tx.outputs[0].data = BufferUtils.writeBigUInt128LE(BigInt(result.amount) + BufferUtils.parseAmountFromSUDTData(targetOutput.data))
     }
 
     tx.inputs = result.anyoneCanPayInputs.concat(result.changeInputs).concat(tx.inputs)
@@ -763,12 +763,12 @@ export class TransactionGenerator {
   private static checkTxSudtAmount(tx: Transaction, msg: string, assetAccountInfo: AssetAccountInfo) {
     const inputAmount = tx.inputs
       .filter(i => i.type && assetAccountInfo.isSudtScript(i.type))
-      .map(i => BufferUtils.readBigUInt128LE(i.data!))
+      .map(i => BufferUtils.parseAmountFromSUDTData(i.data!))
       .reduce((result, c) => result + c, BigInt(0))
 
     const outputAmount = tx.outputs
       .filter(o => o.type && assetAccountInfo.isSudtScript(o.type))
-      .map(o => BufferUtils.readBigUInt128LE(o.data!))
+      .map(o => BufferUtils.parseAmountFromSUDTData(o.data!))
       .reduce((result, c) => result + c, BigInt(0))
 
     assert.equal(inputAmount.toString(), outputAmount.toString(), `${msg}: ${JSON.stringify(tx)}`)

--- a/packages/neuron-wallet/src/services/tx/transaction-service.ts
+++ b/packages/neuron-wallet/src/services/tx/transaction-service.ts
@@ -239,11 +239,11 @@ export class TransactionsService {
           // const typeArgs = sudtInput.typeArgs
           const inputAmount = anyoneCanPayInputs
             .filter(i => i.transactionHash === tx.hash && assetAccountInfo.isSudtScript(i.typeScript()!) && i.typeArgs === typeArgs)
-            .map(i => BufferUtils.readBigUInt128LE(i.data))
+            .map(i => BufferUtils.parseAmountFromSUDTData(i.data))
             .reduce((result, c) => result + c, BigInt(0))
           const outputAmount = anyoneCanPayOutputs
             .filter(o => o.outPointTxHash === tx.hash && assetAccountInfo.isSudtScript(o.typeScript()!) && o.typeArgs === typeArgs)
-            .map(o => BufferUtils.readBigUInt128LE(o.data))
+            .map(o => BufferUtils.parseAmountFromSUDTData(o.data))
             .reduce((result, c) => result + c, BigInt(0))
 
           const amount = outputAmount - inputAmount

--- a/packages/neuron-wallet/src/utils/buffer.ts
+++ b/packages/neuron-wallet/src/utils/buffer.ts
@@ -25,7 +25,7 @@ export default class BufferUtils {
 
   public static parseAmountFromSUDTData(leHex: string): bigint {
     try {
-      return this.readBigUInt128LE(leHex)
+      return this.readBigUInt128LE(leHex.slice(0, 34))
     } catch (error) {
       return BigInt(0)
     }

--- a/packages/neuron-wallet/src/utils/buffer.ts
+++ b/packages/neuron-wallet/src/utils/buffer.ts
@@ -22,4 +22,12 @@ export default class BufferUtils {
     const buf = Buffer.from(leHex.slice(2), 'hex')
     return (buf.readBigUInt64LE(8) << BigInt(64)) + buf.readBigUInt64LE(0)
   }
+
+  public static parseAmountFromSUDTData(leHex: string): bigint {
+    try {
+      return this.readBigUInt128LE(leHex)
+    } catch (error) {
+      return BigInt(0)
+    }
+  }
 }

--- a/packages/neuron-wallet/tests/utils/buffer.test.ts
+++ b/packages/neuron-wallet/tests/utils/buffer.test.ts
@@ -54,4 +54,30 @@ describe('BufferUtils', () => {
       })
     });
   });
+
+  describe('#parseAmountFromSUDTData', () => {
+    describe('when the format of hex string aligns with the protocol', () => {
+      it('converts to a BigInt value', () => {
+        const result = BufferUtils.parseAmountFromSUDTData(leHex)
+        expect(result).toEqual(num)
+      })
+    });
+    describe('when the format of hex string does not align with the protocol', () => {
+      it('throws an error if hex string does not start with 0x', () => {
+        const hexWithout0x = '0100000000000000000001000000000000'
+        const result = BufferUtils.parseAmountFromSUDTData(hexWithout0x)
+        expect(result).toEqual(BigInt(0))
+      })
+      it('throws an error if the length of hex string is less than 34', () => {
+        const shortedHex = '0x0100000000000000000001000000000'
+        const result = BufferUtils.parseAmountFromSUDTData(shortedHex)
+        expect(result).toEqual(BigInt(0))
+      })
+      it('throws an error if the length of hex string is greater than 34', () => {
+        const overflowHex = '0x010000000000000000000100000000000'
+        const result = BufferUtils.parseAmountFromSUDTData(overflowHex)
+        expect(result).toEqual(BigInt(0))
+      })
+    });
+  });
 })

--- a/packages/neuron-wallet/tests/utils/buffer.test.ts
+++ b/packages/neuron-wallet/tests/utils/buffer.test.ts
@@ -57,8 +57,13 @@ describe('BufferUtils', () => {
 
   describe('#parseAmountFromSUDTData', () => {
     describe('when the format of hex string aligns with the protocol', () => {
-      it('converts to a BigInt value', () => {
+      it('converts whole hex string to a BigInt value if the length of hex string equals 34', () => {
         const result = BufferUtils.parseAmountFromSUDTData(leHex)
+        expect(result).toEqual(num)
+      })
+      it('converts to a BigInt value based on the first 34 chars of the hex string', () => {
+        const overflowHex = leHex + '12345'
+        const result = BufferUtils.parseAmountFromSUDTData(overflowHex)
         expect(result).toEqual(num)
       })
     });
@@ -73,9 +78,9 @@ describe('BufferUtils', () => {
         const result = BufferUtils.parseAmountFromSUDTData(shortedHex)
         expect(result).toEqual(BigInt(0))
       })
-      it('throws an error if the length of hex string is greater than 34', () => {
-        const overflowHex = '0x010000000000000000000100000000000'
-        const result = BufferUtils.parseAmountFromSUDTData(overflowHex)
+      it('throws an error if invalid hex string', () => {
+        const shortedHex = '0x0100000000000000000001000000000z'
+        const result = BufferUtils.parseAmountFromSUDTData(shortedHex)
         expect(result).toEqual(BigInt(0))
       })
     });

--- a/packages/neuron-wallet/tests/utils/buffer.test.ts
+++ b/packages/neuron-wallet/tests/utils/buffer.test.ts
@@ -4,25 +4,54 @@ describe('BufferUtils', () => {
   const num = BigInt('1208925819614629174706177')
   const leHex = "0x01000000000000000000010000000000"
 
-  it('writeBigUInt128LE', () => {
-    const result = BufferUtils.writeBigUInt128LE(num)
-    expect(result).toEqual(leHex)
-  })
+  describe('#writeBigUInt128LE', () => {
+    describe('when success', () => {
+      it('converts a BigInt value to a hex string using little endian encoding', () => {
+        const result = BufferUtils.writeBigUInt128LE(num)
+        expect(result).toEqual(leHex)
+      })
+    });
+    describe('when fails', () => {
+      it('throws an error if the value < 0', () => {
+        expect(() => {
+          BufferUtils.writeBigUInt128LE(BigInt(-1))
+        }).toThrowError()
+      })
 
-  it('writeBigUInt128LE, < 0', () => {
-    expect(() => {
-      BufferUtils.writeBigUInt128LE(BigInt(-1))
-    }).toThrowError()
-  })
+      it('throws an error if the value > MAX', () => {
+        expect(() => {
+          BufferUtils.writeBigUInt128LE(BigInt(2) ** BigInt(128))
+        }).toThrowError()
+      })
+    });
+  });
 
-  it('writeBigUInt128LE, > MAX', () => {
-    expect(() => {
-      BufferUtils.writeBigUInt128LE(BigInt(2) ** BigInt(128))
-    }).toThrowError()
-  })
-
-  it('readBigUInt128LE', () => {
-    const result = BufferUtils.readBigUInt128LE(leHex)
-    expect(result).toEqual(num)
-  })
+  describe('#readBigUInt128LE', () => {
+    describe('when success', () => {
+      it('converts a hex string in little endian encoding to a BigInt value', () => {
+        const result = BufferUtils.readBigUInt128LE(leHex)
+        expect(result).toEqual(num)
+      })
+    });
+    describe('when fails', () => {
+      it('throws an error if hex string does not start with 0x', () => {
+        const hexWithout0x = '0100000000000000000001000000000000'
+        expect(() => {
+          BufferUtils.readBigUInt128LE(hexWithout0x)
+        }).toThrowError()
+      })
+      it('throws an error if the length of hex string is less than 34', () => {
+        const hexWithInvalidLength = '0x0100000000000000000001000000000'
+        expect(() => {
+          BufferUtils.readBigUInt128LE(hexWithInvalidLength)
+        }).toThrowError()
+      })
+      it('throws an error if the length of hex string is greater than 34', () => {
+        const hexWithInvalidLength = '0x010000000000000000000100000000000'
+        expect(() => {
+          BufferUtils.readBigUInt128LE(hexWithInvalidLength)
+        }).toThrowError()
+      })
+    });
+  });
 })


### PR DESCRIPTION
- Added `BufferUtils#parseAmountFromSUDTData(leHex)` 
- Restructured and added unit tests for `BufferUtils` 
- Uses `BufferUtils#parseAmountFromSUDTData(leHex)` to parse amounts for sUDT data