### PR TITLE
Disable transfers from ckb asset account to sudt asset account

### DIFF
--- a/packages/neuron-wallet/src/services/anyone-can-pay.ts
+++ b/packages/neuron-wallet/src/services/anyone-can-pay.ts
@@ -60,6 +60,11 @@ export default class AnyoneCanPayService {
     if (!targetOutputLiveCell) {
       throw new TargetOutputNotFoundError()
     }
+
+    if (isCKB && targetOutputLiveCell.type()) {
+      throw new TargetOutputNotFoundError()
+    }
+
     const targetOutput: Output = Output.fromObject({
       capacity: targetOutputLiveCell.capacity,
       lock: targetOutputLiveCell.lock(),

--- a/packages/neuron-wallet/src/services/tx/transaction-generator.ts
+++ b/packages/neuron-wallet/src/services/tx/transaction-generator.ts
@@ -622,6 +622,9 @@ export class TransactionGenerator {
     const secpCellDep = await SystemScriptInfo.getInstance().getSecpCellDep()
     const assetAccountInfo = new AssetAccountInfo()
     const anyoneCanPayDep = assetAccountInfo.anyoneCanPayCellDep
+    const sudtDep = assetAccountInfo.sudtCellDep
+
+    const cellDeps = [secpCellDep, anyoneCanPayDep]
     const needCapacities: bigint = capacity === 'all' ? BigInt(targetOutput.capacity) : BigInt(targetOutput.capacity) + BigInt(capacity)
     const output = Output.fromObject({
       ...targetOutput,
@@ -634,10 +637,15 @@ export class TransactionGenerator {
       lock: targetOutput.lock,
       lockHash: targetOutput.lockHash,
     })
+
+    if (output.type) {
+      cellDeps.push(sudtDep)
+    }
+
     const tx =  Transaction.fromObject({
       version: '0',
       headerDeps: [],
-      cellDeps: [secpCellDep, anyoneCanPayDep],
+      cellDeps,
       inputs: [targetInput],
       outputs: [output],
       outputsData: [output.data],


### PR DESCRIPTION
- Internally supports transfers from ckb asset account to sudt asset account
- For now, reject requests to transfer from ckb asset account to sudt asset account