### PR TITLE
Fix a breaking change by lumos indexer

### DIFF
--- a/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-connector.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-connector.ts
@@ -133,9 +133,7 @@ export default class IndexerConnector {
         args: type.args
       }
     }
-    //this is an required property, which should exist in the lumos interface
-    //@ts-ignore
-    queries.data = data || null
+    queries.data = data || 'any'
 
     const collector = new CellCollector(this.indexer, queries)
 

--- a/packages/neuron-wallet/tests/block-sync-render/indexer-connector.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/indexer-connector.test.ts
@@ -507,7 +507,7 @@ describe('unit tests for IndexerConnector', () => {
               code_hash: query.type!.codeHash,
               args: query.type!.args,
             },
-            data: null
+            data: 'any'
           })
         })
         it('returns live cells with property value fix', async () => {


### PR DESCRIPTION
A fix to a breaking change by lumos indexer.

The lumos query API used to require assigning `null` value to `data` parameter to avoid filtering resulting cells on data property.

The version, Neuron is using now, actually requires assigning `any` instead of `null`. https://github.com/nervosnetwork/lumos/blob/develop/packages/base/index.d.ts#L94

This breaking change leads to a bug that it can't make transfers from asset accounts.
