### PR TITLE
Refactor the messages handling between main and child process

### DIFF
--- a/packages/neuron-wallet/src/block-sync-renderer/index.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/index.ts
@@ -103,7 +103,6 @@ export const createBlockSyncTask = async (clearIndexerFolder: boolean) => {
         resetSyncTask()
         break
       default:
-        logger.debug(`Unhandled message event from child process: ${msg.channel}`)
         break
     }
   })

--- a/packages/neuron-wallet/src/block-sync-renderer/index.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/index.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { fork } from 'child_process'
 import { Network, EMPTY_GENESIS_HASH } from 'models/network'
 import DataUpdateSubject from 'models/subjects/data-update'
+import env from 'env'
 import AddressCreatedSubject from 'models/subjects/address-created-subject'
 import WalletDeletedSubject from 'models/subjects/wallet-deleted-subject'
 import SyncedBlockNumberSubject from 'models/subjects/node'
@@ -11,27 +12,39 @@ import NetworksService from 'services/networks'
 import AddressService from 'services/addresses'
 import WalletService from 'services/wallets'
 import logger from 'utils/logger'
-import CommonUtils from 'utils/common'
 import { LumosCellQuery, LumosCell } from './sync/indexer-connector'
 import IndexerFolderManager from './sync/indexer-folder-manager'
 import { spawn, terminate, subscribe as subscribeToWorkerProcess } from 'utils/worker'
 import SyncApiController from 'controllers/sync-api'
 import type { SyncTask } from './task'
-import env from 'env'
 import TxDbChangedSubject from 'models/subjects/tx-db-changed-subject'
 import AddressDbChangedSubject from 'models/subjects/address-db-changed-subject'
+import { queue } from 'async'
 
 let syncTask: SyncTask | null
 let network: Network | null
 
-const restartSyncTask = async () => {
+const resetSyncTaskQueue = queue(async ({startTask, clearIndexerFolder}) => {
   await killBlockSyncTask()
-  await createBlockSyncTask()
+  if (startTask) {
+    await createBlockSyncTask(clearIndexerFolder)
+  }
+}, 1)
+
+resetSyncTaskQueue.error(err => {
+  logger.error(err)
+})
+
+export const resetSyncTask = async (startTask: boolean = true, clearIndexerFolder: boolean = false) => {
+  if (resetSyncTaskQueue.length() === 0) {
+    resetSyncTaskQueue.push({startTask, clearIndexerFolder})
+    await resetSyncTaskQueue.drain()
+  }
 }
 
 if (BrowserWindow) {
-  AddressCreatedSubject.getSubject().subscribe(restartSyncTask)
-  WalletDeletedSubject.getSubject().subscribe(restartSyncTask)
+  AddressCreatedSubject.getSubject().subscribe(() => resetSyncTask())
+  WalletDeletedSubject.getSubject().subscribe(() => resetSyncTask())
 }
 
 export const switchToNetwork = async (newNetwork: Network, reconnected = false, shouldSync = true) => {
@@ -39,7 +52,7 @@ export const switchToNetwork = async (newNetwork: Network, reconnected = false, 
   network = newNetwork
 
   if (previousNetwork && !reconnected) {
-    if (previousNetwork.id === newNetwork.id || previousNetwork.genesisHash === newNetwork.genesisHash) {
+    if (previousNetwork.id === newNetwork.id) {
       // There's no actual change. No need to reconnect.
       return
     }
@@ -51,55 +64,46 @@ export const switchToNetwork = async (newNetwork: Network, reconnected = false, 
     logger.info('Network:\tswitched to:', network)
   }
 
-  await killBlockSyncTask()
-  //TODO evalutate if this is necessary. This might be unnecessary legacy code.
-  if (shouldSync) {
-    await createBlockSyncTask()
-  } else {
-    SyncedBlockNumberSubject.getSubject().next('-1')
-  }
+  await resetSyncTask(shouldSync)
 }
 
-export const createBlockSyncTask = async (clearIndexerFolder = false) => {
-  await CommonUtils.sleep(2000) // Do not start too fast
-
+export const createBlockSyncTask = async (clearIndexerFolder: boolean) => {
   if (clearIndexerFolder) {
     await new SyncedBlockNumber().setNextBlock(BigInt(0))
     IndexerFolderManager.resetIndexerData()
   }
 
-  if (syncTask) {
-    return
-  }
-
   logger.info('Sync:\tstarting background process')
 
   // prevents the sync task from being started repeatedly if fork does not finish executing.
-  syncTask = Object.create(null)
-  syncTask = await spawn<SyncTask>(
-    fork(path.join(__dirname, 'task-wrapper.js'), [], {
-      env: {
-        fileBasePath: env.fileBasePath
-      }
-    })
-  )
+  const childProcess = fork(path.join(__dirname, 'task-wrapper.js'), [], {
+    env: {
+      fileBasePath: env.fileBasePath
+    },
+    stdio: ['ipc', process.stdout, 'pipe']
+  })
+  childProcess.stderr!.setEncoding('utf8').on('data', data => {
+    logger.error('Sync:ChildProcess:', data)
+  })
+  syncTask = await spawn<SyncTask>(childProcess)
 
   subscribeToWorkerProcess(syncTask, msg => {
-    switch (msg?.channel) {
+    switch (msg.channel) {
       case 'synced-block-number-updated':
-        SyncApiController.emiter.emit('synced-block-number-updated', msg?.result)
+        SyncApiController.emiter.emit('synced-block-number-updated', msg.result)
         break
       case 'tx-db-changed':
-        TxDbChangedSubject.getSubject().next(msg?.result)
+        TxDbChangedSubject.getSubject().next(msg.result)
         break
       case 'address-db-changed':
-        AddressDbChangedSubject.getSubject().next(msg?.result)
+        AddressDbChangedSubject.getSubject().next(msg.result)
         break
       case 'wallet-deleted':
       case 'address-created':
-        restartSyncTask()
+        resetSyncTask()
         break
       default:
+        logger.debug(`Unhandled message event from child process: ${msg.channel}`)
         break
     }
   })
@@ -121,7 +125,7 @@ export const createBlockSyncTask = async (clearIndexerFolder = false) => {
     await WalletService.getInstance().generateAddressesIfNecessary()
 
     // re init txCount in addresses if switch network
-    syncTask?.start(
+    syncTask!.start(
       network.remote,
       network.genesisHash,
       await AddressService.getAddressesByAllWallets()
@@ -133,7 +137,7 @@ export const killBlockSyncTask = async () => {
   if (syncTask) {
     logger.info('Sync:\tkill background process')
     await syncTask.unmount()
-    terminate(syncTask)
+    await terminate(syncTask)
     syncTask = null
   }
 }

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-cache-service.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-cache-service.ts
@@ -142,12 +142,12 @@ export default class IndexerCacheService {
         return
       }
       const blockHeader = await this.rpcService.getHeader(txWithStatus!.txStatus.blockHash!)
-      txWithStatus!.transaction.blockNumber = blockHeader?.number
+      txWithStatus!.transaction.blockNumber = blockHeader!.number
       txWithStatus!.transaction.blockHash = txWithStatus!.txStatus.blockHash!
-      txWithStatus!.transaction.timestamp = blockHeader?.timestamp
+      txWithStatus!.transaction.timestamp = blockHeader!.timestamp
 
       txsWithStatus.push(txWithStatus)
-    }, 100)
+    }, 1)
 
     fetchBlockDetailsQueue.push(newTxHashes)
 

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-connector.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-connector.ts
@@ -1,8 +1,8 @@
-import logger from 'electron-log'
 import { Subject } from 'rxjs'
 import { queue, AsyncQueue } from 'async'
 import { QueryOptions, HashType } from '@ckb-lumos/base'
 import { Indexer, Tip, CellCollector } from '@ckb-lumos/indexer'
+import logger from 'utils/logger'
 import CommonUtils from 'utils/common'
 import RpcService from 'services/rpc-service'
 import TransactionWithStatus from 'models/chain/transaction-with-status'
@@ -76,7 +76,7 @@ export default class IndexerConnector {
 
     this.processNextBlockNumberQueue = queue(async () => this.processTxsInNextBlockNumber(), 1)
     this.processNextBlockNumberQueue.error((err: any) => {
-      logger.error(err)
+      logger.error(`Error in processing next block number queue: ${err}`)
     })
 
     this.indexerQueryQueue = queue(async (query: any) => {
@@ -113,7 +113,7 @@ export default class IndexerConnector {
         await CommonUtils.sleep(5000)
       }
     } catch (error) {
-      logger.error(error)
+      logger.error(`Error connecting to Indexer: ${error.message}`)
       throw error
     }
   }
@@ -236,9 +236,9 @@ export default class IndexerConnector {
         throw new Error(`failed to fetch transaction for hash ${hash}`)
       }
       const blockHeader = await this.rpcService.getHeader(txWithStatus!.txStatus.blockHash!)
-      txWithStatus!.transaction.blockNumber = blockHeader?.number
+      txWithStatus!.transaction.blockNumber = blockHeader!.number
       txWithStatus!.transaction.blockHash = txWithStatus!.txStatus.blockHash!
-      txWithStatus!.transaction.timestamp = blockHeader?.timestamp
+      txWithStatus!.transaction.timestamp = blockHeader!.timestamp
       txsWithStatus.push(txWithStatus)
     }
 

--- a/packages/neuron-wallet/src/controllers/sync.ts
+++ b/packages/neuron-wallet/src/controllers/sync.ts
@@ -1,5 +1,5 @@
 import SyncedBlockNumber from 'models/synced-block-number'
-import { createBlockSyncTask, killBlockSyncTask } from 'block-sync-renderer'
+import { resetSyncTask } from 'block-sync-renderer'
 import ChainCleaner from 'database/chain/cleaner'
 import { ResponseCode } from 'utils/const'
 
@@ -25,8 +25,8 @@ export default class SyncController {
   }
 
   private doClearTask = async (clearIndexerFolder: boolean) => {
-    await killBlockSyncTask()
+    await resetSyncTask(false)
     await ChainCleaner.clean()
-    await createBlockSyncTask(clearIndexerFolder)
+    await resetSyncTask(true, clearIndexerFolder)
   }
 }

--- a/packages/neuron-wallet/tests/block-sync-render/index.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/index.test.ts
@@ -414,15 +414,6 @@ describe('block sync render', () => {
             expect(stubbedSyncTaskStart).toHaveBeenCalledTimes(1)
           })
         });
-        describe('unhandled events from child process', () => {
-          beforeEach(async () => {
-            fakeSendMessageToMainProcess('fake', result)
-          });
-          it('logs the event name', ()=> {
-            expect(stubbedLoggerDebug).toHaveBeenCalledWith(expect.stringMatching(/.*event.*fake/i))
-          })
-        });
-
       })
       describe('with parallel calls', () => {
 

--- a/packages/neuron-wallet/tests/block-sync-render/indexer-connector.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/indexer-connector.test.ts
@@ -78,7 +78,7 @@ describe('unit tests for IndexerConnector', () => {
       })
     )
   });
-  jest.doMock('electron-log', () => {
+  jest.doMock('utils/logger', () => {
     return {error: stubbedLoggerErrorFn}
   });
   jest.doMock('../../src/block-sync-renderer/sync/indexer-cache-service', () => {
@@ -376,7 +376,7 @@ describe('unit tests for IndexerConnector', () => {
             await flushPromises()
           });
           it('throws error', async () => {
-            expect(stubbedLoggerErrorFn).toHaveBeenCalledWith(new Error('failed to fetch transaction for hash hash3'))
+            expect(stubbedLoggerErrorFn).toHaveBeenCalledWith('Error in processing next block number queue: Error: failed to fetch transaction for hash hash3')
           });
         });
       });

--- a/packages/neuron-wallet/tests/utils/worker.test.ts
+++ b/packages/neuron-wallet/tests/utils/worker.test.ts
@@ -63,6 +63,26 @@ describe('utils/workers', () => {
       const res = await Worker.args(1, 2, 3)
       expect(res).toEqual([1, 2, 3])
     })
+
+    describe('handles concurrent requests', () => {
+      let results: any[] = []
+      beforeEach(async () => {
+        results = await Promise.all([
+          Worker.async(),
+          Worker.normal(),
+          Worker.doNothing(),
+          Worker.args(4, 5, 6),
+        ])
+      })
+      it('processes responses in correct order', () => {
+        expect(results).toEqual([
+          'async/await',
+          'normal',
+          undefined,
+          [4, 5, 6]
+        ])
+      })
+    });
   })
 
   describe('terminate', () => {


### PR DESCRIPTION
- Process the requests in Worker child process in a queue so as to ensure the responses are channeled correctly back to the front end.
- Ensure the ongoing requests in the child process are drained and responded to the client when terminated the child process. 
- Refactor the `block-sync-renderer` to reset the child process in order in case there are concurrent calls to the reset function.
- Better logs from the child process.