### PR TITLE
Adjust layout of sign and verify dialog

### DIFF
--- a/packages/neuron-ui/src/components/SUDTSend/sUDTSend.module.scss
+++ b/packages/neuron-ui/src/components/SUDTSend/sUDTSend.module.scss
@@ -90,7 +90,7 @@
     button {
       box-sizing: border-box;
       width: 60px;
-      height: 27px;
+      height: 26px;
       padding: 0;
       line-height: 1;
       display: flex;

--- a/packages/neuron-ui/src/components/Send/send.module.scss
+++ b/packages/neuron-ui/src/components/Send/send.module.scss
@@ -160,7 +160,7 @@ $textfieldWidth: calc(100vw - 370px);
 
 .maxBtn {
   width: 3.125rem;
-  height: 27px;
+  height: 26px;
   min-width: auto;
   margin-top: 22px;
   padding: 0;

--- a/packages/neuron-ui/src/components/SignAndVerify/index.tsx
+++ b/packages/neuron-ui/src/components/SignAndVerify/index.tsx
@@ -253,7 +253,7 @@ const SignAndVerify = () => {
         ) : null}
       </div>
       <h2 className={styles.label}>{t('sign-and-verify.signature')}</h2>
-      <textarea data-field="signature" value={signature} onChange={onInputChange} />
+      <TextField field="signature" value={signature} onChange={onInputChange} className={styles.signatureField} />
       <div className={styles.actions}>
         <Button type="cancel" label={t('sign-and-verify.cancel')} onClick={onCancel} />
         <Button

--- a/packages/neuron-ui/src/components/SignAndVerify/signAndVerify.module.scss
+++ b/packages/neuron-ui/src/components/SignAndVerify/signAndVerify.module.scss
@@ -19,7 +19,7 @@ $inputHeight: 26px;
     font-weight: 600;
   }
 
-  input,
+  .addrInput,
   textarea {
     @include regular-text;
     font-size: 12px !important;
@@ -36,8 +36,11 @@ $inputHeight: 26px;
     height: 74px;
   }
 
-  input {
+  .addrInput {
     height: $inputHeight;
+  }
+  .signatureField [class^='textField_input']:focus-within {
+    border-color: #000;
   }
 }
 

--- a/packages/neuron-ui/src/components/SignAndVerify/signAndVerify.module.scss
+++ b/packages/neuron-ui/src/components/SignAndVerify/signAndVerify.module.scss
@@ -2,6 +2,9 @@
 $inputHeight: 26px;
 
 .container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   .title {
     @include bold-text;
     font-size: 1.375rem;
@@ -29,11 +32,11 @@ $inputHeight: 26px;
     border: 1px solid #000;
     padding: 6px 12px;
     box-sizing: border-box;
-    margin-bottom: 18px;
   }
 
   textarea {
-    height: 74px;
+    flex: 1;
+    margin-bottom: 18px;
   }
 
   .addrInput {
@@ -55,6 +58,7 @@ $inputHeight: 26px;
 
 .address {
   position: relative;
+  margin-bottom: 18px;
 
   .dropdownBtn {
     position: absolute;

--- a/packages/neuron-ui/src/widgets/TextField/textField.module.scss
+++ b/packages/neuron-ui/src/widgets/TextField/textField.module.scss
@@ -48,7 +48,7 @@ $error-red: #d50000;
       font-size: 0.75rem;
       flex: 1;
       border: none;
-      padding: 5px 10px;
+      padding: 4.5px 10px;
       overflow: hidden;
       text-overflow: ellipsis;
       word-break: keep-all;

--- a/packages/neuron-wallet/src/controllers/app/menu.ts
+++ b/packages/neuron-wallet/src/controllers/app/menu.ts
@@ -254,7 +254,9 @@ const updateApplicationMenu = (mainWindow: BrowserWindow | null) => {
         enabled: hasCurrentWallet,
         click: () => {
           const currentWallet = walletsService.getCurrent()
-          showWindow(`#/sign-verify/${currentWallet!.id}`, i18n.t(`messageBox.sign-and-verify.title`))
+          showWindow(`#/sign-verify/${currentWallet!.id}`, i18n.t(`messageBox.sign-and-verify.title`), {
+            width: 900,
+          })
         }
       }
     ]


### PR DESCRIPTION
1. set the width of the sign-and-verify dialog to 900px;
2. use textfield instead of textarea for the signature field;
3. set the height of the form to 100%;