### PR TITLE
Fix icon package issue in Electron 9

### DIFF
--- a/packages/neuron-wallet/src/controllers/app/index.ts
+++ b/packages/neuron-wallet/src/controllers/app/index.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { t } from 'i18next'
-import { app as electronApp, remote, BrowserWindow } from 'electron'
+import { app as electronApp, remote, BrowserWindow, nativeImage } from 'electron'
 import windowStateKeeper from 'electron-window-state'
 
 import env from 'env'
@@ -95,7 +95,9 @@ export default class AppController {
       minHeight: 600,
       show: false,
       backgroundColor: '#e9ecef',
-      icon: path.join(__dirname, '../../../assets/icons/icon.png'),
+      icon: app.isPackaged
+        ? nativeImage.createFromPath(path.join(__dirname, '../../neuron-ui/icon.png'))
+        : path.join(__dirname, '../../../assets/icons/icon.png'),
       webPreferences: {
         devTools: env.isDevMode,
         nodeIntegration: false,

--- a/packages/neuron-wallet/src/controllers/app/index.ts
+++ b/packages/neuron-wallet/src/controllers/app/index.ts
@@ -95,9 +95,13 @@ export default class AppController {
       minHeight: 600,
       show: false,
       backgroundColor: '#e9ecef',
-      icon: app.isPackaged
-        ? nativeImage.createFromPath(path.join(__dirname, '../../neuron-ui/icon.png'))
-        : path.join(__dirname, '../../../assets/icons/icon.png'),
+      icon: nativeImage.createFromPath(
+        app.isPackaged
+          ? path.join(__dirname, '../../neuron-ui/icon.png')
+          // use icon from assets in dev mode
+          // since neuron ui only copied to dist during packaging
+          : path.join(__dirname, '../../../assets/icons/icon.png')
+      ),
       webPreferences: {
         devTools: env.isDevMode,
         nodeIntegration: false,


### PR DESCRIPTION
For some how, in Electron 9 packaged mode, BrowserWindow's `icon` can only accept a instance of `NativeImage`.

ref:
https://github.com/electron/electron/issues/24221