### PR TITLE
fix: fix the active nav item filter

### DIFF
--- a/packages/neuron-ui/src/containers/Navbar/index.tsx
+++ b/packages/neuron-ui/src/containers/Navbar/index.tsx
@@ -77,7 +77,7 @@ const Navbar = () => {
 
   useChainTypeByGenesisBlockHash(networkURL, toggleSUDT)
 
-  const selectedKey = menuItems.find(item => item.key === pathname)?.key ?? null
+  const selectedKey = menuItems.find(item => item.key === pathname.substr(1))?.key ?? null
 
   const syncStatus = getSyncStatus({
     syncedBlockNumber,


### PR DESCRIPTION
Ignore the leading slash in the pathname
![image](https://user-images.githubusercontent.com/7271329/86453586-9dc22080-bd50-11ea-9be5-be0709f4e2c4.png)
