### PR TITLE
Mock electron dependency in child process

### DIFF
--- a/packages/neuron-wallet/src/block-sync-renderer/index.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/index.ts
@@ -77,7 +77,7 @@ export const createBlockSyncTask = async (clearIndexerFolder = false) => {
   // prevents the sync task from being started repeatedly if fork does not finish executing.
   syncTask = Object.create(null)
   syncTask = await spawn<SyncTask>(
-    fork(path.join(__dirname, 'task.js'), [], {
+    fork(path.join(__dirname, 'task-wrapper.js'), [], {
       env: {
         fileBasePath: env.fileBasePath
       }

--- a/packages/neuron-wallet/src/block-sync-renderer/task-wrapper.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/task-wrapper.ts
@@ -1,0 +1,15 @@
+//@ts-nocheck
+import Module from 'module';
+
+const originalLoad = Module._load;
+
+Module._load = function (request: string) {
+  if (request === 'electron') {
+    return {}
+  }
+
+  return originalLoad.apply(this, arguments);
+};
+
+
+export * from './task'

--- a/packages/neuron-wallet/tests/block-sync-render/task.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/task.test.ts
@@ -49,11 +49,6 @@ describe('block sync render', () => {
 
     stubbedGetIndexerConnector.mockReturnValue(stubbedIndexerConnector)
 
-    jest.doMock('electron', () => {
-      return {
-        ipcRenderer: eventEmitter
-      }
-    });
     jest.doMock('../../src/block-sync-renderer/sync/queue', () => {
       return stubbedQueueConstructor
     });
@@ -65,7 +60,7 @@ describe('block sync render', () => {
     let syncTask: any
 
     beforeEach(async () => {
-      syncTask = jest.requireActual('../../src/block-sync-renderer/task').default
+      syncTask = jest.requireActual('../../src/block-sync-renderer/task-wrapper').default
     });
 
     it('call queryIndexer with results', async () => {


### PR DESCRIPTION
In child process, the `electron` dependency won't be available in production environment. Thus it throws error when starting the child process which eventually loads the `env.ts`, and the child process can't be started. 

For now, this PR provides a quick workaround to mock up the `electron` dependency in the child process. Later on, we need to refactor the `env.ts` to handle the unavailability of `electron` into order stub the necessary variables such as the `fileBasePath` so that all these key variables are against accessible from the `env.ts`