### PR TITLE
fix: reset description on entering customized asset list and ignore d…

### DIFF
--- a/packages/neuron-ui/src/components/PasswordRequest/index.tsx
+++ b/packages/neuron-ui/src/components/PasswordRequest/index.tsx
@@ -97,7 +97,7 @@ const PasswordRequest = () => {
             if (isSending) {
               break
             }
-            await sendTransaction({ walletID, tx: generatedTx, description, password })(dispatch).then(status => {
+            await sendTransaction({ walletID, tx: generatedTx, password })(dispatch).then(status => {
               if (isSuccessResponse({ status })) {
                 dispatch({
                   type: AppActions.SetGlobalDialog,

--- a/packages/neuron-ui/src/components/SpecialAssetList/index.tsx
+++ b/packages/neuron-ui/src/components/SpecialAssetList/index.tsx
@@ -66,10 +66,7 @@ const SpecialAssetList = () => {
   const isMainnet = isMainnetUtil(networks, networkID)
 
   useEffect(() => {
-    dispatch({
-      type: AppActions.UpdateGeneratedTx,
-      payload: null,
-    })
+    dispatch({ type: AppActions.ClearSendState })
   }, [dispatch])
 
   const fetchList = useCallback(


### PR DESCRIPTION
…escription on unlocking assets

Since only the generated tx was reset on mounting the customized asset list, and description was passed on sending unlock transaction, an unexpected description was appended to unlock transaction.
This commit remove the description field on sending unlock transaction and reset the entire send state on mounting the customized asset list to fix the bug.