### PR TITLE
Optimize query performance for tx hash upsert

### DIFF
--- a/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-connector.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-connector.ts
@@ -205,12 +205,12 @@ export default class IndexerConnector {
   }
 
   private async upsertTxHashes(): Promise<string[]> {
-    const arrayOfInsertedTxHashes = await Promise.all(
-      [...this.addressesByWalletId.entries()].map(([walletId, addressMetas]) => {
-        const indexerCacheService = new IndexerCacheService(walletId, addressMetas, this.rpcService, this.indexer)
-        return indexerCacheService.upsertTxHashes()
-      })
-    )
+    const arrayOfInsertedTxHashes = []
+    for (const [walletId, addressMetas] of [...this.addressesByWalletId.entries()]) {
+      const indexerCacheService = new IndexerCacheService(walletId, addressMetas, this.rpcService, this.indexer)
+      const txHashes = await indexerCacheService.upsertTxHashes()
+      arrayOfInsertedTxHashes.push(txHashes)
+    }
     return arrayOfInsertedTxHashes.flat()
   }
 


### PR DESCRIPTION
Concurrent SQLite queries are slower than the ones running in sequence. This PR make the concurrent queries run in order.