### PR TITLE
Fix `InvalidCodeHash` error when sending tx

### DIFF
--- a/packages/neuron-wallet/src/services/cells.ts
+++ b/packages/neuron-wallet/src/services/cells.ts
@@ -16,7 +16,7 @@ import BufferUtils from 'utils/buffer'
 import LiveCell from 'models/chain/live-cell'
 import Output from 'models/chain/output'
 import SystemScriptInfo from 'models/system-script-info'
-import Script from 'models/chain/script'
+import Script, { ScriptHashType } from 'models/chain/script'
 import LiveCellService from './live-cell-service'
 
 export const MIN_CELL_CAPACITY = '6100000000'
@@ -295,7 +295,10 @@ export default class CellsService {
       input: Input,
       witness: WitnessArgs,
     },
-    lockCodeHashes: string[] = [SystemScriptInfo.SECP_CODE_HASH]
+    lockClass: {
+      codeHash: string,
+      hashType: ScriptHashType.Type
+    } = {codeHash: SystemScriptInfo.SECP_CODE_HASH, hashType: ScriptHashType.Type}
   ): Promise<{
     inputs: Input[]
     capacities: string
@@ -326,11 +329,13 @@ export default class CellsService {
           FROM hd_public_key_info
           WHERE walletId = :walletId
         ) AND
-        output.lockCodeHash in (:...lockCodeHashes)
+        output.lockCodeHash = :lockCodeHash AND
+        output.lockHashType = :lockHashType
         `, {
         walletId,
         statuses: [OutputStatus.Live, OutputStatus.Sent],
-        lockCodeHashes,
+        lockCodeHash: lockClass.codeHash,
+        lockHashType: lockClass.hashType,
       })
       .getMany()
 
@@ -442,7 +447,10 @@ export default class CellsService {
 
   public static gatherAllInputs = async (
     walletId: string,
-    lockCodeHashes: string[] = [SystemScriptInfo.SECP_CODE_HASH]
+    lockClass: {
+      codeHash: string,
+      hashType: ScriptHashType.Type
+    } = {codeHash: SystemScriptInfo.SECP_CODE_HASH, hashType: ScriptHashType.Type}
   ): Promise<Input[]> => {
     const cellEntities: OutputEntity[] = await getConnection()
       .getRepository(OutputEntity)
@@ -456,11 +464,13 @@ export default class CellsService {
           FROM hd_public_key_info
           WHERE walletId = :walletId
         ) AND
-        output.lockCodeHash in (:...lockCodeHashes)
+        output.lockCodeHash = :lockCodeHash AND
+        output.lockHashType = :lockHashType
         `, {
         walletId,
         statuses: [OutputStatus.Live],
-        lockCodeHashes
+        lockCodeHash: lockClass.codeHash,
+        lockHashType: lockClass.hashType
       })
       .getMany()
 

--- a/packages/neuron-wallet/src/services/tx/transaction-service.ts
+++ b/packages/neuron-wallet/src/services/tx/transaction-service.ts
@@ -407,11 +407,11 @@ export class TransactionsService {
       .driver
       .escapeQueryWithParameters(`
         SELECT
-          lockHash,
+          lockArgs,
           count(DISTINCT (transactionHash)) AS cnt
         FROM (
           SELECT
-            lockHash,
+            lockArgs,
             transactionHash
           FROM
             input
@@ -424,7 +424,7 @@ export class TransactionsService {
             )
           UNION
           SELECT
-            lockHash,
+            lockArgs,
             transactionHash
           FROM
             output
@@ -437,20 +437,19 @@ export class TransactionsService {
             )
         ) AS cell
         GROUP BY
-          lockHash;
+          lockArgs;
         `,
         {
-          // statuses: [...statuses],
           walletId
         },
         {}
       )
 
-    const count: { lockHash: string, cnt: number }[] = await getConnection().manager.query(sql, parameters)
+    const count: { lockArgs: string, cnt: number }[] = await getConnection().manager.query(sql, parameters)
 
     const result = new Map<string, number>()
     count.forEach(c => {
-      result.set(c.lockHash, c.cnt)
+      result.set(c.lockArgs, c.cnt)
     })
 
     return result

--- a/packages/neuron-wallet/tests/services/cells.test.ts
+++ b/packages/neuron-wallet/tests/services/cells.test.ts
@@ -223,6 +223,9 @@ describe('CellsService', () => {
     const createCells = async () => {
       const cells: OutputEntity[] = [
         generateCell(toShannon('1000'), OutputStatus.Live, false, null),
+        generateCell(toShannon('1'), OutputStatus.Live, false, null, {
+          lockScript: new Script(bob.lockScript.codeHash, bob.lockScript.args, ScriptHashType.Data)
+        }),
         generateCell(toShannon('200'), OutputStatus.Sent, false, null),
         generateCell(toShannon('2000'), OutputStatus.Live, true, null),
         generateCell(toShannon('3000'), OutputStatus.Live, false, typeScript),
@@ -471,7 +474,7 @@ describe('CellsService', () => {
             undefined,
             undefined,
             undefined,
-            [lockCodeHash]
+            {codeHash: lockCodeHash, hashType: ScriptHashType.Type}
           )
         } catch (e) {
           error = e
@@ -486,6 +489,9 @@ describe('CellsService', () => {
     beforeEach(async () => {
       const cells: OutputEntity[] = [
         generateCell(toShannon('1000'), OutputStatus.Live, false, null),
+        generateCell(toShannon('1'), OutputStatus.Live, false, null, {
+          lockScript: new Script(bob.lockScript.codeHash, bob.lockScript.args, ScriptHashType.Data)
+        }),
         generateCell(toShannon('200'), OutputStatus.Sent, false, null),
         generateCell(toShannon('2000'), OutputStatus.Live, true, null),
         generateCell(toShannon('3000'), OutputStatus.Live, false, typeScript),
@@ -509,7 +515,7 @@ describe('CellsService', () => {
       beforeEach(async () => {
         allInputs = await CellsService.gatherAllInputs(
           walletId1,
-          ['non exist lock code hash']
+          {codeHash: 'non exist lock code hash', hashType: ScriptHashType.Type}
         )
       });
       it('returns empty array', async () => {


### PR DESCRIPTION
* Fix incorrect inputs gathering, which could resulting in `InvalidCodeHash` error if a gathered input cell comes with an unexpected hash type in the lock script.
* Count transactions based on public key hash