### PR TITLE
Fix unhandled rejection error in test

### DIFF
--- a/packages/neuron-wallet/src/block-sync-renderer/index.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/index.ts
@@ -52,6 +52,7 @@ export const switchToNetwork = async (newNetwork: Network, reconnected = false, 
   }
 
   await killBlockSyncTask()
+  //TODO evalutate if this is necessary. This might be unnecessary legacy code.
   if (shouldSync) {
     await createBlockSyncTask()
   } else {

--- a/packages/neuron-wallet/tests/setup.ts
+++ b/packages/neuron-wallet/tests/setup.ts
@@ -33,3 +33,5 @@ jest.mock('levelup', () => {
     }
   })
 })
+
+process.on('unhandledRejection', console.error)


### PR DESCRIPTION
Currently, it throws unhandled rejection error in the console for this test suit even the tests are passed. This error is caused by the improper setup of the network service dependency during the tests and resolved by mocking up that dependency.