### PR TITLE
Backend fixes for 0.32-beta.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,9 +77,6 @@ stages:
       inputs:
         versionSpec: $(node_version)
       displayName: 'Install Node.js'
-    - script: |
-        powershell -Command "choco install llvm; refreshenv"
-      displayName: 'Install clang (Windows)'
     - script: yarn global add lerna
       displayName: 'Install lerna'
     - script: |
@@ -156,8 +153,6 @@ stages:
       inputs:
         versionSpec: 12.x
       displayName: 'Install Node.js'
-    - pwsh: choco install llvm; refreshenv
-      displayName: 'Install clang (Windows)'
     - script: yarn global add lerna
       displayName: 'Install lerna'
     - script: |

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "packages/*"
   ],
   "scripts": {
-    "bootstrap": "lerna bootstrap && lerna link",
+    "bootstrap": "LUMOS_NODE_RUNTIME=electron LUMOS_NODE_RUNTIME_VERSION=7.1.4 lerna bootstrap && lerna link",
     "start:ui": "cd packages/neuron-ui && yarn run start",
     "start:wallet": "cd packages/neuron-wallet && yarn run start:dev",
     "start": "concurrently \"cross-env BROWSER=none yarn run start:ui\" \"wait-on http://localhost:3000 && yarn run start:wallet\"",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "packages/*"
   ],
   "scripts": {
-    "bootstrap": "LUMOS_NODE_RUNTIME=electron LUMOS_NODE_RUNTIME_VERSION=7.1.4 lerna bootstrap && lerna link",
+    "bootstrap": "cross-env LUMOS_NODE_RUNTIME=electron LUMOS_NODE_RUNTIME_VERSION=7.1.4 lerna bootstrap && lerna link",
+    "prebootstrap": "npm i cross-env@5.2.1 --no-save",
     "start:ui": "cd packages/neuron-ui && yarn run start",
     "start:wallet": "cd packages/neuron-wallet && yarn run start:dev",
     "start": "concurrently \"cross-env BROWSER=none yarn run start:ui\" \"wait-on http://localhost:3000 && yarn run start:wallet\"",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "packages/*"
   ],
   "scripts": {
-    "bootstrap": "cross-env LUMOS_NODE_RUNTIME=electron LUMOS_NODE_RUNTIME_VERSION=7.1.4 lerna bootstrap && lerna link",
-    "prebootstrap": "npm i cross-env@5.2.1 --no-save",
+    "bootstrap": "npx cross-env LUMOS_NODE_RUNTIME=electron LUMOS_NODE_RUNTIME_VERSION=7.1.4 lerna bootstrap && lerna link",
     "start:ui": "cd packages/neuron-ui && yarn run start",
     "start:wallet": "cd packages/neuron-wallet && yarn run start:dev",
     "start": "concurrently \"cross-env BROWSER=none yarn run start:ui\" \"wait-on http://localhost:3000 && yarn run start:wallet\"",

--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -78,7 +78,6 @@
     "electron-notarize": "0.2.1",
     "jest-when": "2.7.2",
     "lint-staged": "9.2.5",
-    "neon-cli": "0.4.0",
     "neuron-ui": "0.32.0-beta.1",
     "rimraf": "3.0.0",
     "ts-transformer-imports": "0.4.3",

--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -25,8 +25,7 @@
     "test:watch": "jest --watch",
     "lint": "eslint --fix --ext .ts,.js src",
     "precommit": "lint-staged",
-    "rebuild:nativemodules": "electron-builder install-app-deps && yarn rebuild:neondeps",
-    "rebuild:neondeps": "electron-build-env neon build -p ../../node_modules/@ckb-lumos/indexer --release"
+    "rebuild:nativemodules": "electron-builder install-app-deps"
   },
   "lint-staged": {
     "src/**/*.ts": [
@@ -35,7 +34,8 @@
     ]
   },
   "dependencies": {
-    "@ckb-lumos/indexer": "0.3.0",
+    "@ckb-lumos/base": "0.4.8",
+    "@ckb-lumos/indexer": "0.4.8",
     "@nervosnetwork/ckb-sdk-core": "0.32.0",
     "@nervosnetwork/ckb-sdk-utils": "0.32.0",
     "archiver": "3.1.1",

--- a/packages/neuron-wallet/src/block-sync-renderer/index.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/index.ts
@@ -4,6 +4,7 @@ import { Network, EMPTY_GENESIS_HASH } from 'models/network'
 import { AddressVersion } from 'database/address/address-dao'
 import DataUpdateSubject from 'models/subjects/data-update'
 import AddressCreatedSubject from 'models/subjects/address-created-subject'
+import WalletDeletedSubject from 'models/subjects/wallet-deleted-subject'
 import SyncedBlockNumberSubject from 'models/subjects/node'
 import SyncedBlockNumber from 'models/synced-block-number'
 import NetworksService from 'services/networks'
@@ -30,6 +31,10 @@ const updateAllAddressesTxCountAndUsedByAnyoneCanPay = async (genesisBlockHash: 
 
 if (BrowserWindow) {
   AddressCreatedSubject.getSubject().subscribe(async () => {
+    killBlockSyncTask()
+    await createBlockSyncTask()
+  })
+  WalletDeletedSubject.getSubject().subscribe(async () => {
     killBlockSyncTask()
     await createBlockSyncTask()
   })

--- a/packages/neuron-wallet/src/block-sync-renderer/index.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/index.ts
@@ -1,7 +1,7 @@
 import { BrowserWindow, ipcMain } from 'electron'
 import path from 'path'
 import { Network, EMPTY_GENESIS_HASH } from 'models/network'
-import { Address, AddressVersion } from 'database/address/address-dao'
+import { AddressVersion } from 'database/address/address-dao'
 import DataUpdateSubject from 'models/subjects/data-update'
 import AddressCreatedSubject from 'models/subjects/address-created-subject'
 import SyncedBlockNumberSubject from 'models/subjects/node'
@@ -29,11 +29,9 @@ const updateAllAddressesTxCountAndUsedByAnyoneCanPay = async (genesisBlockHash: 
 }
 
 if (BrowserWindow) {
-  AddressCreatedSubject.getSubject().subscribe(async (addresses: Address[]) => {
-    // Force rescan when address is imported and there's no previous records (from existing identical wallet)
-    const shouldRescan = addresses.some(address => address.isImporting === true)
+  AddressCreatedSubject.getSubject().subscribe(async () => {
     killBlockSyncTask()
-    await createBlockSyncTask(shouldRescan)
+    await createBlockSyncTask()
   })
 }
 

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-cache-service.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-cache-service.ts
@@ -3,7 +3,7 @@ import { queue } from 'async'
 import AddressMeta from "database/address/meta"
 import IndexerTxHashCache from 'database/chain/entities/indexer-tx-hash-cache'
 import RpcService from 'services/rpc-service'
-import { Indexer } from '@ckb-lumos/indexer'
+import { Indexer, TransactionCollector } from '@ckb-lumos/indexer'
 import TransactionWithStatus from 'models/chain/transaction-with-status'
 
 export default class IndexerCacheService {
@@ -93,13 +93,16 @@ export default class IndexerCacheService {
       ]
 
       for (const lockScript of lockScripts) {
-        const fetchedTxHashes = this.indexer.getTransactionsByLockScript({
-          code_hash: lockScript.codeHash,
-          hash_type: lockScript.hashType,
-          args: lockScript.args
+        const transactionCollector = new TransactionCollector(this.indexer, {
+          lock: {
+            code_hash: lockScript.codeHash,
+            hash_type: lockScript.hashType,
+            args: lockScript.args
+          }
         })
-
-        if (!fetchedTxHashes || !fetchedTxHashes.length) {
+        //@ts-ignore
+        const fetchedTxHashes = transactionCollector.get_transaction_hashes().toArray()
+        if (!fetchedTxHashes.length) {
           continue
         }
 

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-cache-service.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-cache-service.ts
@@ -50,13 +50,13 @@ export default class IndexerCacheService {
       .getMany()
   }
 
-  public static async nextUnprocessedBlock(): Promise<{blockNumber: string, blockHash: string} | undefined> {
+  public static async nextUnprocessedBlock(walletIds: string[]): Promise<{blockNumber: string, blockHash: string} | undefined> {
     const result = await getConnection()
       .getRepository(IndexerTxHashCache)
       .createQueryBuilder()
-      .where({
-        isProcessed: false
-      })
+      .where(
+        'walletId IN (:...walletIds) and isProcessed = false', {walletIds}
+      )
       .orderBy('blockNumber', 'ASC')
       .getOne()
 

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-connector.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-connector.ts
@@ -239,11 +239,7 @@ export default class IndexerConnector {
     return txsWithStatus
   }
 
-  public async notifyCurrentBlockNumberProcessed(blockNumber: string) {
-    for (const [walletId, addressMetas] of this.addressesByWalletId.entries()) {
-      const indexerCacheService = new IndexerCacheService(walletId, addressMetas, this.rpcService, this.indexer)
-      await indexerCacheService.updateProcessedTxHashes(blockNumber)
-    }
+  public async notifyCurrentBlockNumberProcessed() {
     this.processNextBlockNumberQueue!.push(null)
   }
 }

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-connector.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-connector.ts
@@ -1,7 +1,8 @@
 import logger from 'electron-log'
 import { Subject } from 'rxjs'
 import { queue, AsyncQueue } from 'async'
-import { Indexer, Tip, CollectorQueries, CellCollector } from '@ckb-lumos/indexer'
+import { QueryOptions, HashType } from '@ckb-lumos/base'
+import { Indexer, Tip, CellCollector } from '@ckb-lumos/indexer'
 import CommonUtils from 'utils/common'
 import RpcService from 'services/rpc-service'
 import TransactionWithStatus from 'models/chain/transaction-with-status'
@@ -12,8 +13,8 @@ import IndexerCacheService from './indexer-cache-service'
 import IndexerFolderManager from './indexer-folder-manager'
 
 export interface LumosCellQuery {
-  lock: {codeHash: string, hashType: string, args: string} | null,
-  type: {codeHash: string, hashType: string, args: string} | null,
+  lock: {codeHash: string, hashType: HashType, args: string} | null,
+  type: {codeHash: string, hashType: HashType, args: string} | null,
   data: string | null
 }
 
@@ -84,7 +85,7 @@ export default class IndexerConnector {
       await this.processNextBlockNumber()
 
       while (this.pollingIndexer) {
-        this.indexerTip = this.indexer.tip()
+        this.indexerTip = await this.indexer.tip()
 
         const newInserts = await this.upsertTxHashes()
 
@@ -117,7 +118,7 @@ export default class IndexerConnector {
       throw new Error('at least one parameter is required')
     }
 
-    const queries: CollectorQueries = {}
+    const queries: QueryOptions = {}
     if (lock) {
       queries.lock = {
         code_hash: lock.codeHash,

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-connector.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-connector.ts
@@ -89,7 +89,7 @@ export default class IndexerConnector {
 
         const newInserts = await this.upsertTxHashes()
 
-        const nextUnprocessedBlockTip = await IndexerCacheService.nextUnprocessedBlock()
+        const nextUnprocessedBlockTip = await IndexerCacheService.nextUnprocessedBlock([...this.addressesByWalletId.keys()])
         if (nextUnprocessedBlockTip) {
           this.blockTipSubject.next({
             block_number: nextUnprocessedBlockTip.blockNumber,
@@ -190,7 +190,7 @@ export default class IndexerConnector {
   }
 
   private async upsertTxHashes(): Promise<string[]> {
-    const nextUnprocessedBlock = await IndexerCacheService.nextUnprocessedBlock()
+    const nextUnprocessedBlock = await IndexerCacheService.nextUnprocessedBlock([...this.addressesByWalletId.keys()])
     if (nextUnprocessedBlock) {
       return []
     }

--- a/packages/neuron-wallet/src/models/subjects/wallet-deleted-subject.ts
+++ b/packages/neuron-wallet/src/models/subjects/wallet-deleted-subject.ts
@@ -1,0 +1,15 @@
+import { Subject } from 'rxjs'
+import ProcessUtils from 'utils/process'
+import { remote } from 'electron'
+
+export default class WalletDeletedSubject {
+  private static subject = new Subject<string>()
+
+  public static getSubject() {
+    if (ProcessUtils.isRenderer()) {
+      return remote.require('./models/subjects/wallet-delete-subject').default.getSubject()
+    } else {
+      return this.subject
+    }
+  }
+}

--- a/packages/neuron-wallet/src/services/tx/transaction-persistor.ts
+++ b/packages/neuron-wallet/src/services/tx/transaction-persistor.ts
@@ -184,6 +184,7 @@ export class TransactionPersistor {
       } catch (err) {
         logger.error('Database:\tsaveWithFetch update error:', err)
         await queryRunner.rollbackTransaction()
+        throw err
       } finally {
         await queryRunner.release()
       }
@@ -318,6 +319,7 @@ export class TransactionPersistor {
     } catch (err) {
       logger.error('Database:\tcreate transaction error:', err)
       await queryRunner.rollbackTransaction()
+      throw err
     } finally {
       await queryRunner.release()
     }

--- a/packages/neuron-wallet/src/services/wallets.ts
+++ b/packages/neuron-wallet/src/services/wallets.ts
@@ -1,9 +1,10 @@
 import { v4 as uuid } from 'uuid'
-import { AccountExtendedPublicKey, DefaultAddressNumber } from 'models/keys/key'
-import Keystore from 'models/keys/keystore'
-import Store from 'models/store'
 import { WalletNotFound, IsRequired, UsedName } from 'exceptions'
+import Store from 'models/store'
+import Keystore from 'models/keys/keystore'
+import WalletDeletedSubject from 'models/subjects/wallet-deleted-subject'
 import { WalletListSubject, CurrentWalletSubject } from 'models/subjects/wallets'
+import { AccountExtendedPublicKey, DefaultAddressNumber } from 'models/keys/key'
 
 import FileService from './file'
 import AddressService from './addresses'
@@ -239,6 +240,7 @@ export default class WalletService {
     this.listStore.writeSync(this.walletsKey, newWallets)
     wallet.deleteKeystore()
     AddressService.deleteByWalletId(id)
+    WalletDeletedSubject.getSubject().next(id)
   }
 
   public setCurrent = (id: string) => {

--- a/packages/neuron-wallet/tests/block-sync-render/index.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/index.test.ts
@@ -3,7 +3,8 @@ import { LumosCellQuery } from "../../src/block-sync-renderer/sync/indexer-conne
 const stubbedElectronBrowserOn = jest.fn()
 const stubbedElectronBrowserLoadURL = jest.fn()
 const stubbedElectronBrowserWebContentSend = jest.fn()
-const stubbedSubjectSubscribe = jest.fn()
+const stubbedAddressCreatedSubjectSubscribe = jest.fn()
+const stubbedWalletDeletedSubjectSubscribe = jest.fn()
 
 const stubbedIpcMainOnce = jest.fn()
 
@@ -22,7 +23,8 @@ const resetMocks = () => {
   stubbedElectronBrowserLoadURL.mockReset()
   stubbedElectronBrowserWebContentSend.mockReset()
 
-  stubbedSubjectSubscribe.mockReset()
+  stubbedAddressCreatedSubjectSubscribe.mockReset()
+  stubbedWalletDeletedSubjectSubscribe.mockReset()
 
   stubbedIpcMainOnce.mockReset()
 }
@@ -47,7 +49,14 @@ describe('block sync render', () => {
       jest.doMock('models/subjects/address-created-subject', () => {
         return {
           getSubject: () => ({
-            subscribe: stubbedSubjectSubscribe
+            subscribe: stubbedAddressCreatedSubjectSubscribe
+          })
+        }
+      });
+      jest.doMock('models/subjects/wallet-deleted-subject', () => {
+        return {
+          getSubject: () => ({
+            subscribe: stubbedWalletDeletedSubjectSubscribe
           })
         }
       });
@@ -58,8 +67,9 @@ describe('block sync render', () => {
     afterEach(() => {
       jest.clearAllTimers()
     });
-    it('subscribes to #AddressCreatedSubject', () => {
-      expect(stubbedSubjectSubscribe).toHaveBeenCalled()
+    it('subscribes to #AddressCreatedSubject and #WalletDeletedSubject', () => {
+      expect(stubbedAddressCreatedSubjectSubscribe).toHaveBeenCalled()
+      expect(stubbedWalletDeletedSubjectSubscribe).toHaveBeenCalled()
     })
     describe('after initialized BrowserWindow', () => {
       beforeEach(() => {
@@ -94,8 +104,9 @@ describe('block sync render', () => {
       });
       require('../../src/block-sync-renderer')
     });
-    it('should not subscribe to #AddressCreatedSubject', () => {
-      expect(stubbedSubjectSubscribe).toHaveBeenCalledTimes(0)
+    it('should not subscribe to #AddressCreatedSubject and #WalletDeletedSubject', () => {
+      expect(stubbedAddressCreatedSubjectSubscribe).toHaveBeenCalledTimes(0)
+      expect(stubbedWalletDeletedSubjectSubscribe).toHaveBeenCalledTimes(0)
     });
   });
 });

--- a/packages/neuron-wallet/tests/block-sync-render/indexer-cache-service.intg.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/indexer-cache-service.intg.test.ts
@@ -1,7 +1,6 @@
 import { when } from 'jest-when'
 import { getConnection } from 'typeorm'
 import { initConnection } from '../../src/database/chain/ormconfig'
-// import IndexerCacheService from '../../src/block-sync-renderer/sync/indexer-cache-service';
 import AddressMeta from '../../src/database/address/meta';
 import { AddressType } from '../../src/models/keys/address';
 import { AddressVersion } from '../../src/database/address/address-dao';

--- a/packages/neuron-wallet/tests/block-sync-render/indexer-cache-service.intg.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/indexer-cache-service.intg.test.ts
@@ -1,7 +1,7 @@
 import { when } from 'jest-when'
 import { getConnection } from 'typeorm'
 import { initConnection } from '../../src/database/chain/ormconfig'
-import IndexerCacheService from '../../src/block-sync-renderer/sync/indexer-cache-service';
+// import IndexerCacheService from '../../src/block-sync-renderer/sync/indexer-cache-service';
 import AddressMeta from '../../src/database/address/meta';
 import { AddressType } from '../../src/models/keys/address';
 import { AddressVersion } from '../../src/database/address/address-dao';
@@ -25,6 +25,8 @@ const stubbedIndexerConstructor = jest.fn().mockImplementation(
   })
 )
 
+const stubbedTransactionCollectorConstructor = jest.fn()
+
 const resetMocks = () => {
   stubbedGetTransactionFn.mockReset()
   stubbedGetHeaderFn.mockReset()
@@ -32,7 +34,8 @@ const resetMocks = () => {
 }
 
 describe('indexer cache service', () => {
-  let indexerCacheService: IndexerCacheService
+  let IndexerCacheService: any
+  let indexerCacheService: any
   let rpcService: RpcService
 
   const walletId = '1'
@@ -52,11 +55,37 @@ describe('indexer cache service', () => {
   }
   const addressMeta = AddressMeta.fromObject(address)
   const addressMetas = [addressMeta]
-  const script = addressMeta.generateDefaultLockScript()
-  const formattedScript = {
-    code_hash: script.codeHash,
-    hash_type: script.hashType,
-    args: script.args
+  const defaultLockScript = addressMeta.generateDefaultLockScript()
+  const singleMultiSignLockScript = addressMeta.generateSingleMultiSignLockScript()
+  const acpLockScript = addressMeta.generateACPLockScript()
+  const formattedDefaultLockScript = {
+    code_hash: defaultLockScript.codeHash,
+    hash_type: defaultLockScript.hashType,
+    args: defaultLockScript.args
+  }
+  const formattedSingleMultiSignLockScript = {
+    code_hash: singleMultiSignLockScript.codeHash,
+    hash_type: singleMultiSignLockScript.hashType,
+    args: singleMultiSignLockScript.args
+  }
+  const formattedAcpLockScript = {
+    code_hash: acpLockScript.codeHash,
+    hash_type: acpLockScript.hashType,
+    args: acpLockScript.args
+  }
+
+  const mockGetTransactionHashes = (mocks: any[]) => {
+    const stubbedConstructor = when(stubbedTransactionCollectorConstructor)
+    for (const mock of mocks) {
+      const {lock, hashes} = mock
+      stubbedConstructor
+        .calledWith(expect.anything(), {lock})
+        .mockReturnValue({
+          get_transaction_hashes: jest.fn().mockReturnValue({
+            toArray: () => hashes
+          }),
+        })
+    }
   }
 
   const fakeBlock1 = {number: '1', hash: '1', timestamp: '1'}
@@ -85,7 +114,15 @@ describe('indexer cache service', () => {
 
     resetMocks()
 
+    jest.doMock('@ckb-lumos/indexer', () => {
+      return {
+        Indexer : stubbedIndexerConstructor,
+        TransactionCollector : stubbedTransactionCollectorConstructor
+      }
+    });
+
     rpcService = new stubbedRPCServiceConstructor()
+    IndexerCacheService = require('../../src/block-sync-renderer/sync/indexer-cache-service').default
     indexerCacheService = new IndexerCacheService(walletId, addressMetas, rpcService, stubbedIndexerConstructor())
   })
 
@@ -103,12 +140,23 @@ describe('indexer cache service', () => {
     describe('when there are tx hashes from indexer', () => {
       let initTxHashes: any
       beforeEach(async () => {
-        when(stubbedGetTransactionsByLockScriptFn)
-          .calledWith(formattedScript)
-          .mockReturnValueOnce([
-            fakeTx1.transaction.hash,
-            fakeTx3.transaction.hash,
-          ])
+        mockGetTransactionHashes([
+          {
+            lock: formattedDefaultLockScript,
+            hashes: [
+              fakeTx1.transaction.hash,
+              fakeTx3.transaction.hash,
+            ]
+          },
+          {
+            lock: formattedSingleMultiSignLockScript,
+            hashes: []
+          },
+          {
+            lock: formattedAcpLockScript,
+            hashes: []
+          }
+        ])
         when(stubbedGetTransactionFn)
           .calledWith(fakeTx1.transaction.hash).mockReturnValueOnce(fakeTx1)
           .calledWith(fakeTx3.transaction.hash).mockReturnValueOnce(fakeTx3)
@@ -133,13 +181,24 @@ describe('indexer cache service', () => {
       });
       describe('when new tx hash available', () => {
         beforeEach(async () => {
-          when(stubbedGetTransactionsByLockScriptFn)
-            .calledWith(formattedScript)
-            .mockReturnValueOnce([
-              fakeTx1.transaction.hash,
-              fakeTx2.transaction.hash,
-              fakeTx3.transaction.hash,
-            ])
+          mockGetTransactionHashes([
+            {
+              lock: formattedDefaultLockScript,
+              hashes: [
+                fakeTx1.transaction.hash,
+                fakeTx2.transaction.hash,
+                fakeTx3.transaction.hash,
+              ]
+            },
+            {
+              lock: formattedSingleMultiSignLockScript,
+              hashes: []
+            },
+            {
+              lock: formattedAcpLockScript,
+              hashes: []
+            }
+          ])
           when(stubbedGetTransactionFn)
             .calledWith(fakeTx2.transaction.hash)
             .mockReturnValueOnce(fakeTx2)
@@ -162,12 +221,23 @@ describe('indexer cache service', () => {
       describe('when all of tx hashes cache exists', () => {
         beforeEach(async () => {
           resetMocks()
-          when(stubbedGetTransactionsByLockScriptFn)
-            .calledWith(formattedScript)
-            .mockReturnValueOnce([
-              fakeTx1.transaction.hash,
-              fakeTx3.transaction.hash,
-            ])
+          mockGetTransactionHashes([
+            {
+              lock: formattedDefaultLockScript,
+              hashes: [
+                fakeTx1.transaction.hash,
+                fakeTx3.transaction.hash,
+              ]
+            },
+            {
+              lock: formattedSingleMultiSignLockScript,
+              hashes: []
+            },
+            {
+              lock: formattedAcpLockScript,
+              hashes: []
+            }
+          ])
 
           await indexerCacheService.upsertTxHashes()
         });
@@ -185,13 +255,24 @@ describe('indexer cache service', () => {
   });
   describe('#updateProcessedTxHashes', () => {
     beforeEach(async () => {
-      when(stubbedGetTransactionsByLockScriptFn)
-        .calledWith(formattedScript)
-        .mockReturnValueOnce([
-          fakeTx1.transaction.hash,
-          fakeTx2.transaction.hash,
-          fakeTx3.transaction.hash,
-        ])
+      mockGetTransactionHashes([
+        {
+          lock: formattedDefaultLockScript,
+          hashes: [
+            fakeTx1.transaction.hash,
+            fakeTx2.transaction.hash,
+            fakeTx3.transaction.hash,
+          ]
+        },
+        {
+          lock: formattedSingleMultiSignLockScript,
+          hashes: []
+        },
+        {
+          lock: formattedAcpLockScript,
+          hashes: []
+        }
+      ])
       when(stubbedGetTransactionFn)
         .calledWith(fakeTx1.transaction.hash).mockReturnValueOnce(fakeTx1)
         .calledWith(fakeTx2.transaction.hash).mockReturnValueOnce(fakeTx2)
@@ -215,13 +296,24 @@ describe('indexer cache service', () => {
   describe('#nextUnprocessedTxsGroupedByBlockNumber', () => {
     describe('when there are caches', () => {
       beforeEach(async () => {
-        when(stubbedGetTransactionsByLockScriptFn)
-          .calledWith(formattedScript)
-          .mockReturnValueOnce([
-            fakeTx1.transaction.hash,
-            fakeTx2.transaction.hash,
-            fakeTx3.transaction.hash,
-          ])
+        mockGetTransactionHashes([
+          {
+            lock: formattedDefaultLockScript,
+            hashes: [
+              fakeTx1.transaction.hash,
+              fakeTx2.transaction.hash,
+              fakeTx3.transaction.hash,
+            ]
+          },
+          {
+            lock: formattedSingleMultiSignLockScript,
+            hashes: []
+          },
+          {
+            lock: formattedAcpLockScript,
+            hashes: []
+          }
+        ])
         when(stubbedGetTransactionFn)
           .calledWith(fakeTx1.transaction.hash).mockReturnValueOnce(fakeTx1)
           .calledWith(fakeTx2.transaction.hash).mockReturnValueOnce(fakeTx2)
@@ -281,13 +373,24 @@ describe('indexer cache service', () => {
     });
     describe('when all transactions are processed', () => {
       beforeEach(async () => {
-        when(stubbedGetTransactionsByLockScriptFn)
-          .calledWith(formattedScript)
-          .mockReturnValueOnce([
-            fakeTx1.transaction.hash,
-            fakeTx2.transaction.hash,
-            fakeTx3.transaction.hash,
-          ])
+        mockGetTransactionHashes([
+          {
+            lock: formattedDefaultLockScript,
+            hashes: [
+              fakeTx1.transaction.hash,
+              fakeTx2.transaction.hash,
+              fakeTx3.transaction.hash,
+            ]
+          },
+          {
+            lock: formattedSingleMultiSignLockScript,
+            hashes: []
+          },
+          {
+            lock: formattedAcpLockScript,
+            hashes: []
+          }
+        ])
         when(stubbedGetTransactionFn)
           .calledWith(fakeTx1.transaction.hash).mockReturnValueOnce(fakeTx1)
           .calledWith(fakeTx2.transaction.hash).mockReturnValueOnce(fakeTx2)
@@ -313,9 +416,22 @@ describe('indexer cache service', () => {
   });
   describe('#nextUnprocessedBlock', () => {
     beforeEach(async () => {
-      when(stubbedGetTransactionsByLockScriptFn)
-        .calledWith(formattedScript)
-        .mockReturnValueOnce([fakeTx1.transaction.hash])
+      mockGetTransactionHashes([
+        {
+          lock: formattedDefaultLockScript,
+          hashes: [
+            fakeTx1.transaction.hash,
+          ]
+        },
+        {
+          lock: formattedSingleMultiSignLockScript,
+          hashes: []
+        },
+        {
+          lock: formattedAcpLockScript,
+          hashes: []
+        }
+      ])
       when(stubbedGetTransactionFn)
         .calledWith(fakeTx1.transaction.hash).mockReturnValueOnce(fakeTx1)
       when(stubbedGetHeaderFn)
@@ -350,13 +466,24 @@ describe('indexer cache service', () => {
   describe('#updateCacheProcessed', () => {
     describe('when there are unprocessed tx hash cache', () => {
       beforeEach(async () => {
-        when(stubbedGetTransactionsByLockScriptFn)
-          .calledWith(formattedScript)
-          .mockReturnValueOnce([
-            fakeTx1.transaction.hash,
-            fakeTx2.transaction.hash,
-            fakeTx3.transaction.hash,
-          ])
+        mockGetTransactionHashes([
+          {
+            lock: formattedDefaultLockScript,
+            hashes: [
+              fakeTx1.transaction.hash,
+              fakeTx2.transaction.hash,
+              fakeTx3.transaction.hash,
+            ]
+          },
+          {
+            lock: formattedSingleMultiSignLockScript,
+            hashes: []
+          },
+          {
+            lock: formattedAcpLockScript,
+            hashes: []
+          }
+        ])
         when(stubbedGetTransactionFn)
           .calledWith(fakeTx1.transaction.hash).mockReturnValueOnce(fakeTx1)
           .calledWith(fakeTx2.transaction.hash).mockReturnValueOnce(fakeTx2)

--- a/packages/neuron-wallet/tests/block-sync-render/indexer-cache-service.intg.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/indexer-cache-service.intg.test.ts
@@ -440,11 +440,32 @@ describe('indexer cache service', () => {
       await indexerCacheService.upsertTxHashes()
     });
     describe('when has unprocessed blocks', () => {
-      it('returns next unprocessed block number', async () => {
-        const nextUnprocessedBlock = await IndexerCacheService.nextUnprocessedBlock()
-        expect(nextUnprocessedBlock).toEqual({
-          blockNumber: fakeBlock1.number, blockHash: fakeBlock1.hash
-        })
+      let nextUnprocessedBlock: any
+      describe('check with walletId having tx hash caches', () => {
+        beforeEach(async () => {
+          nextUnprocessedBlock = await IndexerCacheService.nextUnprocessedBlock([walletId])
+        });
+        it('returns next unprocessed block number', async () => {
+          expect(nextUnprocessedBlock).toEqual({
+            blockNumber: fakeBlock1.number, blockHash: fakeBlock1.hash
+          })
+        });
+      });
+      describe('check with walletId that does not have hash caches', () => {
+        beforeEach(async () => {
+          nextUnprocessedBlock = await IndexerCacheService.nextUnprocessedBlock(['w1'])
+        });
+        it('returns undefined', async () => {
+          expect(nextUnprocessedBlock).toEqual(undefined)
+        });
+      });
+      describe('check with empty walletIds array', () => {
+        beforeEach(async () => {
+          nextUnprocessedBlock = await IndexerCacheService.nextUnprocessedBlock([])
+        });
+        it('returns undefined', async () => {
+          expect(nextUnprocessedBlock).toEqual(undefined)
+        });
       });
     });
     describe('when has no unprocessed blocks', () => {
@@ -458,7 +479,7 @@ describe('indexer cache service', () => {
           .execute()
       });
       it('returns undefined', async () => {
-        const nextUnprocessedBlock = await IndexerCacheService.nextUnprocessedBlock()
+        const nextUnprocessedBlock = await IndexerCacheService.nextUnprocessedBlock([walletId])
         expect(nextUnprocessedBlock).toEqual(undefined)
       });
     });

--- a/packages/neuron-wallet/tests/block-sync-render/indexer-connector.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/indexer-connector.test.ts
@@ -382,6 +382,8 @@ describe('unit tests for IndexerConnector', () => {
             args: '0x'
           },
           type: {
+            //test the workaround for this lumos data issue
+            //@ts-ignore
             hashType: 'lock',
             codeHash: '0xcode',
             args: '0x'

--- a/packages/neuron-wallet/tests/block-sync-render/queue.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/queue.test.ts
@@ -28,6 +28,7 @@ const stubbedSaveFetchFn = jest.fn()
 const stubbedUpdateUsedAddressesFn = jest.fn()
 const stubbedNotifyCurrentBlockNumberProcessedFn = jest.fn()
 const stubbedUpdateCacheProcessedFn = jest.fn()
+const stubbedLoggerErrorFn = jest.fn()
 
 const stubbedTxAddressFinder = jest.fn().mockImplementation(
   (...args) => {
@@ -58,6 +59,7 @@ const resetMocks = () => {
   stubbedGetTransactionFn.mockReset()
   stubbedNotifyCurrentBlockNumberProcessedFn.mockReset()
   stubbedUpdateCacheProcessedFn.mockReset()
+  stubbedLoggerErrorFn.mockReset()
 }
 
 const generateFakeTx = (id: string) => {
@@ -148,6 +150,9 @@ describe('queue', () => {
         updateUsedAddresses: stubbedUpdateUsedAddressesFn
       }
     });
+    jest.doMock('utils/logger', () => {
+      return {error: stubbedLoggerErrorFn}
+    });
     jest.doMock('../../src/block-sync-renderer/sync/indexer-connector', () => {
       return stubbedIndexerConnector
     });
@@ -189,14 +194,14 @@ describe('queue', () => {
       });
     })
     describe('subscribes to IndexerConnector#transactionsSubject', () => {
-      describe('processes transactions from an event', () => {
-        const fakeTxWithStatus1 = generateFakeTx('1')
-        const fakeTxWithStatus2 = generateFakeTx('2')
+      const fakeTxWithStatus1 = generateFakeTx('1')
+      const fakeTxWithStatus2 = generateFakeTx('2')
 
-        const fakeTxs = [
-          fakeTxWithStatus2
-        ]
-        beforeEach(async () => {
+      const fakeTxs = [
+        fakeTxWithStatus2
+      ]
+      describe('processes transactions from an event', () => {
+        beforeEach(() => {
           stubbedAddressesFn.mockResolvedValue([
             true,
             addresses.map(addressMeta => addressMeta.address),
@@ -204,39 +209,53 @@ describe('queue', () => {
           ])
           stubbedGetTransactionFn.mockResolvedValue(fakeTxWithStatus1)
           stubbedTransactionsSubject.next(fakeTxs)
-          await flushPromises()
         });
-        it('check infos by hashes derived from addresses', () => {
-          const lockHashes = ['0x1f2615a8dde4e28ca736ff763c2078aff990043f4cbf09eb4b3a58a140a0862d']
-          const acpLockHashes = ['0xbda2cfe4214ec63ec301170527222742d9af51b876af12d842a309bc28ee6523']
-          const multiSignBlake160s = ['0x3f9dcc063f5212ec07bbee31e62950b4ea481c53']
-          expect(stubbedTxAddressFinderConstructor).toHaveBeenCalledWith(
-            lockHashes,
-            acpLockHashes,
-            fakeTxs[0].transaction,
-            multiSignBlake160s
-          )
-        })
-        it('saves transactions', () => {
-          for (const {transaction} of fakeTxs) {
-            expect(stubbedSaveFetchFn).toHaveBeenCalledWith(transaction)
-          }
-        });
-        it('updates used addresses', () => {
-          for (let i = 0; i < fakeTxs.length; i++) {
-            expect(stubbedUpdateUsedAddressesFn).toHaveBeenCalledWith(
-              addresses.map(addressMeta => addressMeta.address), []
+        describe('when saving transactions is succeeded', () => {
+          beforeEach(flushPromises)
+
+          it('check infos by hashes derived from addresses', () => {
+            const lockHashes = ['0x1f2615a8dde4e28ca736ff763c2078aff990043f4cbf09eb4b3a58a140a0862d']
+            const acpLockHashes = ['0xbda2cfe4214ec63ec301170527222742d9af51b876af12d842a309bc28ee6523']
+            const multiSignBlake160s = ['0x3f9dcc063f5212ec07bbee31e62950b4ea481c53']
+            expect(stubbedTxAddressFinderConstructor).toHaveBeenCalledWith(
+              lockHashes,
+              acpLockHashes,
+              fakeTxs[0].transaction,
+              multiSignBlake160s
             )
-          }
+          })
+          it('saves transactions', () => {
+            for (const {transaction} of fakeTxs) {
+              expect(stubbedSaveFetchFn).toHaveBeenCalledWith(transaction)
+            }
+          });
+          it('updates used addresses', () => {
+            for (let i = 0; i < fakeTxs.length; i++) {
+              expect(stubbedUpdateUsedAddressesFn).toHaveBeenCalledWith(
+                addresses.map(addressMeta => addressMeta.address), []
+              )
+            }
+          });
+          it('notify indexer connector of processed block number', () => {
+            expect(stubbedNotifyCurrentBlockNumberProcessedFn).toHaveBeenCalledWith()
+          });
+          it('updates tx hash cache to be processed', () => {
+            expect(stubbedUpdateCacheProcessedFn).toHaveBeenCalledWith(fakeTxs[0].transaction.hash)
+          })
         });
-        it('notify indexer connector of processed block number', () => {
-          expect(stubbedNotifyCurrentBlockNumberProcessedFn).toHaveBeenCalledWith(
-            fakeTxWithStatus1.transaction.blockNumber
-          )
+        describe('when failed saving transactions', () => {
+          const err = new Error()
+          beforeEach(async () => {
+            stubbedSaveFetchFn.mockRejectedValueOnce(err)
+            await flushPromises()
+          });
+          it('handles the exception', async () => {
+            expect(stubbedLoggerErrorFn).toHaveBeenCalledWith(
+              expect.stringMatching(/retry saving transactions in.*seconds/),
+              err
+            )
+          })
         });
-        it('updates tx hash cache to be processed', () => {
-          expect(stubbedUpdateCacheProcessedFn).toHaveBeenCalledWith(fakeTxs[0].transaction.hash)
-        })
       });
     });
   });

--- a/packages/neuron-wallet/tests/services/wallets.test.ts
+++ b/packages/neuron-wallet/tests/services/wallets.test.ts
@@ -110,14 +110,6 @@ describe('wallet service', () => {
     expect(wallet && wallet.name).toEqual(wallet2.name)
   })
 
-  it('delete wallet', () => {
-    const w1 = walletService.create(wallet1)
-    walletService.create(wallet2)
-    expect(walletService.getAll().length).toBe(2)
-    walletService.delete(w1.id)
-    expect(() => walletService.get(w1.id)).toThrowError()
-  })
-
   it('get and set active wallet', () => {
     const w1 = walletService.create(wallet1)
     const w2 = walletService.create(wallet2)
@@ -142,20 +134,43 @@ describe('wallet service', () => {
     expect(activeWallet && activeWallet.id).toEqual(w2.id)
   })
 
-  it('delete current wallet', () => {
-    const w1 = walletService.create(wallet1)
-    const w2 = walletService.create(wallet2)
-    walletService.delete(w1.id)
-    const activeWallet = walletService.getCurrent()
-    expect(activeWallet && activeWallet.id).toEqual(w2.id)
-    expect(walletService.getAll().length).toEqual(1)
-  })
+  describe('#delete', () => {
+    let w1: any
+    beforeEach(() => {
+      w1 = walletService.create(wallet1)
+    });
+    it('delete wallet', () => {
+      walletService.create(wallet2)
+      expect(walletService.getAll().length).toBe(2)
+      walletService.delete(w1.id)
+      expect(() => walletService.get(w1.id)).toThrowError()
+    })
 
-  it('delete none current wallet', () => {
-    const w1 = walletService.create(wallet1)
-    const w2 = walletService.create(wallet2)
-    walletService.delete(w2.id)
-    const activeWallet = walletService.getCurrent()
-    expect(activeWallet && activeWallet.id).toEqual(w1.id)
-  })
+    describe('with more than one wallets', () => {
+      let w2: any
+      beforeEach(() => {
+        w2 = walletService.create(wallet2)
+      });
+      describe('when deleted current wallet', () => {
+        beforeEach(() => {
+          walletService.delete(w1.id)
+        });
+        it('switches active wallet', () => {
+          const activeWallet = walletService.getCurrent()
+          expect(activeWallet && activeWallet.id).toEqual(w2.id)
+          expect(walletService.getAll().length).toEqual(1)
+        })
+      });
+      describe('when deleted wallets other than current wallet', () => {
+        beforeEach(() => {
+          walletService.delete(w2.id)
+        });
+        it('should not switch active wallet', () => {
+          const activeWallet = walletService.getCurrent()
+          expect(activeWallet && activeWallet.id).toEqual(w1.id)
+        })
+      });
+
+    });
+  });
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1424,11 +1424,22 @@
   resolved "https://node.bit.dev/primefaces.primereact.utils.dom-handler/-/primefaces.primereact.utils.dom-handler-3.1.8.tgz#02a740dbe15d1f47aa412ade327e394d425a412f"
   integrity sha1-AqdA2+FdH0eqQSreMn45TUJaQS8=
 
-"@ckb-lumos/indexer@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@ckb-lumos/indexer/-/indexer-0.3.0.tgz#f803a3084625ea21446796af8925fce8b55126e0"
-  integrity sha512-nINQPewEiYAEfjilNjbL5BLdKqyydXt0aEVlck6xZNMSUyTrTbRk0o1PvUwYe0XKjUNIhRmupoUQjdSDkG4ssQ==
+"@ckb-lumos/base@0.4.8", "@ckb-lumos/base@^0.4.8":
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/@ckb-lumos/base/-/base-0.4.8.tgz#04551817312530146383d12104717a8d3764a5da"
+  integrity sha512-Nwp5zhN0JgYjyqkeuIGR3tGL8j4f6G/rFsWK/qWpZhpsK95zJlPC+OogP/gVES/Cl9XPa9Ouq886sCe/8qfiHg==
   dependencies:
+    blake2b "^2.1.3"
+    ckb-js-toolkit "^0.9.1"
+    immutable "^4.0.0-rc.12"
+    xxhash "^0.3.0"
+
+"@ckb-lumos/indexer@0.4.8":
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/@ckb-lumos/indexer/-/indexer-0.4.8.tgz#272f0d55d34a610667070318f1daf0390004d66f"
+  integrity sha512-h90zKSuJoPQhNCChxD/Fw8vPRoS7BJ07x8zU6NrAkyqRBtm8uBMUJXD7Rh/lL3ExID0pALD8Wu+ReXOzFNHq3w==
+  dependencies:
+    "@ckb-lumos/base" "^0.4.8"
     ckb-js-toolkit "^0.9.1"
     immutable "^4.0.0-rc.12"
     neon-cli "^0.4.0"
@@ -5807,6 +5818,21 @@ blake2b-wasm@2.1.0:
   resolved "https://registry.yarnpkg.com/blake2b-wasm/-/blake2b-wasm-2.1.0.tgz#aa90ed687b8a92e1c01d1643db86bcf21caa2ab7"
   integrity sha512-8zKXt9nk4cUCBU2jaUcSYcPA+UESwWOmb9Gsi8J35BifVb+tjVmbDhZbvmVmZEk6xZN1y35RNW6VqOwb0mkqsg==
   dependencies:
+    nanoassert "^1.0.0"
+
+blake2b-wasm@^1.1.0:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/blake2b-wasm/-/blake2b-wasm-1.1.7.tgz#e4d075da10068e5d4c3ec1fb9accc4d186c55d81"
+  integrity sha512-oFIHvXhlz/DUgF0kq5B1CqxIDjIJwh9iDeUUGQUcvgiGz7Wdw03McEO7CfLBy7QKGdsydcMCgO9jFNBAFCtFcA==
+  dependencies:
+    nanoassert "^1.0.0"
+
+blake2b@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/blake2b/-/blake2b-2.1.3.tgz#f5388be424768e7c6327025dad0c3c6d83351bca"
+  integrity sha512-pkDss4xFVbMb4270aCyGD3qLv92314Et+FsKzilCLxDz5DuZ2/1g3w4nmBbu6nKApPspnjG7JcwTjGZnduB1yg==
+  dependencies:
+    blake2b-wasm "^1.1.0"
     nanoassert "^1.0.0"
 
 block-stream@*:

--- a/yarn.lock
+++ b/yarn.lock
@@ -14072,7 +14072,7 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
-neon-cli@0.4.0, neon-cli@^0.4.0:
+neon-cli@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/neon-cli/-/neon-cli-0.4.0.tgz#d89e0a55b8db577324af70470e2b4e67157205f6"
   integrity sha512-66HhHb8rk+zHSG64CI6jhyOQqpibBAald8ObdQPCjXcCjzSEVnkQHutUE8dyNlHRNT7xLfrZGkDbtwrYh2p+6w==


### PR DESCRIPTION
* Upgrade to lumos indexer 0.4.8
* Refactors according to the API changes between lumos indexer 0.3.0 and 0.4.8
* Prevent unnecessary index rebuild after imported a wallet
* Fix the incorrect balance issue caused by the silenced errors when saving transactions
* Update yarn bootstrap script to deprecate building for lumos indexer
* Reload sync block render after deleted a wallet