### PR TITLE
Temporary fix for the sqlite too many variables error

### DIFF
--- a/packages/neuron-wallet/src/services/cells.ts
+++ b/packages/neuron-wallet/src/services/cells.ts
@@ -78,16 +78,21 @@ export default class CellsService {
   }
 
   public static async usedByAnyoneCanPayBlake160s(anyoneCanPayLockHashes: string[], blake160s: string[]): Promise<string[]> {
+    const blake160Set = new Set(blake160s)
     const liveCells = await getConnection()
       .getRepository(OutputEntity)
       .createQueryBuilder('output')
       .where({
-        lockHash: In(anyoneCanPayLockHashes),
-        lockArgs: In(blake160s),
+        lockHash: In(anyoneCanPayLockHashes)
       })
       .getMany()
 
-    return liveCells.map(c => c.lockArgs)
+    const lockArgs = liveCells
+      .filter(c => blake160Set.has(c.lockArgs))
+      .map(c => c.lockArgs)
+
+    const uniqueLockArgs = [...new Set(lockArgs)]
+    return uniqueLockArgs
   }
 
   public static async getDaoCells(lockHashes: string[]): Promise<Cell[]> {


### PR DESCRIPTION
This is a temporary fix to the issue `SQLITE_ERROR: too many SQL variables`.

We will need to refactor the similar queries of this kind in the other places so that it only queries with the variables within a wallet's scope instead of all wallets'.