### PR TITLE
Build and test in same step in Windows CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,10 +83,10 @@ stages:
         yarn bootstrap
         set CI=false
         yarn build
-      name: Build
+      name: Bootstrap
     - script: |
         set CI=true
-        yarn test
+        yarn test:ci
       name: Test
 
 - stage: release

--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
     "clean": "lerna run --stream clean",
     "prebuild": "yarn clean",
     "build": "lerna run --stream build",
+    "build:main": "lerna run build --scope=neuron-wallet",
     "release": "yarn build && ./scripts/copy-ui-files.sh && ./scripts/release.sh",
     "test": "lerna run --parallel test",
+    "test:ci": "yarn build:main && yarn test",
     "lint": "lerna run --stream lint",
     "postinstall": "lerna run rebuild:nativemodules",
     "db:chain": "node ./node_modules/.bin/typeorm"


### PR DESCRIPTION
Windows CI seems to purge files that have been created after each step, resulting in compiled files that cannot be found in the test.

This PR resolves the testing issue with #1800.

failed case:
https://dev.azure.com/nervosnetwork/neuron/_build/results?buildId=13509&view=logs&j=1dd1a9fa-5bd6-5a58-be75-4682264ffaf4&t=0fd07730-01dd-5646-2168-32456ff1e2aa&l=861

success case(in my own repo):
https://dev.azure.com/nervjs/Nervjs/_build/results?buildId=65&view=logs&j=1dd1a9fa-5bd6-5a58-be75-4682264ffaf4&t=0fd07730-01dd-5646-2168-32456ff1e2aa&l=232