### PR TITLE
Deprecate the 'remote' module

### DIFF
--- a/packages/neuron-ui/src/components/ImportKeystore/index.tsx
+++ b/packages/neuron-ui/src/components/ImportKeystore/index.tsx
@@ -69,7 +69,12 @@ const ImportKeystore = () => {
     showOpenDialogModal({
       title: 'import keystore',
     })
-      .then(({ filePaths }: { filePaths: string[] }) => {
+      .then(res => {
+        if (!isSuccessResponse(res)) {
+          console.error(res.message)
+          return
+        }
+        const { filePaths } = res.result!
         const filePath = filePaths[0]
         if (filePath) {
           setFields({

--- a/packages/neuron-ui/src/electron-modules.tsx
+++ b/packages/neuron-ui/src/electron-modules.tsx
@@ -7,5 +7,4 @@ export const { ipcRenderer } = window.electron
 export const { clipboard } = window.electron
 export const { nativeImage } = window.electron
 export const { shell } = window.electron
-export const { remote } = window.electron
 export const { desktopCapturer } = window.electron

--- a/packages/neuron-ui/src/services/remote/app.ts
+++ b/packages/neuron-ui/src/services/remote/app.ts
@@ -1,3 +1,4 @@
+import { OpenDialogOptions, MenuItemConstructorOptions, MenuItem, Size, OpenDialogReturnValue } from 'electron'
 import { LOCALES } from 'utils/const'
 import { remoteApi } from './remoteApiWrapper'
 
@@ -9,3 +10,9 @@ export const showSettings = remoteApi<Controller.ShowSettingsParams>('show-setti
 export const setLocale = remoteApi<typeof LOCALES[number]>('set-locale')
 
 export const clearCellCache = remoteApi<Controller.ClearCache.Params>('clear-cache')
+
+export const invokeShowErrorMessage = remoteApi<{ title: string; content: string }>('show-error-message')
+export const invokeShowOpenDialog = remoteApi<OpenDialogOptions, OpenDialogReturnValue>('show-open-dialog')
+export const invokeShowOpenDialogModal = remoteApi<OpenDialogOptions, OpenDialogReturnValue>('show-open-dialog-modal')
+export const invokeOpenContextMenu = remoteApi<Array<MenuItemConstructorOptions | MenuItem>>('open-context-menu')
+export const invokeGetAllDisplaysSize = remoteApi<void, Size[]>('get-all-displays-size')

--- a/packages/neuron-ui/src/services/remote/remoteApiWrapper.ts
+++ b/packages/neuron-ui/src/services/remote/remoteApiWrapper.ts
@@ -1,9 +1,9 @@
 import { ResponseCode, ErrorCode, isSuccessResponse } from 'utils'
 import { ipcRenderer } from 'electron'
 
-export interface SuccessFromController {
+export interface SuccessFromController<R = any> {
   status: ResponseCode.SUCCESS
-  result: any
+  result: R | null
 }
 
 export interface FailureFromController {
@@ -16,7 +16,7 @@ export interface FailureFromController {
       }
 }
 
-export type ControllerResponse = SuccessFromController | FailureFromController
+export type ControllerResponse<R = any> = SuccessFromController<R> | FailureFromController
 
 export const RemoteNotLoadError = {
   status: ResponseCode.FAILURE,
@@ -35,6 +35,12 @@ type Action =
   | 'handle-view-error'
   | 'show-settings'
   | 'set-locale'
+  | 'show-error-message'
+  | 'show-open-dialog'
+  | 'show-open-dialog-modal'
+  | 'open-external'
+  | 'open-context-menu'
+  | 'get-all-displays-size'
   // Wallets
   | 'get-all-wallets'
   | 'get-current-wallet'
@@ -95,8 +101,8 @@ type Action =
   | 'send-to-anyone-can-pay'
   | 'get-token-info-list'
 
-export const remoteApi = <T = any>(action: Action) => async (params: T): Promise<ControllerResponse> => {
-  const res: SuccessFromController | FailureFromController = await ipcRenderer.invoke(action, params).catch(() => ({
+export const remoteApi = <P = any, R = any>(action: Action) => async (params: P): Promise<ControllerResponse<R>> => {
+  const res: SuccessFromController<R> | FailureFromController = await ipcRenderer.invoke(action, params).catch(() => ({
     status: ResponseCode.FAILURE,
     message: {
       content: 'Invalid response format',

--- a/packages/neuron-ui/src/types/global/index.d.ts
+++ b/packages/neuron-ui/src/types/global/index.d.ts
@@ -1,14 +1,6 @@
 declare interface Window {
   electron: {
     clipboard: any
-    remote: {
-      getCurrentWebContents: Function
-      getCurrentWindow: Function
-      getGlobal: (name: string) => any
-      require: (module: string) => any
-      process: any
-      app: any
-    }
     shell: any
     require: any
     nativeImage: any

--- a/packages/neuron-ui/src/utils/hooks.ts
+++ b/packages/neuron-ui/src/utils/hooks.ts
@@ -1,6 +1,5 @@
 import { useState, useMemo, useCallback, useEffect } from 'react'
 import { useHistory } from 'react-router-dom'
-import { MenuItemConstructorOptions } from 'electron'
 import { TFunction, i18n as i18nType } from 'i18next'
 import { openContextMenu, requestPassword, deleteNetwork } from 'services/remote'
 import { syncRebuildNotification } from 'services/localCache'
@@ -20,6 +19,7 @@ import {
   validateTokenName,
   validateDecimal,
 } from 'utils/validators'
+import { MenuItemConstructorOptions } from 'electron'
 
 export const useGoBack = (history: ReturnType<typeof useHistory>) => {
   return useCallback(() => {

--- a/packages/neuron-ui/src/utils/hooks.ts
+++ b/packages/neuron-ui/src/utils/hooks.ts
@@ -1,5 +1,6 @@
 import { useState, useMemo, useCallback, useEffect } from 'react'
 import { useHistory } from 'react-router-dom'
+import { MenuItemConstructorOptions } from 'electron'
 import { TFunction, i18n as i18nType } from 'i18next'
 import { openContextMenu, requestPassword, deleteNetwork } from 'services/remote'
 import { syncRebuildNotification } from 'services/localCache'
@@ -19,7 +20,6 @@ import {
   validateTokenName,
   validateDecimal,
 } from 'utils/validators'
-import { MenuItemConstructorOptions } from 'electron'
 
 export const useGoBack = (history: ReturnType<typeof useHistory>) => {
   return useCallback(() => {

--- a/packages/neuron-wallet/src/block-sync-renderer/index.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/index.ts
@@ -84,6 +84,8 @@ export const createBlockSyncTask = async (clearIndexerFolder = false) => {
 
   logger.info('Sync:\tstarting background process')
 
+  // prevents the sync task from being started repeatedly if fork does not finish executing.
+  syncTask = Object.create(null)
   syncTask = await spawn<SyncTask>(
     fork(path.join(__dirname, 'task.js'), [], {
       env: {

--- a/packages/neuron-wallet/src/block-sync-renderer/tx-status-listener.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/tx-status-listener.ts
@@ -5,7 +5,6 @@ import { CONNECTION_NOT_FOUND_NAME } from 'database/chain/ormconfig'
 import RpcService from 'services/rpc-service'
 import NetworksService from 'services/networks'
 import { AddressPrefix } from 'models/keys/address'
-import NodeService from 'services/node'
 import WalletService from 'services/wallets'
 import { TransactionStatus } from 'models/chain/transaction'
 import TransactionWithStatus from 'models/chain/transaction-with-status'
@@ -13,7 +12,7 @@ import logger from 'utils/logger'
 import AddressGenerator from 'models/address-generator'
 
 const getTransactionStatus = async (hash: string) => {
-  const url: string = NodeService.getInstance().ckb.rpc.node.url
+  const url: string = NetworksService.getInstance().getCurrent().remote
   const rpcService = new RpcService(url)
   const txWithStatus: TransactionWithStatus | undefined = await rpcService.getTransaction(hash)
   if (!txWithStatus) {
@@ -65,7 +64,7 @@ const trackingStatus = async () => {
   }
 
   if (successTxs.length > 0) {
-    const url: string = NodeService.getInstance().ckb.rpc.node.url
+    const url: string = NetworksService.getInstance().getCurrent().remote
     const ckb = new CKB(url)
     const rpcService = new RpcService(ckb.rpc.node.url)
     for (const successTx of successTxs) {

--- a/packages/neuron-wallet/src/controllers/api.ts
+++ b/packages/neuron-wallet/src/controllers/api.ts
@@ -1,5 +1,5 @@
 import { take } from 'rxjs/operators'
-import { ipcMain, IpcMainInvokeEvent, dialog, app, OpenDialogSyncOptions, MenuItemConstructorOptions, MenuItem, Menu, screen } from 'electron'
+import { ipcMain, IpcMainInvokeEvent, dialog, app, OpenDialogSyncOptions, MenuItemConstructorOptions, MenuItem, Menu, screen, BrowserWindow } from 'electron'
 import { t } from 'i18next'
 import env from 'env'
 import { showWindow } from './app/show-window'
@@ -75,24 +75,10 @@ export default class ApiController {
 
     ipcMain.on('get-platform', e => {
       e.returnValue = process.platform
-      // @ts-ignore
-      e.sender.getOwnerBrowserWindow()
     })
 
     ipcMain.on('get-win-id', e => {
-      // Note that we're using a undocumented and untyped method called `getOwnerBrowserWindow` from `e.sender`(instance of `WebContents`).
-      // This is because since `remote` was deprecated, the Electron community had no alternative to `remote.getCurrentWindow()` yet.
-      // However, as we can see by reading the source code of `remote.getCurrentWindow()`:
-      // `remote.getCurrentWindow()` is implemented by calling the `getOwnerBrowserWindow` method of `WebContents`.
-      // see the discussion in electron repo:
-      // https://github.com/electron/electron/issues/21408#issuecomment-656006346
-      // implementation of `remote.getCurrentWindow()':
-      // https://github.com/electron/electron/blob/9-x-y/lib/browser/remote/server.ts#L450-L460
-      // source of `WebContents`:
-      // https://github.com/electron/electron/blob/9-x-y/shell/browser/api/electron_api_web_contents.h#L358-L359
-
-      // @ts-ignore
-      e.returnValue = e.sender.getOwnerBrowserWindow().id
+      e.returnValue = BrowserWindow.fromWebContents(e.sender)?.id
     })
 
     // App

--- a/packages/neuron-wallet/src/controllers/api.ts
+++ b/packages/neuron-wallet/src/controllers/api.ts
@@ -102,8 +102,7 @@ export default class ApiController {
     })
 
     handle('show-open-dialog-modal', async (e, params: OpenDialogSyncOptions) => {
-      // @ts-ignore
-      const win = e.sender.getOwnerBrowserWindow()
+      const win = BrowserWindow.fromWebContents(e.sender)!
       const result = await dialog.showOpenDialog(win, params)
       return {
         status: ResponseCode.Success,

--- a/packages/neuron-wallet/src/controllers/app/index.ts
+++ b/packages/neuron-wallet/src/controllers/app/index.ts
@@ -99,7 +99,7 @@ export default class AppController {
       webPreferences: {
         devTools: env.isDevMode,
         nodeIntegration: false,
-        enableRemoteModule: true,
+        enableRemoteModule: false,
         preload: path.join(__dirname, './preload.js'),
       },
     })

--- a/packages/neuron-wallet/src/controllers/app/preload.ts
+++ b/packages/neuron-wallet/src/controllers/app/preload.ts
@@ -1,4 +1,4 @@
-import { remote, clipboard, nativeImage, IpcRenderer, ipcRenderer, shell, desktopCapturer, DesktopCapturer } from 'electron'
+import { clipboard, nativeImage, IpcRenderer, ipcRenderer, shell, desktopCapturer, DesktopCapturer } from 'electron'
 
 declare global {
   interface Window {
@@ -6,7 +6,6 @@ declare global {
       clipboard: Electron.Clipboard
       nativeImage: any
       ipcRenderer: IpcRenderer
-      remote: Electron.Remote
       shell: Electron.Shell
       desktopCapturer: DesktopCapturer
     }
@@ -26,7 +25,6 @@ window.electron = {
   clipboard,
   nativeImage,
   ipcRenderer,
-  remote,
   shell,
   desktopCapturer,
 }

--- a/packages/neuron-wallet/src/controllers/app/show-window.ts
+++ b/packages/neuron-wallet/src/controllers/app/show-window.ts
@@ -23,7 +23,7 @@ const showWindow = (url: string, title: string, options?: Electron.BrowserWindow
       webPreferences: {
         devTools: env.isDevMode,
         nodeIntegration: false,
-        enableRemoteModule: true,
+        enableRemoteModule: false,
         preload: path.join(__dirname, './preload.js'),
       },
       ...options,

--- a/packages/neuron-wallet/src/models/subjects/address-created-subject.ts
+++ b/packages/neuron-wallet/src/models/subjects/address-created-subject.ts
@@ -5,6 +5,6 @@ export default class AddressCreatedSubject {
   private static subject = new ReplaySubject<Address[]>(100)
 
   public static getSubject() {
-    return this.subject
+    return AddressCreatedSubject.subject
   }
 }

--- a/packages/neuron-wallet/src/models/subjects/address-db-changed-subject.ts
+++ b/packages/neuron-wallet/src/models/subjects/address-db-changed-subject.ts
@@ -5,7 +5,7 @@ export class AddressDbChangedSubject {
   private static subject = new ReplaySubject<string>(100)
 
   public static getSubject() {
-    return this.subject
+    return AddressDbChangedSubject.subject
   }
 }
 

--- a/packages/neuron-wallet/src/models/subjects/address-db-changed-subject.ts
+++ b/packages/neuron-wallet/src/models/subjects/address-db-changed-subject.ts
@@ -1,17 +1,11 @@
 import { ReplaySubject } from 'rxjs'
-import ProcessUtils from 'utils/process'
-import { remote } from 'electron'
 
 // subscribe this Subject to monitor any address table changes
 export class AddressDbChangedSubject {
   private static subject = new ReplaySubject<string>(100)
 
   public static getSubject() {
-    if (ProcessUtils.isRenderer()) {
-      return remote.require('./models/subjects/address-db-changed-subject').default.getSubject()
-    } else {
-      return this.subject
-    }
+    return this.subject
   }
 }
 

--- a/packages/neuron-wallet/src/models/subjects/node.ts
+++ b/packages/neuron-wallet/src/models/subjects/node.ts
@@ -1,6 +1,4 @@
 import { BehaviorSubject } from 'rxjs'
-import ProcessUtils from 'utils/process'
-import { remote } from 'electron'
 
 export const ConnectionStatusSubject = new BehaviorSubject<{
   url: string,
@@ -14,10 +12,6 @@ export default class SyncedBlockNumberSubject {
   private static subject = new BehaviorSubject<string>('0')
 
   public static getSubject(): BehaviorSubject<string> {
-    if (ProcessUtils.isRenderer()) {
-      return remote.require('./models/subjects/node').default.getSubject()
-    } else {
-      return this.subject
-    }
+    return this.subject
   }
 }

--- a/packages/neuron-wallet/src/models/subjects/node.ts
+++ b/packages/neuron-wallet/src/models/subjects/node.ts
@@ -12,6 +12,6 @@ export default class SyncedBlockNumberSubject {
   private static subject = new BehaviorSubject<string>('0')
 
   public static getSubject(): BehaviorSubject<string> {
-    return this.subject
+    return SyncedBlockNumberSubject.subject
   }
 }

--- a/packages/neuron-wallet/src/models/subjects/tx-db-changed-subject.ts
+++ b/packages/neuron-wallet/src/models/subjects/tx-db-changed-subject.ts
@@ -9,7 +9,7 @@ export class TxDbChangedSubject {
   private static subject = new ReplaySubject<TransactionChangedMessage>(100)
 
   public static getSubject() {
-    return this.subject
+    return TxDbChangedSubject.subject
   }
 }
 

--- a/packages/neuron-wallet/src/models/subjects/tx-db-changed-subject.ts
+++ b/packages/neuron-wallet/src/models/subjects/tx-db-changed-subject.ts
@@ -1,6 +1,4 @@
 import { ReplaySubject } from 'rxjs'
-import ProcessUtils from 'utils/process'
-import { remote } from 'electron'
 
 export interface TransactionChangedMessage {
   event: string
@@ -11,11 +9,7 @@ export class TxDbChangedSubject {
   private static subject = new ReplaySubject<TransactionChangedMessage>(100)
 
   public static getSubject() {
-    if (ProcessUtils.isRenderer()) {
-      return remote.require('./models/subjects/tx-db-changed-subject').default.getSubject()
-    } else {
-      return this.subject
-    }
+    return this.subject
   }
 }
 

--- a/packages/neuron-wallet/src/models/subjects/wallet-deleted-subject.ts
+++ b/packages/neuron-wallet/src/models/subjects/wallet-deleted-subject.ts
@@ -1,15 +1,9 @@
 import { Subject } from 'rxjs'
-import ProcessUtils from 'utils/process'
-import { remote } from 'electron'
 
 export default class WalletDeletedSubject {
   private static subject = new Subject<string>()
 
   public static getSubject() {
-    if (ProcessUtils.isRenderer()) {
-      return remote.require('./models/subjects/wallet-delete-subject').default.getSubject()
-    } else {
-      return this.subject
-    }
+    return this.subject
   }
 }

--- a/packages/neuron-wallet/src/models/subjects/wallet-deleted-subject.ts
+++ b/packages/neuron-wallet/src/models/subjects/wallet-deleted-subject.ts
@@ -4,6 +4,6 @@ export default class WalletDeletedSubject {
   private static subject = new Subject<string>()
 
   public static getSubject() {
-    return this.subject
+    return WalletDeletedSubject.subject
   }
 }

--- a/packages/neuron-wallet/src/services/file.ts
+++ b/packages/neuron-wallet/src/services/file.ts
@@ -14,7 +14,9 @@ export default class FileService {
     return FileService.instance
   }
 
-  public basePath = env.fileBasePath
+  // get fileBasePath value from child_process.fork() env
+  public basePath = process.env['fileBasePath'] ?? env.fileBasePath
+
   public config = {
     encoding: 'utf8',
   }

--- a/packages/neuron-wallet/src/services/node.ts
+++ b/packages/neuron-wallet/src/services/node.ts
@@ -3,7 +3,7 @@ import { promisify } from 'util'
 import path from 'path'
 import https from 'https'
 import http from 'http'
-import { remote, dialog, shell } from 'electron'
+import { dialog, shell } from 'electron'
 import { t } from 'i18next'
 import CKB from '@nervosnetwork/ckb-sdk-core'
 import { interval, BehaviorSubject, merge } from 'rxjs'
@@ -16,7 +16,6 @@ import NetworksService from 'services/networks'
 import RpcService from 'services/rpc-service'
 import { startCkbNode } from 'services/ckb-runner'
 import HexUtils from 'utils/hex'
-import ProcessUtils from 'utils/process'
 import { BUNDLED_CKB_URL } from 'utils/const'
 import logger from 'utils/logger'
 
@@ -25,11 +24,7 @@ class NodeService {
 
   static getInstance(): NodeService {
     if (!NodeService.instance) {
-      if (ProcessUtils.isRenderer()) {
-        NodeService.instance = remote.require('./services/node').default.getInstance()
-      } else {
-        NodeService.instance = new NodeService()
-      }
+      NodeService.instance = new NodeService()
     }
     return NodeService.instance
   }


### PR DESCRIPTION
Note that this PR using a undocumented and untyped method called `getOwnerBrowserWindow()`, more details and explanations can be found in the comments.

The usages of `remote` in the main process has also been removed, see the discussion in https://github.com/nervosnetwork/neuron/pull/1800#discussion_r472820886 for details.

This PR has rebase the latest changes to #1800 and #1802  for QA team.