### PR TITLE
Fix lumos query for multisign lock

### DIFF
--- a/packages/neuron-wallet/src/database/address/meta.ts
+++ b/packages/neuron-wallet/src/database/address/meta.ts
@@ -3,6 +3,7 @@ import { AddressType } from "models/keys/address";
 import Script from "models/chain/script";
 import SystemScriptInfo from "models/system-script-info";
 import AssetAccountInfo from "models/asset-account-info";
+import MultiSign from "models/multi-sign";
 
 export default class AddressMeta implements Address {
   walletId: string
@@ -80,7 +81,7 @@ export default class AddressMeta implements Address {
   }
 
   public generateSingleMultiSignLockScript(): Script {
-    return SystemScriptInfo.generateMultiSignScript(this.blake160)
+    return SystemScriptInfo.generateMultiSignScript(new MultiSign().hash(this.blake160))
   }
 
   public generateACPLockScript(): Script {

--- a/packages/neuron-wallet/tests/block-sync-render/queue.intg.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/queue.intg.test.ts
@@ -24,6 +24,7 @@ const stubbedGetTransactionFn = jest.fn()
 const stubbedGetHeaderFn = jest.fn()
 const stubbedGenesisBlockHashFn = jest.fn()
 const stubbedGetTransactionsByLockScriptFn = jest.fn()
+const stubbedCellCollectorConstructor = jest.fn()
 
 const resetMocks = () => {
   stubbedGetTransactionFn.mockReset()
@@ -148,6 +149,22 @@ describe('integration tests for sync pipeline', () => {
 
     when(stubbedGetHeaderFn).calledWith(fakeBlock1.hash).mockReturnValue(fakeBlock1)
 
+    when(stubbedCellCollectorConstructor)
+      .calledWith(expect.anything())
+      .mockReturnValue({
+        collect: () => {
+          return {
+            [Symbol.asyncIterator]: () => {
+              return {
+                next: async () => {
+                  return {done: true}
+                }
+              }
+            }
+          }
+        }
+      })
+
     stubbedIndexerConstructor = jest.fn().mockImplementation(
       () => ({
         startForever: stubbedStartForeverFn,
@@ -170,7 +187,8 @@ describe('integration tests for sync pipeline', () => {
     jest.doMock('@ckb-lumos/indexer', () => {
       return {
         Indexer : stubbedIndexerConstructor,
-        TransactionCollector : stubbedTransactionCollectorConstructor
+        TransactionCollector : stubbedTransactionCollectorConstructor,
+        CellCollector : stubbedCellCollectorConstructor
       }
     });
 

--- a/packages/neuron-wallet/tests/database/address/meta.test.ts
+++ b/packages/neuron-wallet/tests/database/address/meta.test.ts
@@ -1,6 +1,7 @@
 import { AddressVersion, Address } from '../../../src/database/address/address-dao'
 import { AddressType } from '../../../src/models/keys/address'
 import AddressMeta from '../../../src/database/address/meta'
+import MultiSign from "../../../src/models/multi-sign";
 
 describe('Address Dao tests', () => {
   const address: Address = {
@@ -32,7 +33,7 @@ describe('Address Dao tests', () => {
     it('#generateDefaultLockScript', () => {
       const script = addressMeta.generateDefaultLockScript()
       expect(script).toEqual({
-        args: '0x36c329ed630d6ce750712a477543672adab57f4c',
+        args: address.blake160,
         codeHash: '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
         hashType: 'type'
       })
@@ -41,7 +42,7 @@ describe('Address Dao tests', () => {
     it('#generateSingleMultiSignLockScript', () => {
       const script = addressMeta.generateSingleMultiSignLockScript()
       expect(script).toEqual({
-        args: '0x36c329ed630d6ce750712a477543672adab57f4c',
+        args: new MultiSign().hash(address.blake160),
         codeHash: '0x5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8',
         hashType: 'type'
       })
@@ -50,7 +51,7 @@ describe('Address Dao tests', () => {
     it('#generateACPLockScript', () => {
       const script = addressMeta.generateACPLockScript()
       expect(script).toEqual({
-        args: '0x36c329ed630d6ce750712a477543672adab57f4c',
+        args: address.blake160,
         codeHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
         hashType: 'type'
       })


### PR DESCRIPTION
- Fix incorrect `args` for the multi-sign lock 
- Use `argsLen` lumos query filter to locate the cells by multi-sign lock and cache their corresponding transaction hashes for indexing.