### PR TITLE
Backend fixes

### DIFF
--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -38,7 +38,7 @@
     "@ckb-lumos/indexer": "0.5.1",
     "@nervosnetwork/ckb-sdk-core": "0.32.0",
     "@nervosnetwork/ckb-sdk-utils": "0.32.0",
-    "archiver": "3.1.1",
+    "archiver": "4.0.2",
     "async": "3.2.0",
     "bn.js": "4.11.8",
     "chalk": "3.0.0",

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-connector.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-connector.ts
@@ -230,7 +230,7 @@ export default class IndexerConnector {
     return txsWithStatus
   }
 
-  public async notifyCurrentBlockNumberProcessed(blockNumber: string) {
+  public notifyCurrentBlockNumberProcessed(blockNumber: string) {
     if (blockNumber === this.processingBlockNumber) {
       delete this.processingBlockNumber
     }

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
@@ -73,7 +73,7 @@ export default class Queue {
         }
       }
 
-      await this.indexerConnector!.notifyCurrentBlockNumberProcessed(transactions[0].blockNumber)
+      this.indexerConnector!.notifyCurrentBlockNumberProcessed(transactions[0].blockNumber)
     })
 
     this.checkAndSaveQueue.error((err: any, task: any) => {

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
@@ -73,7 +73,7 @@ export default class Queue {
         }
       }
 
-      await this.indexerConnector!.notifyCurrentBlockNumberProcessed()
+      await this.indexerConnector!.notifyCurrentBlockNumberProcessed(transactions[0].blockNumber)
     })
 
     this.checkAndSaveQueue.error((err: any, task: any) => {

--- a/packages/neuron-wallet/tests/block-sync-render/indexer-connector.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/indexer-connector.test.ts
@@ -310,7 +310,7 @@ describe('unit tests for IndexerConnector', () => {
                     .mockResolvedValueOnce([
                       fakeTxHashCache3,
                     ])
-                  await indexerConnector.notifyCurrentBlockNumberProcessed(fakeTx1.transaction.blockNumber)
+                  indexerConnector.notifyCurrentBlockNumberProcessed(fakeTx1.transaction.blockNumber)
                   await flushPromises()
                 })
                 it('emits new transactions', async () => {
@@ -322,7 +322,7 @@ describe('unit tests for IndexerConnector', () => {
                   stubbedNextUnprocessedTxsGroupedByBlockNumberFn
                     .mockResolvedValueOnce([])
                     .mockResolvedValueOnce([])
-                  await indexerConnector.notifyCurrentBlockNumberProcessed(fakeTx1.transaction.blockNumber)
+                  indexerConnector.notifyCurrentBlockNumberProcessed(fakeTx1.transaction.blockNumber)
                   await flushPromises()
                 })
                 it('emits new transactions', async () => {
@@ -339,7 +339,7 @@ describe('unit tests for IndexerConnector', () => {
                   .mockResolvedValueOnce([
                     fakeTxHashCache3,
                   ])
-                await indexerConnector.notifyCurrentBlockNumberProcessed('3')
+                indexerConnector.notifyCurrentBlockNumberProcessed('3')
                 await flushPromises()
               })
               it('should not emit new transactions', async () => {

--- a/packages/neuron-wallet/tests/block-sync-render/indexer-connector.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/indexer-connector.test.ts
@@ -226,13 +226,13 @@ describe('unit tests for IndexerConnector', () => {
             stubbedUpsertTxHashesFn.mockResolvedValueOnce([fakeTx3.transaction.hash])
 
             when(stubbedGetTransactionFn)
-              .calledWith(fakeTx1.transaction.hash).mockResolvedValueOnce(fakeTx1)
-              .calledWith(fakeTx2.transaction.hash).mockResolvedValueOnce(fakeTx2)
-              .calledWith(fakeTx3.transaction.hash).mockResolvedValueOnce(fakeTx3)
+              .calledWith(fakeTx1.transaction.hash).mockResolvedValue(fakeTx1)
+              .calledWith(fakeTx2.transaction.hash).mockResolvedValue(fakeTx2)
+              .calledWith(fakeTx3.transaction.hash).mockResolvedValue(fakeTx3)
 
             when(stubbedGetHeaderFn)
-              .calledWith(fakeBlock1.hash).mockResolvedValueOnce(fakeBlock1)
-              .calledWith(fakeBlock2.hash).mockResolvedValueOnce(fakeBlock2)
+              .calledWith(fakeBlock1.hash).mockResolvedValue(fakeBlock1)
+              .calledWith(fakeBlock2.hash).mockResolvedValue(fakeBlock2)
 
             txObserver = jest.fn()
             transactionsSubject.subscribe((transactions: any) => txObserver(transactions))
@@ -283,6 +283,70 @@ describe('unit tests for IndexerConnector', () => {
               expect(txObserver).toHaveBeenCalledWith([fakeTx1])
             });
           });
+          describe('#notifyCurrentBlockNumberProcessed', () => {
+            beforeEach(async () => {
+              stubbedNextUnprocessedTxsGroupedByBlockNumberFn
+                .mockResolvedValueOnce([
+                  fakeTxHashCache1,
+                  fakeTxHashCache2
+                ])
+                .mockResolvedValueOnce([
+                  fakeTxHashCache3,
+                ])
+
+              await connectIndexer(indexerConnector)
+              await flushPromises()
+            })
+            it('emits new transactions', async () => {
+              expect(txObserver).toHaveBeenCalledTimes(1)
+            })
+            describe('when match with the current block number in process', () => {
+              describe('having unprocessed transactions', () => {
+                beforeEach(async () => {
+                  stubbedNextUnprocessedTxsGroupedByBlockNumberFn
+                    .mockResolvedValueOnce([
+                      fakeTxHashCache3
+                    ])
+                    .mockResolvedValueOnce([
+                      fakeTxHashCache3,
+                    ])
+                  await indexerConnector.notifyCurrentBlockNumberProcessed(fakeTx1.transaction.blockNumber)
+                  await flushPromises()
+                })
+                it('emits new transactions', async () => {
+                  expect(txObserver).toHaveBeenCalledTimes(2)
+                })
+              });
+              describe('having no unprocessed transactions', () => {
+                beforeEach(async () => {
+                  stubbedNextUnprocessedTxsGroupedByBlockNumberFn
+                    .mockResolvedValueOnce([])
+                    .mockResolvedValueOnce([])
+                  await indexerConnector.notifyCurrentBlockNumberProcessed(fakeTx1.transaction.blockNumber)
+                  await flushPromises()
+                })
+                it('emits new transactions', async () => {
+                  expect(txObserver).toHaveBeenCalledTimes(1)
+                })
+              });
+            });
+            describe('when not match with the current block number in process', () => {
+              beforeEach(async () => {
+                stubbedNextUnprocessedTxsGroupedByBlockNumberFn
+                  .mockResolvedValueOnce([
+                    fakeTxHashCache3
+                  ])
+                  .mockResolvedValueOnce([
+                    fakeTxHashCache3,
+                  ])
+                await indexerConnector.notifyCurrentBlockNumberProcessed('3')
+                await flushPromises()
+              })
+              it('should not emit new transactions', async () => {
+                expect(txObserver).toHaveBeenCalledTimes(1)
+              })
+            });
+          })
         });
         describe('when there are no transactions matched', () => {
           let txObserver: any

--- a/packages/neuron-wallet/tests/block-sync-render/queue.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/queue.test.ts
@@ -237,7 +237,7 @@ describe('queue', () => {
             }
           });
           it('notify indexer connector of processed block number', () => {
-            expect(stubbedNotifyCurrentBlockNumberProcessedFn).toHaveBeenCalledWith()
+            expect(stubbedNotifyCurrentBlockNumberProcessedFn).toHaveBeenCalledWith(fakeTxs[0].transaction.blockNumber)
           });
           it('updates tx hash cache to be processed', () => {
             expect(stubbedUpdateCacheProcessedFn).toHaveBeenCalledWith(fakeTxs[0].transaction.hash)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3827,7 +3827,15 @@
   dependencies:
     "@types/node" "*"
 
-"@types/glob@*", "@types/glob@^7.1.1":
+"@types/glob@*":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
+  integrity sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
+"@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
   integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
@@ -4913,18 +4921,18 @@ archiver-utils@^2.1.0:
     normalize-path "^3.0.0"
     readable-stream "^2.0.0"
 
-archiver@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/archiver/-/archiver-3.1.1.tgz#9db7819d4daf60aec10fe86b16cb9258ced66ea0"
-  integrity sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==
+archiver@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/archiver/-/archiver-4.0.2.tgz#43c72865eadb4ddaaa2fb74852527b6a450d927c"
+  integrity sha512-B9IZjlGwaxF33UN4oPbfBkyA4V1SxNLeIhR1qY8sRXSsbdUkEHrrOvwlYFPx+8uQeCe9M+FG6KgO+imDmQ79CQ==
   dependencies:
     archiver-utils "^2.1.0"
-    async "^2.6.3"
+    async "^3.2.0"
     buffer-crc32 "^0.2.1"
-    glob "^7.1.4"
-    readable-stream "^3.4.0"
-    tar-stream "^2.1.0"
-    zip-stream "^2.1.2"
+    glob "^7.1.6"
+    readable-stream "^3.6.0"
+    tar-stream "^2.1.2"
+    zip-stream "^3.0.1"
 
 are-we-there-yet@~1.1.2:
   version "1.1.5"
@@ -5190,12 +5198,12 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
-async@3.2.0:
+async@3.2.0, async@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
   integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
 
-async@^2.6.2, async@^2.6.3:
+async@^2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
   integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
@@ -6986,15 +6994,15 @@ compose-function@3.0.3:
   dependencies:
     arity-n "^1.0.4"
 
-compress-commons@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-2.1.1.tgz#9410d9a534cf8435e3fbbb7c6ce48de2dc2f0610"
-  integrity sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==
+compress-commons@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-3.0.0.tgz#833944d84596e537224dd91cf92f5246823d4f1d"
+  integrity sha512-FyDqr8TKX5/X0qo+aVfaZ+PVmNJHJeckFBlq8jZGSJOgnynhfifoyl24qaqdUdDIBe0EVTHByN6NAkqYvE/2Xg==
   dependencies:
     buffer-crc32 "^0.2.13"
     crc32-stream "^3.0.1"
     normalize-path "^3.0.0"
-    readable-stream "^2.3.6"
+    readable-stream "^2.3.7"
 
 compressible@~2.0.16:
   version "2.0.18"
@@ -17057,7 +17065,7 @@ read@1, read@~1.0.1:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@^2.3.7, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -17074,6 +17082,15 @@ read@1, read@~1.0.1:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.5.0.tgz#465d70e6d1087f6162d079cd0b5db7fbebfd1606"
   integrity sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
+readable-stream@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -19034,10 +19051,10 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar-stream@^2.1.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.2.tgz#6d5ef1a7e5783a95ff70b69b97455a5968dc1325"
-  integrity sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==
+tar-stream@^2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.3.tgz#1e2022559221b7866161660f118255e20fa79e41"
+  integrity sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==
   dependencies:
     bl "^4.0.1"
     end-of-stream "^1.4.1"
@@ -21026,14 +21043,14 @@ yauzl@2.4.1:
   dependencies:
     fd-slicer "~1.0.1"
 
-zip-stream@^2.1.2:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/zip-stream/-/zip-stream-2.1.3.tgz#26cc4bdb93641a8590dd07112e1f77af1758865b"
-  integrity sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==
+zip-stream@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/zip-stream/-/zip-stream-3.0.1.tgz#cb8db9d324a76c09f9b76b31a12a48638b0b9708"
+  integrity sha512-r+JdDipt93ttDjsOVPU5zaq5bAyY+3H19bDrThkvuVxC0xMQzU1PJcS6D+KrP3u96gH9XLomcHPb+2skoDjulQ==
   dependencies:
     archiver-utils "^2.1.0"
-    compress-commons "^2.1.1"
-    readable-stream "^3.4.0"
+    compress-commons "^3.0.0"
+    readable-stream "^3.6.0"
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
* Fix log export by upgrading `archiver` to 4.0.2,  which has the same major version of `async` dependency as wallet backend has.
* Avoid redundant processing on the blocks that have been processed already.