### PR TITLE
Deprecating leveldb

### DIFF
--- a/packages/neuron-wallet/src/controllers/anyone-can-pay.ts
+++ b/packages/neuron-wallet/src/controllers/anyone-can-pay.ts
@@ -4,7 +4,7 @@ import { ServiceHasNoResponse } from "exceptions"
 import { ResponseCode } from "utils/const"
 import AnyoneCanPayService from "services/anyone-can-pay"
 import TransactionSender from "services/transaction-sender"
-import { set as setDescription } from 'database/leveldb/transaction-description'
+import { set as setDescription } from 'services/tx/transaction-description'
 
 export interface GenerateAnyoneCanPayTxParams {
   walletID: string

--- a/packages/neuron-wallet/src/controllers/transactions.ts
+++ b/packages/neuron-wallet/src/controllers/transactions.ts
@@ -8,7 +8,7 @@ import { ResponseCode } from 'utils/const'
 import { TransactionNotFound, CurrentWalletNotSet } from 'exceptions'
 import Transaction from 'models/chain/transaction'
 
-import { set as setDescription, get as getDescription } from 'database/leveldb/transaction-description'
+import { set as setDescription, get as getDescription } from 'services/tx/transaction-description'
 import AddressParser from 'models/address-parser'
 
 export default class TransactionsController {

--- a/packages/neuron-wallet/src/controllers/wallets.ts
+++ b/packages/neuron-wallet/src/controllers/wallets.ts
@@ -27,7 +27,7 @@ import { MainnetAddressRequired, TestnetAddressRequired } from 'exceptions/addre
 import TransactionSender from 'services/transaction-sender'
 import Transaction from 'models/chain/transaction'
 import logger from 'utils/logger'
-import { set as setDescription } from 'database/leveldb/transaction-description'
+import { set as setDescription } from 'services/tx/transaction-description'
 
 export default class WalletsController {
   public async getAll(): Promise<Controller.Response<Pick<Wallet, 'id' | 'name'>[]>> {

--- a/packages/neuron-wallet/src/database/chain/entities/tx-description.ts
+++ b/packages/neuron-wallet/src/database/chain/entities/tx-description.ts
@@ -1,0 +1,23 @@
+import { Entity, Column, PrimaryGeneratedColumn, Index } from 'typeorm'
+
+@Entity()
+export default class TxDescription {
+  @PrimaryGeneratedColumn()
+  id!: number
+
+  @Column({
+    type: 'varchar',
+  })
+  walletId!: string
+
+  @Column({
+    type: 'varchar',
+  })
+  @Index()
+  txHash!: string
+
+  @Column({
+    type: 'varchar',
+  })
+  description!: string
+}

--- a/packages/neuron-wallet/src/database/chain/migrations/1599441769473-TxDescription.ts
+++ b/packages/neuron-wallet/src/database/chain/migrations/1599441769473-TxDescription.ts
@@ -1,0 +1,50 @@
+import {MigrationInterface, QueryRunner } from "typeorm";
+import env from "env";
+
+export class TxDescription1599441769473 implements MigrationInterface {
+  name = 'TxDescription1599441769473'
+
+  public async up(queryRunner: QueryRunner): Promise<any> {
+      await queryRunner.query(`CREATE TABLE "tx_description" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "walletId" varchar NOT NULL, "txHash" varchar NOT NULL, "description" varchar NOT NULL)`, undefined);
+      await queryRunner.query(`CREATE INDEX "IDX_723cdd2978f3288000c33bdcc5" ON "tx_description" ("txHash") `, undefined);
+
+      //the following leveldb migration code will be deprecated and removed in next minor version 0.34
+      if (env.isTestMode) {
+        return
+      }
+      const maindb = require('../../leveldb').maindb
+
+      const itemsToMigrate: any[] = await new Promise(resolve => {
+        const itemsToMigrate: any = []
+        maindb.createReadStream()
+          .on('data', function (data: { key: any; value: any; }) {
+            try {
+              const keys = data.key.toString('utf8').split(':')
+              const [, walletId, txHash] = keys
+              itemsToMigrate.push([walletId, txHash, data.value.toString('utf8')])
+            } catch (error) {
+              console.error(error)
+            }
+          })
+          .on('error', function () {
+            resolve(itemsToMigrate)
+          })
+          .on('close', function () {
+            resolve(itemsToMigrate)
+          })
+          .on('end', function () {
+            resolve(itemsToMigrate)
+          })
+      })
+
+      for (const [walletId, txHash, description] of itemsToMigrate) {
+        await queryRunner.query(`INSERT INTO "tx_description" ("walletId", "txHash", "description") values('${walletId}', '${txHash}', '${description}')`, undefined);
+
+      }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`DROP TABLE "tx_description"`, undefined);
+    }
+
+}

--- a/packages/neuron-wallet/src/database/chain/ormconfig.ts
+++ b/packages/neuron-wallet/src/database/chain/ormconfig.ts
@@ -13,6 +13,7 @@ import SyncInfo from './entities/sync-info'
 import AssetAccount from './entities/asset-account'
 import SudtTokenInfo from './entities/sudt-token-info'
 import IndexerTxHashCache from './entities/indexer-tx-hash-cache'
+import TxDescription from './entities/tx-description'
 
 import { InitMigration1566959757554 } from './migrations/1566959757554-InitMigration'
 import { AddTypeAndHasData1567144517514 } from './migrations/1567144517514-AddTypeAndHasData'
@@ -35,6 +36,7 @@ import { RemoveAssetAccountWalletID1589273902050 } from './migrations/1589273902
 import { RemoveLiveCell1592781363749 } from './migrations/1592781363749-RemoveLiveCell'
 import { AddIndexerTxHashCache1592727615004 } from './migrations/1592727615004-AddIndexerTxHashCache'
 import { HDPublicKeyInfo1598087517643 } from './migrations/1598087517643-HDPublicKeyInfo'
+import { TxDescription1599441769473 } from './migrations/1599441769473-TxDescription'
 
 export const CONNECTION_NOT_FOUND_NAME = 'ConnectionNotFoundError'
 
@@ -57,6 +59,7 @@ const connectOptions = async (genesisBlockHash: string): Promise<SqliteConnectio
     entities: [
       HdPublicKeyInfo,
       Transaction,
+      TxDescription,
       Input,
       Output,
       SyncInfo,
@@ -86,6 +89,7 @@ const connectOptions = async (genesisBlockHash: string): Promise<SqliteConnectio
       RemoveLiveCell1592781363749,
       AddIndexerTxHashCache1592727615004,
       HDPublicKeyInfo1598087517643,
+      TxDescription1599441769473,
     ],
     logger: 'simple-console',
     logging,

--- a/packages/neuron-wallet/src/database/leveldb/index.ts
+++ b/packages/neuron-wallet/src/database/leveldb/index.ts
@@ -14,7 +14,7 @@ const leveldb = (dbname: string): LevelUp => {
   const dbpath = path.join(dir, dbname)
   return levelup(leveldown(dbpath), (err: Error | undefined) => {
     if (err) {
-      logger.error(`Database:\tfail to open leveldb ${dbname}:`, err?.toString())
+      logger.error(`Database:\tfail to open leveldb ${dbname}:`, err.toString())
     }
 
   })

--- a/packages/neuron-wallet/src/database/leveldb/index.ts
+++ b/packages/neuron-wallet/src/database/leveldb/index.ts
@@ -13,7 +13,9 @@ const leveldb = (dbname: string): LevelUp => {
 
   const dbpath = path.join(dir, dbname)
   return levelup(leveldown(dbpath), (err: Error | undefined) => {
-    logger.error(`Database:\tfail to open leveldb ${dbname}:`, err?.toString())
+    if (err) {
+      logger.error(`Database:\tfail to open leveldb ${dbname}:`, err?.toString())
+    }
 
   })
 }

--- a/packages/neuron-wallet/src/services/tx/transaction-description.ts
+++ b/packages/neuron-wallet/src/services/tx/transaction-description.ts
@@ -1,7 +1,3 @@
-// Transaction description is stored in LevelDB separated from Sqlite3 data,
-// to keep persisted. Sqlite3 transaction table gets cleaned when user clears
-// cache or sync rebuilds txs.
-
 import { getConnection } from 'typeorm'
 import TxDescription from 'database/chain/entities/tx-description'
 
@@ -23,19 +19,18 @@ export const get = async (walletId: string, txHash: string) => {
   return ''
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const set = async (_walletID: string, _txHash: string, _description: string) => {
-  const entity = await getEntity(_walletID, _txHash)
+export const set = async (walletID: string, txHash: string, description: string) => {
+  const entity = await getEntity(walletID, txHash)
   if (entity) {
-    entity.description = _description
+    entity.description = description
     await getConnection().manager.save(entity)
     return
   }
 
   const txDesc = new TxDescription()
-  txDesc.walletId = _walletID
-  txDesc.txHash = _txHash
-  txDesc.description = _description
+  txDesc.walletId = walletID
+  txDesc.txHash = txHash
+  txDesc.description = description
 
   await getConnection().manager.save(txDesc)
 }

--- a/packages/neuron-wallet/src/services/tx/transaction-description.ts
+++ b/packages/neuron-wallet/src/services/tx/transaction-description.ts
@@ -1,0 +1,41 @@
+// Transaction description is stored in LevelDB separated from Sqlite3 data,
+// to keep persisted. Sqlite3 transaction table gets cleaned when user clears
+// cache or sync rebuilds txs.
+
+import { getConnection } from 'typeorm'
+import TxDescription from 'database/chain/entities/tx-description'
+
+const getEntity = async (walletId: string, txHash: string) => {
+  return await getConnection()
+    .getRepository(TxDescription)
+    .createQueryBuilder()
+    .where({walletId, txHash})
+    .getOne()
+}
+
+export const get = async (walletId: string, txHash: string) => {
+  const entity = await getEntity(walletId, txHash)
+
+  if (entity) {
+    return entity.description
+  }
+
+  return ''
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const set = async (_walletID: string, _txHash: string, _description: string) => {
+  const entity = await getEntity(_walletID, _txHash)
+  if (entity) {
+    entity.description = _description
+    await getConnection().manager.save(entity)
+    return
+  }
+
+  const txDesc = new TxDescription()
+  txDesc.walletId = _walletID
+  txDesc.txHash = _txHash
+  txDesc.description = _description
+
+  await getConnection().manager.save(txDesc)
+}

--- a/packages/neuron-wallet/src/utils/export-history.ts
+++ b/packages/neuron-wallet/src/utils/export-history.ts
@@ -6,7 +6,7 @@ import AddressService from 'services/addresses'
 import { ChainType } from 'models/network'
 import Transaction from 'models/chain/transaction'
 import toCSVRow from 'utils/to-csv-row'
-import { get as getDescription } from 'database/leveldb/transaction-description'
+import { get as getDescription } from 'services/tx/transaction-description'
 
 const exportHistory = async ({
   walletID,

--- a/packages/neuron-wallet/tests/services/tx/transaction.description.intg.test.ts
+++ b/packages/neuron-wallet/tests/services/tx/transaction.description.intg.test.ts
@@ -1,0 +1,79 @@
+import initConnection from "../../../src/database/chain/ormconfig";
+import { getConnection } from "typeorm";
+import TxDescription from "../../../src/database/chain/entities/tx-description";
+import { get, set } from "../../../src/services/tx/transaction-description";
+
+describe('transaction description service', () => {
+  const txs = [
+    {walletId: 'w1', txHash: 'hash1', description: 'desc1'},
+    {walletId: 'w2', txHash: 'hash2', description: 'desc2'},
+    {walletId: 'w3', txHash: 'hash3', description: 'desc3'},
+  ]
+  beforeAll(async () => {
+    await initConnection('')
+  })
+
+  afterAll(async () => {
+    await getConnection().close()
+  })
+
+  beforeEach(async () => {
+    await getConnection().synchronize(true)
+
+    const entities = txs.map(tx => {
+      const txDesc = new TxDescription()
+      txDesc.walletId = tx.walletId
+      txDesc.txHash = tx.txHash
+      txDesc.description = tx.description
+      return txDesc
+    })
+
+    await getConnection().manager.save(entities)
+
+  })
+  describe('#get', () => {
+    let result: any
+    describe('when matched txs', () => {
+      beforeEach(async () => {
+        result = await get(txs[0].walletId, txs[0].txHash)
+      });
+      it('returns description', () => {
+        expect(result).toEqual(txs[0].description)
+      });
+    });
+    describe('when no matched txs', () => {
+      beforeEach(async () => {
+        result = await get(txs[0].walletId, 'hash4')
+      });
+      it('return empty string', () => {
+        expect(result).toEqual('')
+      })
+    });
+  });
+  describe('#set', () => {
+    describe('when no matched records', () => {
+      const walletId = 'w4'
+      const txHash = 'hash3'
+      const description = 'desc4'
+      beforeEach(async () => {
+        await set(walletId, txHash, description)
+      });
+      it('saves new description', async () => {
+        const desc = await get(walletId, txHash)
+        expect(desc).toEqual(description)
+      });
+    });
+    describe('when matched a tx', () => {
+      const walletId = 'w3'
+      const txHash = 'hash3'
+      const description = 'desc4'
+      beforeEach(async () => {
+        await set(walletId, txHash, description)
+      });
+      it('updates description', async () => {
+        const desc = await get(walletId, txHash)
+        expect(desc).toEqual(description)
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Refactor to use a sqlite table for storing the tx descriptions
- Migrate data from leveldb to the sqlite table
- leveldb dependency will be deprecated in the next minor version (0.34)