### PR TITLE
chore: Bump version to v0.32.0-rc1 and update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+# 0.32.0-rc1 (2020-07-21)
+
+This is an RC version to preview the changes in the next release.
+
+### Bundled CKB node
+
+[CKB v0.32.0](https://github.com/nervosnetwork/ckb/releases/tag/v0.32.0) was released on May 22nd, 2020. This version of CKB node is now bundled and preconfigured in Neuron. 
+
+### New features
+
+* Detect vcredist on Windows when user launches Neuron.
+* Enable the button of exporting transaction history.
+* Support two modes for clearing caches: Refresh cache / Fully rebuild index.
+* UI tune for pop-up windows.
+* Share token info across different wallets.
+* Add a link of `Deposit rules` on `Nervos DAO` page.
+* Remove the FAQ from menu and update docs link.
+* Order the `Completed` DAO records by unlock time in desc.
+
+### Syncing
+
+It has adopted a brand new indexing mechanism, which can significantly speed up the cache indexing process. The caches will be rebuilt for the first time, but it should be much faster than the previous versions (up to 3-4x on macOS, Windows and Linux).
+
+### Bug fixes
+
+* Fixed minor bugs on `History` page.
+* Fixed some Traditional Chinese words.
+
+
 # 0.32.0-beta.1 (2020-07-04)
 
 This is a beta version to preview the changes in the next release and may not be stable. It is not suggested to install this version for asset management. Welcome any questions or suggestions.

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.32.0-beta.1",
+  "version": "0.32.0-rc1",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "neuron",
   "productName": "Neuron",
   "description": "CKB Neuron Wallet",
-  "version": "0.32.0-beta.1",
+  "version": "0.32.0-rc1",
   "private": true,
   "author": {
     "name": "Nervos Core Dev",

--- a/packages/neuron-ui/package.json
+++ b/packages/neuron-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neuron-ui",
-  "version": "0.32.0-beta.1",
+  "version": "0.32.0-rc1",
   "private": true,
   "author": {
     "name": "Nervos Core Dev",

--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -3,7 +3,7 @@
   "productName": "Neuron",
   "description": "CKB Neuron Wallet",
   "homepage": "https://www.nervos.org/",
-  "version": "0.32.0-beta.1",
+  "version": "0.32.0-rc1",
   "private": true,
   "author": {
     "name": "Nervos Core Dev",
@@ -78,7 +78,7 @@
     "electron-notarize": "0.2.1",
     "jest-when": "2.7.2",
     "lint-staged": "9.2.5",
-    "neuron-ui": "0.32.0-beta.1",
+    "neuron-ui": "0.32.0-rc1",
     "rimraf": "3.0.0",
     "ts-transformer-imports": "0.4.3",
     "ttypescript": "1.5.10"


### PR DESCRIPTION
v0.32.0-rc1, scheduled to be released on July 21st.