### PR TITLE
Additional flags for bundled node

### DIFF
--- a/packages/neuron-ui/src/components/SUDTSend/index.tsx
+++ b/packages/neuron-ui/src/components/SUDTSend/index.tsx
@@ -370,7 +370,7 @@ const SUDTSend = () => {
               />
             </div>
             <div className={styles.remoteError}>
-              {isFormReady && remoteError ? (
+              {remoteError ? (
                 <>
                   <Attention />
                   {remoteError}

--- a/packages/neuron-wallet/src/models/subjects/node.ts
+++ b/packages/neuron-wallet/src/models/subjects/node.ts
@@ -2,10 +2,14 @@ import { BehaviorSubject } from 'rxjs'
 
 export const ConnectionStatusSubject = new BehaviorSubject<{
   url: string,
-  connected: boolean
+  connected: boolean,
+  isBundledNode: boolean,
+  startedBundledNode: boolean,
 }>({
   url: '',
-  connected: false
+  connected: false,
+  isBundledNode: true,
+  startedBundledNode: false,
 })
 
 export default class SyncedBlockNumberSubject {

--- a/packages/neuron-wallet/src/services/node.ts
+++ b/packages/neuron-wallet/src/services/node.ts
@@ -35,6 +35,7 @@ class NodeService {
   public connectionStatusSubject = new BehaviorSubject<boolean>(false)
 
   private _tipBlockNumber: string = '0'
+  private startedBundledNode: boolean = false
 
   public ckb: CKB = new CKB('')
 
@@ -62,6 +63,8 @@ class NodeService {
         ConnectionStatusSubject.next({
           url: this.ckb.node.url,
           connected,
+          isBundledNode: this.ckb.node.url === BUNDLED_CKB_URL,
+          startedBundledNode: this.startedBundledNode
         })
       })
   }
@@ -142,7 +145,9 @@ class NodeService {
     } catch (err) {
       logger.info('CKB:\texternal RPC on default uri not detected, starting bundled CKB node.')
       const isReadyToStart = await this.detectDependency()
-      return isReadyToStart ? this.startNode() : this.showGuideDialog()
+      this.startedBundledNode = await (isReadyToStart ? this.startNode() : this.showGuideDialog())
+
+      return this.startedBundledNode
     }
   }
 

--- a/packages/neuron-wallet/src/services/node.ts
+++ b/packages/neuron-wallet/src/services/node.ts
@@ -60,11 +60,12 @@ class NodeService {
     merge(periodSync, realtimeSync)
       .pipe(debounceTime(500))
       .subscribe(connected => {
+        const isBundledNode = this.ckb.node.url === BUNDLED_CKB_URL
         ConnectionStatusSubject.next({
           url: this.ckb.node.url,
           connected,
-          isBundledNode: this.ckb.node.url === BUNDLED_CKB_URL,
-          startedBundledNode: this.startedBundledNode
+          isBundledNode,
+          startedBundledNode: isBundledNode ? this.startedBundledNode : false
         })
       })
   }

--- a/packages/neuron-wallet/tests/services/node.test.ts
+++ b/packages/neuron-wallet/tests/services/node.test.ts
@@ -1,4 +1,3 @@
-// import NodeService from "../../src/services/node";
 import { distinctUntilChanged, sampleTime, flatMap, delay, retry } from 'rxjs/operators'
 import { BUNDLED_CKB_URL } from '../../src/utils/const'
 
@@ -10,15 +9,24 @@ describe('NodeService', () => {
   const stubbedGetTipBlockNumber = jest.fn()
   const stubbedRxjsDebounceTime = jest.fn()
   const stubbedCKB = jest.fn()
+  const stubbedCurrentNetworkIDSubjectSubscribe = jest.fn()
+  const stubbedNetworsServiceGet = jest.fn()
+  const stubbedLoggerInfo = jest.fn()
+  const stubbedLoggerError = jest.fn()
 
-  const fakeCKBUrl = 'fakeurl'
+  const fakeHTTPUrl = 'http://fakeurl'
+  const fakeHTTPSUrl = 'https://fakeurl'
 
   const resetMocks = () => {
     stubbedStartCKBNode.mockReset()
     stubbedConnectionStatusSubjectNext.mockReset()
     stubbedCKBSetNode.mockReset()
     stubbedGetTipBlockNumber.mockReset()
-    // stubbedCKB.mockReset()
+    stubbedCKB.mockReset()
+    stubbedCurrentNetworkIDSubjectSubscribe.mockReset()
+    stubbedNetworsServiceGet.mockReset()
+    stubbedLoggerInfo.mockReset()
+    stubbedLoggerError.mockReset()
   }
 
   beforeEach(() => {
@@ -30,10 +38,25 @@ describe('NodeService', () => {
         startCkbNode: stubbedStartCKBNode
       }
     })
+    jest.doMock('../../src/services/networks', () => {
+      return {
+        getInstance: () => ({
+          get: stubbedNetworsServiceGet,
+          getCurrent: stubbedNetworsServiceGet
+        }),
+      }
+    })
     jest.doMock('../../src/models/subjects/node', () => {
       return {
         ConnectionStatusSubject: {
           next: stubbedConnectionStatusSubjectNext
+        }
+      }
+    })
+    jest.doMock('../../src/models/subjects/networks', () => {
+      return {
+        CurrentNetworkIDSubject: {
+          subscribe: stubbedCurrentNetworkIDSubjectSubscribe
         }
       }
     })
@@ -48,6 +71,12 @@ describe('NodeService', () => {
         delay,
         retry,
         debounceTime: stubbedRxjsDebounceTime,
+      }
+    })
+    jest.doMock('../../src/utils/logger', () => {
+      return {
+        info: stubbedLoggerInfo,
+        error: stubbedLoggerError,
       }
     })
 
@@ -66,7 +95,7 @@ describe('NodeService', () => {
           getTipBlockNumber: stubbedGetTipBlockNumber,
         },
         node: {
-          url: fakeCKBUrl
+          url: fakeHTTPUrl
         }
       }))
 
@@ -77,7 +106,7 @@ describe('NodeService', () => {
     });
     it('emits disconnected event in ConnectionStatusSubject', () => {
       expect(stubbedConnectionStatusSubjectNext).toHaveBeenCalledWith({
-        url: fakeCKBUrl,
+        url: fakeHTTPUrl,
         connected: false,
         isBundledNode: false,
         startedBundledNode: false,
@@ -91,7 +120,7 @@ describe('NodeService', () => {
       });
       it('emits connected event in ConnectionStatusSubject', () => {
         expect(stubbedConnectionStatusSubjectNext).toHaveBeenCalledWith({
-          url: fakeCKBUrl,
+          url: fakeHTTPUrl,
           connected: true,
           isBundledNode: false,
           startedBundledNode: false,
@@ -106,7 +135,7 @@ describe('NodeService', () => {
         });
         it('emits disconnected event in ConnectionStatusSubject', () => {
           expect(stubbedConnectionStatusSubjectNext).toHaveBeenCalledWith({
-            url: fakeCKBUrl,
+            url: fakeHTTPUrl,
             connected: false,
             isBundledNode: false,
             startedBundledNode: false,
@@ -130,54 +159,160 @@ describe('NodeService', () => {
       const NodeService = require('../../src/services/node').default
       nodeService = new NodeService()
 
-      stubbedStartCKBNode.mockResolvedValue(true)
-      await nodeService.tryStartNodeOnDefaultURI()
-
-      jest.advanceTimersByTime(1000)
+      stubbedNetworsServiceGet.mockReturnValueOnce({remote: BUNDLED_CKB_URL})
     });
-    it('emits disconnected event in ConnectionStatusSubject', () => {
-      expect(stubbedConnectionStatusSubjectNext).toHaveBeenCalledWith({
-        url: BUNDLED_CKB_URL,
-        connected: false,
-        isBundledNode: true,
-        startedBundledNode: false,
-      })
-    })
-    describe('advance to next event', () => {
+    describe('when node starts', () => {
       beforeEach(async () => {
-        stubbedConnectionStatusSubjectNext.mockReset()
-        stubbedGetTipBlockNumber.mockResolvedValueOnce('0x1')
+        stubbedStartCKBNode.mockResolvedValue(true)
+        await nodeService.tryStartNodeOnDefaultURI()
+
         jest.advanceTimersByTime(1000)
       });
-      it('emits connected event in ConnectionStatusSubject', () => {
+      it('emits disconnected event in ConnectionStatusSubject', () => {
         expect(stubbedConnectionStatusSubjectNext).toHaveBeenCalledWith({
           url: BUNDLED_CKB_URL,
-          connected: true,
+          connected: false,
           isBundledNode: true,
-          startedBundledNode: true,
+          startedBundledNode: false,
         })
       })
-
-      describe('got exception when polling CKB RPC', () => {
+      describe('advance to next event', () => {
         beforeEach(async () => {
           stubbedConnectionStatusSubjectNext.mockReset()
-          stubbedGetTipBlockNumber.mockRejectedValueOnce(new Error())
+          stubbedGetTipBlockNumber.mockResolvedValueOnce('0x1')
           jest.advanceTimersByTime(1000)
         });
-        it('emits disconnected event in ConnectionStatusSubject', () => {
+        it('emits connected event in ConnectionStatusSubject', () => {
           expect(stubbedConnectionStatusSubjectNext).toHaveBeenCalledWith({
             url: BUNDLED_CKB_URL,
-            connected: false,
+            connected: true,
             isBundledNode: true,
             startedBundledNode: true,
           })
         })
+
+        describe('got exception when polling CKB RPC', () => {
+          beforeEach(async () => {
+            stubbedConnectionStatusSubjectNext.mockReset()
+            stubbedGetTipBlockNumber.mockRejectedValueOnce(new Error())
+            jest.advanceTimersByTime(1000)
+          });
+          it('emits disconnected event in ConnectionStatusSubject', () => {
+            expect(stubbedConnectionStatusSubjectNext).toHaveBeenCalledWith({
+              url: BUNDLED_CKB_URL,
+              connected: false,
+              isBundledNode: true,
+              startedBundledNode: true,
+            })
+          })
+        });
       });
+    });
+    describe('when node failed to start', () => {
+      beforeEach(async () => {
+        stubbedStartCKBNode.mockRejectedValue(new Error())
+        await nodeService.tryStartNodeOnDefaultURI()
+      });
+      it('logs error', () => {
+        expect(stubbedLoggerInfo).toHaveBeenCalledWith('CKB:	fail to start bundled CKB with error:')
+        expect(stubbedLoggerError).toHaveBeenCalledWith(new Error())
+      });
+      it('emits disconnected event in ConnectionStatusSubject', () => {
+        expect(stubbedConnectionStatusSubjectNext).toHaveBeenCalledWith({
+          url: BUNDLED_CKB_URL,
+          connected: false,
+          isBundledNode: true,
+          startedBundledNode: false,
+        })
+      })
     });
   });
   describe('CurrentNetworkIDSubject#subscribe', () => {
-    describe('#setNetwork', () => {
+    let eventCallback: any
+    const stubbedTipNumberSubjectCallback = jest.fn()
+    beforeEach(() => {
+      stubbedCKB.mockImplementation(() => ({
+        setNode: stubbedCKBSetNode,
+        rpc: {
+          getTipBlockNumber: stubbedGetTipBlockNumber,
+        },
+        node: {
+          url: fakeHTTPUrl
+        }
+      }))
 
+      const NodeService = require('../../src/services/node').default
+      nodeService = new NodeService()
+      nodeService.tipNumberSubject.subscribe(stubbedTipNumberSubjectCallback)
+
+      eventCallback = stubbedCurrentNetworkIDSubjectSubscribe.mock.calls[0][0]
     });
-  })
+    it('emits disconnected event in ConnectionStatusSubject', () => {
+      expect(stubbedConnectionStatusSubjectNext).toHaveBeenCalledWith({
+        url: fakeHTTPUrl,
+        connected: false,
+        isBundledNode: false,
+        startedBundledNode: false,
+      })
+    })
+    it('resets tip block number', () => {
+      expect(stubbedTipNumberSubjectCallback).toHaveBeenCalledWith('0')
+    })
+    describe('with http url', () => {
+      beforeEach(async () => {
+        stubbedNetworsServiceGet.mockReturnValueOnce({remote: fakeHTTPUrl})
+        await eventCallback({currentNetworkID: 'test'})
+      });
+      it('sets http agent', () => {
+        expect(stubbedCKBSetNode).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: fakeHTTPUrl,
+            httpAgent: expect.anything()
+          })
+        )
+      });
+    });
+    describe('with https url', () => {
+      beforeEach(async () => {
+        stubbedNetworsServiceGet.mockReturnValueOnce({remote: fakeHTTPSUrl})
+        await eventCallback({currentNetworkID: 'test'})
+      });
+      it('sets https agent', () => {
+        expect(stubbedCKBSetNode).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: fakeHTTPSUrl,
+            httpsAgent: expect.anything()
+          })
+        )
+      });
+    });
+    describe('with invalid url', () => {
+      beforeEach(() => {
+        stubbedNetworsServiceGet.mockReturnValueOnce({remote: 'invalidurl'})
+      });
+      it('throws error', async () => {
+        let err
+        try {
+          await eventCallback({currentNetworkID: 'test'})
+        } catch (error) {
+          err = error
+        }
+        expect(err).toEqual(new Error('Protocol of url should be specified'))
+      });
+    });
+    describe('when url is not a string', () => {
+      beforeEach(() => {
+        stubbedNetworsServiceGet.mockReturnValueOnce({remote: {}})
+      });
+      it('throws error', async () => {
+        let err
+        try {
+          await eventCallback({currentNetworkID: 'test'})
+        } catch (error) {
+          err = error
+        }
+        expect(err).toEqual(new Error('should-be-type-of'))
+      });
+    });
+  });
 });

--- a/packages/neuron-wallet/tests/services/node.test.ts
+++ b/packages/neuron-wallet/tests/services/node.test.ts
@@ -1,0 +1,183 @@
+// import NodeService from "../../src/services/node";
+import { distinctUntilChanged, sampleTime, flatMap, delay, retry } from 'rxjs/operators'
+import { BUNDLED_CKB_URL } from '../../src/utils/const'
+
+describe('NodeService', () => {
+  let nodeService: any
+  const stubbedStartCKBNode = jest.fn()
+  const stubbedConnectionStatusSubjectNext = jest.fn()
+  const stubbedCKBSetNode = jest.fn()
+  const stubbedGetTipBlockNumber = jest.fn()
+  const stubbedRxjsDebounceTime = jest.fn()
+  const stubbedCKB = jest.fn()
+
+  const fakeCKBUrl = 'fakeurl'
+
+  const resetMocks = () => {
+    stubbedStartCKBNode.mockReset()
+    stubbedConnectionStatusSubjectNext.mockReset()
+    stubbedCKBSetNode.mockReset()
+    stubbedGetTipBlockNumber.mockReset()
+    // stubbedCKB.mockReset()
+  }
+
+  beforeEach(() => {
+    resetMocks()
+    jest.useFakeTimers()
+
+    jest.doMock('../../src/services/ckb-runner', () => {
+      return {
+        startCkbNode: stubbedStartCKBNode
+      }
+    })
+    jest.doMock('../../src/models/subjects/node', () => {
+      return {
+        ConnectionStatusSubject: {
+          next: stubbedConnectionStatusSubjectNext
+        }
+      }
+    })
+    jest.doMock('@nervosnetwork/ckb-sdk-core', () => {
+      return stubbedCKB
+    })
+    jest.doMock('rxjs/operators', () => {
+      return {
+        distinctUntilChanged,
+        sampleTime,
+        flatMap,
+        delay,
+        retry,
+        debounceTime: stubbedRxjsDebounceTime,
+      }
+    })
+
+    stubbedRxjsDebounceTime.mockReturnValue((x: any) => x)
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers()
+  });
+
+  describe('when targets external node', () => {
+    beforeEach(async () => {
+      stubbedCKB.mockImplementation(() => ({
+        setNode: stubbedCKBSetNode,
+        rpc: {
+          getTipBlockNumber: stubbedGetTipBlockNumber,
+        },
+        node: {
+          url: fakeCKBUrl
+        }
+      }))
+
+      const NodeService = require('../../src/services/node').default
+      nodeService = new NodeService()
+
+      jest.advanceTimersByTime(1000)
+    });
+    it('emits disconnected event in ConnectionStatusSubject', () => {
+      expect(stubbedConnectionStatusSubjectNext).toHaveBeenCalledWith({
+        url: fakeCKBUrl,
+        connected: false,
+        isBundledNode: false,
+        startedBundledNode: false,
+      })
+    })
+    describe('advance to next event', () => {
+      beforeEach(async () => {
+        stubbedConnectionStatusSubjectNext.mockReset()
+        stubbedGetTipBlockNumber.mockResolvedValueOnce('0x1')
+        jest.advanceTimersByTime(1000)
+      });
+      it('emits connected event in ConnectionStatusSubject', () => {
+        expect(stubbedConnectionStatusSubjectNext).toHaveBeenCalledWith({
+          url: fakeCKBUrl,
+          connected: true,
+          isBundledNode: false,
+          startedBundledNode: false,
+        })
+      })
+
+      describe('got exception when polling CKB RPC', () => {
+        beforeEach(async () => {
+          stubbedConnectionStatusSubjectNext.mockReset()
+          stubbedGetTipBlockNumber.mockRejectedValueOnce(new Error())
+          jest.advanceTimersByTime(1000)
+        });
+        it('emits disconnected event in ConnectionStatusSubject', () => {
+          expect(stubbedConnectionStatusSubjectNext).toHaveBeenCalledWith({
+            url: fakeCKBUrl,
+            connected: false,
+            isBundledNode: false,
+            startedBundledNode: false,
+          })
+        })
+      });
+    });
+  });
+  describe('when targets bundled node', () => {
+    beforeEach(async () => {
+      stubbedCKB.mockImplementation(() => ({
+        setNode: stubbedCKBSetNode,
+        rpc: {
+          getTipBlockNumber: stubbedGetTipBlockNumber,
+        },
+        node: {
+          url: BUNDLED_CKB_URL
+        }
+      }))
+
+      const NodeService = require('../../src/services/node').default
+      nodeService = new NodeService()
+
+      stubbedStartCKBNode.mockResolvedValue(true)
+      await nodeService.tryStartNodeOnDefaultURI()
+
+      jest.advanceTimersByTime(1000)
+    });
+    it('emits disconnected event in ConnectionStatusSubject', () => {
+      expect(stubbedConnectionStatusSubjectNext).toHaveBeenCalledWith({
+        url: BUNDLED_CKB_URL,
+        connected: false,
+        isBundledNode: true,
+        startedBundledNode: false,
+      })
+    })
+    describe('advance to next event', () => {
+      beforeEach(async () => {
+        stubbedConnectionStatusSubjectNext.mockReset()
+        stubbedGetTipBlockNumber.mockResolvedValueOnce('0x1')
+        jest.advanceTimersByTime(1000)
+      });
+      it('emits connected event in ConnectionStatusSubject', () => {
+        expect(stubbedConnectionStatusSubjectNext).toHaveBeenCalledWith({
+          url: BUNDLED_CKB_URL,
+          connected: true,
+          isBundledNode: true,
+          startedBundledNode: true,
+        })
+      })
+
+      describe('got exception when polling CKB RPC', () => {
+        beforeEach(async () => {
+          stubbedConnectionStatusSubjectNext.mockReset()
+          stubbedGetTipBlockNumber.mockRejectedValueOnce(new Error())
+          jest.advanceTimersByTime(1000)
+        });
+        it('emits disconnected event in ConnectionStatusSubject', () => {
+          expect(stubbedConnectionStatusSubjectNext).toHaveBeenCalledWith({
+            url: BUNDLED_CKB_URL,
+            connected: false,
+            isBundledNode: true,
+            startedBundledNode: true,
+          })
+        })
+      });
+    });
+  });
+  describe('CurrentNetworkIDSubject#subscribe', () => {
+    describe('#setNetwork', () => {
+
+    });
+  })
+});


### PR DESCRIPTION
Added the two additional flags for the bundled node:
- isBundledNode
- startedBundledNode

These flags would help the front end refine the display of connection statuses, particularly for the bundled node.