### PR TITLE
Estimation on synchronization

### DIFF
--- a/packages/neuron-ui/src/containers/Main/hooks.ts
+++ b/packages/neuron-ui/src/containers/Main/hooks.ts
@@ -186,10 +186,10 @@ export const useSubscription = ({
       }
     })
 
-    const syncedBlockNumberSubscription = SyncedBlockNumberSubject.subscribe(syncedBlockNumber => {
+    const syncedBlockNumberSubscription = SyncedBlockNumberSubject.subscribe(({ cacheTipNumber }) => {
       dispatch({
         type: NeuronWalletActions.UpdateSyncedBlockNumber,
-        payload: syncedBlockNumber,
+        payload: cacheTipNumber.toString(),
       })
     })
 

--- a/packages/neuron-ui/src/services/subjects.ts
+++ b/packages/neuron-ui/src/services/subjects.ts
@@ -23,7 +23,7 @@ const SubjectConstructor = <T>(
     | 'current-network-id-updated'
     | 'network-list-updated'
     | 'connection-status-updated'
-    | 'synced-block-number-updated'
+    | 'sync-estimate-updated'
     | 'command'
     | 'app-updater-updated'
     | 'navigation'
@@ -50,7 +50,7 @@ export const WalletList = SubjectConstructor<any[]>('wallet-list-updated')
 export const NetworkList = SubjectConstructor<Subject.NetworkList>('network-list-updated')
 export const CurrentNetworkID = SubjectConstructor<Subject.CurrentNetworkID>('current-network-id-updated')
 export const ConnectionStatus = SubjectConstructor<Subject.ConnectionStatus>('connection-status-updated')
-export const SyncedBlockNumber = SubjectConstructor<Subject.BlockNumber>('synced-block-number-updated')
+export const SyncedBlockNumber = SubjectConstructor<Subject.SyncStatus>('sync-estimate-updated')
 export const AppUpdater = SubjectConstructor<Subject.AppUpdater>('app-updater-updated')
 export const Command = SubjectConstructor<Subject.CommandMetaInfo>('command')
 export const Navigation = SubjectConstructor<Subject.URL>('navigation')

--- a/packages/neuron-ui/src/types/Subject/index.d.ts
+++ b/packages/neuron-ui/src/types/Subject/index.d.ts
@@ -26,6 +26,7 @@ declare namespace Subject {
   }
   type ConnectionStatus = { url: string; connected: boolean }
   type BlockNumber = string
+  type SyncStatus = { cacheTipNumber: number; bestKnownBlockNumber: number; estimate: number }
   interface AppUpdater {
     checking: boolean
     downloadProgress: number

--- a/packages/neuron-wallet/src/block-sync-renderer/index.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/index.ts
@@ -6,7 +6,6 @@ import DataUpdateSubject from 'models/subjects/data-update'
 import env from 'env'
 import AddressCreatedSubject from 'models/subjects/address-created-subject'
 import WalletDeletedSubject from 'models/subjects/wallet-deleted-subject'
-import SyncedBlockNumberSubject from 'models/subjects/node'
 import SyncedBlockNumber from 'models/synced-block-number'
 import NetworksService from 'services/networks'
 import AddressService from 'services/addresses'
@@ -89,11 +88,8 @@ export const createBlockSyncTask = async (clearIndexerFolder: boolean) => {
 
   subscribeToWorkerProcess(syncTask, msg => {
     switch (msg.channel) {
-      case 'synced-block-number-updated':
-        SyncApiController.emiter.emit('synced-block-number-updated', msg.result)
-        break
-      case 'sync-states-updated':
-        SyncApiController.emiter.emit('sync-states-updated', msg.result)
+      case 'sync-estimate-updated':
+        SyncApiController.emiter.emit('sync-estimate-updated', msg.result)
         break
       case 'tx-db-changed':
         TxDbChangedSubject.getSubject().next(msg.result)
@@ -113,10 +109,6 @@ export const createBlockSyncTask = async (clearIndexerFolder: boolean) => {
   if (!network) {
     network = NetworksService.getInstance().getCurrent()
   }
-
-  const startBlockNumber = (await new SyncedBlockNumber().getNextBlock()).toString()
-  SyncedBlockNumberSubject.getSubject().next(startBlockNumber)
-  logger.info('Sync:\tbackground process started, scan from block #' + startBlockNumber)
 
   DataUpdateSubject.next({
     dataType: 'transaction',

--- a/packages/neuron-wallet/src/block-sync-renderer/index.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/index.ts
@@ -92,6 +92,9 @@ export const createBlockSyncTask = async (clearIndexerFolder: boolean) => {
       case 'synced-block-number-updated':
         SyncApiController.emiter.emit('synced-block-number-updated', msg.result)
         break
+      case 'sync-states-updated':
+        SyncApiController.emiter.emit('sync-states-updated', msg.result)
+        break
       case 'tx-db-changed':
         TxDbChangedSubject.getSubject().next(msg.result)
         break

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-connector.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-connector.ts
@@ -1,7 +1,7 @@
 import { Subject } from 'rxjs'
 import { queue, AsyncQueue } from 'async'
 import { QueryOptions, HashType } from '@ckb-lumos/base'
-import { Indexer, Tip, CellCollector } from '@ckb-lumos/indexer'
+import { Indexer, CellCollector, Tip } from '@ckb-lumos/indexer'
 import logger from 'utils/logger'
 import CommonUtils from 'utils/common'
 import RpcService from 'services/rpc-service'
@@ -40,6 +40,11 @@ export interface LumosCell {
   data?: string
 }
 
+export interface BlockTips {
+  cacheTipNumber: number
+  indexerTipNumber: number | undefined
+}
+
 export default class IndexerConnector {
   private indexer: Indexer
   private rpcService: RpcService
@@ -48,9 +53,8 @@ export default class IndexerConnector {
   private indexerQueryQueue: AsyncQueue<LumosCellQuery> | undefined
 
   private processingBlockNumber: string | undefined
-  private indexerTip: Tip | undefined
   public pollingIndexer: boolean = false
-  public readonly blockTipSubject: Subject<any> = new Subject<any>()
+  public readonly blockTipsSubject: Subject<BlockTips> = new Subject<BlockTips>()
   public readonly transactionsSubject: Subject<Array<TransactionWithStatus>> = new Subject<Array<TransactionWithStatus>>()
 
   constructor(
@@ -84,6 +88,33 @@ export default class IndexerConnector {
     })
   }
 
+  private async synchronize(indexerTipBlock: Tip) {
+    if (!indexerTipBlock) {
+      return
+    }
+
+    await this.upsertTxHashes()
+
+    const indexerTipNumber = parseInt(indexerTipBlock.block_number, 16)
+
+    const nextUnprocessedBlockTip = await IndexerCacheService.nextUnprocessedBlock([...this.addressesByWalletId.keys()])
+    if (nextUnprocessedBlockTip) {
+      this.blockTipsSubject.next({
+        cacheTipNumber: parseInt(nextUnprocessedBlockTip.blockNumber),
+        indexerTipNumber,
+      })
+      if (!this.processingBlockNumber) {
+        await this.processNextBlockNumber()
+      }
+    }
+    else {
+      this.blockTipsSubject.next({
+        cacheTipNumber: indexerTipNumber,
+        indexerTipNumber,
+      })
+    }
+  }
+
   public async connect() {
     try {
       this.indexer.startForever()
@@ -92,29 +123,8 @@ export default class IndexerConnector {
       await this.processNextBlockNumber()
 
       while (this.pollingIndexer) {
-        this.indexerTip = await this.indexer.tip()
-
-        await this.upsertTxHashes()
-
-        const nextUnprocessedBlockTip = await IndexerCacheService.nextUnprocessedBlock([...this.addressesByWalletId.keys()])
-        if (nextUnprocessedBlockTip) {
-          this.blockTipSubject.next({
-            block_number: nextUnprocessedBlockTip.blockNumber,
-            block_hash: nextUnprocessedBlockTip.blockHash,
-            indexer_tip_number: BigInt(this.indexerTip.block_number).toString(),
-          })
-          if (!this.processingBlockNumber) {
-            await this.processNextBlockNumber()
-          }
-        }
-        else if (this.indexerTip) {
-          this.blockTipSubject.next({
-            block_number: BigInt(this.indexerTip.block_number).toString(),
-            block_hash: this.indexerTip.block_hash,
-            indexer_tip_number: BigInt(this.indexerTip.block_number).toString()
-          })
-        }
-
+        const indexerTipBlock = await this.indexer.tip()
+        await this.synchronize(indexerTipBlock)
         await CommonUtils.sleep(5000)
       }
     } catch (error) {

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-connector.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-connector.ts
@@ -50,7 +50,7 @@ export default class IndexerConnector {
   private processingBlockNumber: string | undefined
   private indexerTip: Tip | undefined
   public pollingIndexer: boolean = false
-  public readonly blockTipSubject: Subject<Tip> = new Subject<Tip>()
+  public readonly blockTipSubject: Subject<any> = new Subject<any>()
   public readonly transactionsSubject: Subject<Array<TransactionWithStatus>> = new Subject<Array<TransactionWithStatus>>()
 
   constructor(
@@ -101,13 +101,18 @@ export default class IndexerConnector {
           this.blockTipSubject.next({
             block_number: nextUnprocessedBlockTip.blockNumber,
             block_hash: nextUnprocessedBlockTip.blockHash,
+            indexer_tip_number: BigInt(this.indexerTip.block_number).toString(),
           })
           if (!this.processingBlockNumber) {
             await this.processNextBlockNumber()
           }
         }
         else if (this.indexerTip) {
-          this.blockTipSubject.next(this.indexerTip)
+          this.blockTipSubject.next({
+            block_number: BigInt(this.indexerTip.block_number).toString(),
+            block_hash: this.indexerTip.block_hash,
+            indexer_tip_number: BigInt(this.indexerTip.block_number).toString()
+          })
         }
 
         await CommonUtils.sleep(5000)

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
@@ -13,7 +13,7 @@ import AssetAccountService from 'services/asset-account-service'
 import { Address as AddressInterface } from "models/address"
 import AddressParser from 'models/address-parser'
 import MultiSign from 'models/multi-sign'
-import IndexerConnector from './indexer-connector'
+import IndexerConnector, { BlockTips } from './indexer-connector'
 import IndexerCacheService from './indexer-cache-service'
 import CommonUtils from 'utils/common'
 import { ChildProcess } from 'utils/worker'
@@ -54,8 +54,8 @@ export default class Queue {
       this.url
     )
     this.indexerConnector.connect()
-    this.indexerConnector.blockTipSubject.subscribe(tip => {
-      this.updateCurrentBlockNumber(tip)
+    this.indexerConnector.blockTipsSubject.subscribe(tip => {
+      this.updateBlockNumberTips(tip)
     });
 
 
@@ -213,17 +213,12 @@ export default class Queue {
     }
   }
 
-  private updateCurrentBlockNumber(tip: any) {
-    const currentBlockNumber = BigInt(tip.block_number)
+  private updateBlockNumberTips(tip: BlockTips) {
     ChildProcess.send({
-      channel: 'synced-block-number-updated',
-      result: currentBlockNumber.toString()
-    })
-    ChildProcess.send({
-      channel: 'sync-states-updated',
+      channel: 'sync-estimate-updated',
       result: {
-        indexerTip: tip.indexer_tip_number,
-        cacheTip: tip.block_number,
+        indexerTipNumber: tip.indexerTipNumber,
+        cacheTipNumber: tip.cacheTipNumber,
         timestamp: Date.now()
       }
     })

--- a/packages/neuron-wallet/src/controllers/app/subscribe.ts
+++ b/packages/neuron-wallet/src/controllers/app/subscribe.ts
@@ -1,6 +1,6 @@
 import { BrowserWindow } from 'electron'
 import { t } from 'i18next'
-import { debounceTime, sampleTime } from 'rxjs/operators'
+import { debounceTime, sampleTime, startWith } from 'rxjs/operators'
 
 import CommandSubject from 'models/subjects/command'
 import DataUpdateSubject from 'models/subjects/data-update'
@@ -11,7 +11,7 @@ import dataUpdateSubject from 'models/subjects/data-update'
 import AppUpdaterSubject from 'models/subjects/app-updater'
 import { SETTINGS_WINDOW_TITLE } from 'utils/const'
 import SyncStateSubject from 'models/subjects/sync-state-subject'
-
+import { combineLatest } from 'rxjs';
 interface AppResponder {
   sendMessage: (channel: string, arg: any) => void
   runCommand: (command: string, arg: any) => void
@@ -32,8 +32,16 @@ export const subscribe = (dispatcher: AppResponder) => {
     dispatcher.sendMessage('connection-status-updated', params)
   })
 
-  SyncStateSubject.pipe(sampleTime(1000)).subscribe(params => {
-    dispatcher.sendMessage('sync-estimate-updated', params)
+  combineLatest([
+    SyncStateSubject.pipe(sampleTime(1000)),
+    SyncStateSubject.pipe(sampleTime(60000), startWith({estimate: 0}))
+  ]).subscribe(([oneSecSample, oneMinSample]) => {
+    const estimation = {
+      ...oneSecSample,
+      estimate: oneMinSample.estimate === 0 ? oneSecSample.estimate : oneMinSample.estimate
+    }
+
+    dispatcher.sendMessage('sync-estimate-updated', estimation)
   })
 
   CommandSubject.subscribe(params => {

--- a/packages/neuron-wallet/src/controllers/app/subscribe.ts
+++ b/packages/neuron-wallet/src/controllers/app/subscribe.ts
@@ -5,11 +5,12 @@ import { debounceTime, sampleTime } from 'rxjs/operators'
 import CommandSubject from 'models/subjects/command'
 import DataUpdateSubject from 'models/subjects/data-update'
 import { CurrentNetworkIDSubject, NetworkListSubject } from 'models/subjects/networks'
-import SyncedBlockNumberSubject, { ConnectionStatusSubject } from 'models/subjects/node'
+import { ConnectionStatusSubject } from 'models/subjects/node'
 import { WalletListSubject, CurrentWalletSubject } from 'models/subjects/wallets'
 import dataUpdateSubject from 'models/subjects/data-update'
 import AppUpdaterSubject from 'models/subjects/app-updater'
 import { SETTINGS_WINDOW_TITLE } from 'utils/const'
+import SyncStateSubject from 'models/subjects/sync-state-subject'
 
 interface AppResponder {
   sendMessage: (channel: string, arg: any) => void
@@ -31,8 +32,8 @@ export const subscribe = (dispatcher: AppResponder) => {
     dispatcher.sendMessage('connection-status-updated', params)
   })
 
-  SyncedBlockNumberSubject.getSubject().pipe(sampleTime(1000)).subscribe(params => {
-    dispatcher.sendMessage('synced-block-number-updated', params)
+  SyncStateSubject.pipe(sampleTime(1000)).subscribe(params => {
+    dispatcher.sendMessage('sync-estimate-updated', params)
   })
 
   CommandSubject.subscribe(params => {

--- a/packages/neuron-wallet/src/controllers/sync-api.ts
+++ b/packages/neuron-wallet/src/controllers/sync-api.ts
@@ -117,7 +117,7 @@ export default class SyncApiController {
 
       const indexRate = this.calculateAvgIndexRate(indexerTipNumber, timestamp)
       if (!newSyncEstimate.synced && indexRate) {
-        const estimate = remainingBlocksToIndex / indexRate
+        const estimate = Math.round(remainingBlocksToIndex / indexRate)
         Object.assign(newSyncEstimate, {
           indexRate,
           estimate,

--- a/packages/neuron-wallet/src/controllers/sync-api.ts
+++ b/packages/neuron-wallet/src/controllers/sync-api.ts
@@ -1,19 +1,130 @@
-import SyncedBlockNumber from 'models/synced-block-number'
 import EventEmiter from 'events'
+import SyncedBlockNumber from 'models/synced-block-number'
+import SyncStateSubject from 'models/subjects/sync-state-subject'
+import NodeService from 'services/node'
 
-// Handle channel messages with EventEmiter in the main process
-// @TODO: EventEmiter should replace with MessagePort in the future Worker Thread refactor
+interface SyncState {
+  nodeUrl: string,
+  timestamp: number,
+  indexerTip: number,
+  cacheTip: number,
+  bestKnownBlockNumber: number,
+  indexRate: number | undefined,
+  cacheRate: number | undefined,
+  estimate: number | undefined,
+  synced: boolean,
+}
+
 export default class SyncApiController {
   #syncedBlockNumber = new SyncedBlockNumber()
   static emiter = new EventEmiter()
+
+  private estimates: Array<SyncState> = []
+  private sampleTime: number = 60000
+  private minimumSteps = 50
+  private nodeUrl: string | undefined
 
   public async mount() {
     this.registerHandlers()
   }
 
+  private getEstimatesByCurrentNode () {
+    return this.estimates.filter(
+      state => state.nodeUrl === this.nodeUrl
+    )
+  }
+
+  private calculateAvgIndexRate (currentIndexerTip: number, timestamp: number) {
+    const firstState = this.getEstimatesByCurrentNode()[0]
+    if (!firstState) {
+      return undefined
+    }
+    const advancedIndexerTip = currentIndexerTip - firstState.indexerTip
+    if (advancedIndexerTip < this.minimumSteps) {
+      return undefined
+    }
+    const lastedTime = timestamp - firstState.timestamp
+    const indexRate = advancedIndexerTip / lastedTime
+    return indexRate
+  }
+
+  private updateEstimates (newState: SyncState) {
+    const currentTime = Date.now()
+    this.estimates = this.getEstimatesByCurrentNode().filter(
+      state => currentTime - state.timestamp <= this.sampleTime
+    )
+    this.estimates.push(newState)
+    console.log(this.estimates.length)
+
+    return newState
+  }
+
+  private async estimate (states: any): Promise<SyncState> {
+    const indexerTip = parseInt(states.indexerTip)
+    const cacheTip = parseInt(states.cacheTip)
+    const timestamp = parseInt(states.timestamp)
+
+    const ckb = NodeService.getInstance().ckb
+    //@ts-ignore
+    const syncState = await ckb.rpc.syncState()
+    const bestKnownBlockNumber = parseInt(syncState.bestKnownBlockNumber)
+
+    this.nodeUrl = ckb.node.url
+
+    const estimatesByNode = this.getEstimatesByCurrentNode()
+    const lastSyncState = estimatesByNode[estimatesByNode.length - 1]
+
+    const remainingBlocksToCache = bestKnownBlockNumber - cacheTip
+    const remainingBlocksToIndex = bestKnownBlockNumber - indexerTip
+    const synced = remainingBlocksToCache < 5
+
+    let newState: SyncState
+
+    if (!lastSyncState || synced) {
+      newState = {
+        nodeUrl: this.nodeUrl,
+        timestamp,
+        indexerTip,
+        cacheTip,
+        bestKnownBlockNumber,
+        indexRate: undefined,
+        cacheRate: undefined,
+        estimate: undefined,
+        synced,
+      }
+    }
+    else {
+      let estimate = undefined
+
+      const indexRate = this.calculateAvgIndexRate(indexerTip, timestamp)
+
+      if (indexRate) {
+        estimate = remainingBlocksToIndex / indexRate
+      }
+
+      newState = {
+        nodeUrl: this.nodeUrl,
+        timestamp,
+        indexerTip,
+        cacheTip,
+        bestKnownBlockNumber,
+        indexRate,
+        cacheRate: undefined,
+        estimate,
+        synced,
+      }
+    }
+
+    return this.updateEstimates(newState)
+  }
+
   private registerHandlers() {
     SyncApiController.emiter.on('synced-block-number-updated', async blockNumber => {
       this.#syncedBlockNumber.setNextBlock(BigInt(blockNumber))
+    })
+    SyncApiController.emiter.on('sync-states-updated', async states => {
+      const newState = await this.estimate(states)
+      SyncStateSubject.next(newState)
     })
   }
 }

--- a/packages/neuron-wallet/src/controllers/sync-api.ts
+++ b/packages/neuron-wallet/src/controllers/sync-api.ts
@@ -132,7 +132,6 @@ export default class SyncApiController {
   private registerHandlers() {
     SyncApiController.emiter.on('sync-estimate-updated', async states => {
       const newSyncEstimate = await this.estimate(states)
-      console.log(newSyncEstimate)
       this.#syncedBlockNumber.setNextBlock(BigInt(newSyncEstimate.cacheTipNumber))
       SyncStateSubject.next(newSyncEstimate)
     })

--- a/packages/neuron-wallet/src/models/subjects/node.ts
+++ b/packages/neuron-wallet/src/models/subjects/node.ts
@@ -7,11 +7,3 @@ export const ConnectionStatusSubject = new BehaviorSubject<{
   url: '',
   connected: false
 })
-
-export default class SyncedBlockNumberSubject {
-  private static subject = new BehaviorSubject<string>('0')
-
-  public static getSubject(): BehaviorSubject<string> {
-    return SyncedBlockNumberSubject.subject
-  }
-}

--- a/packages/neuron-wallet/src/models/subjects/sync-state-subject.ts
+++ b/packages/neuron-wallet/src/models/subjects/sync-state-subject.ts
@@ -1,0 +1,21 @@
+import { BehaviorSubject } from 'rxjs'
+
+const SyncStateSubject = new BehaviorSubject<{
+  timestamp: number,
+  indexerTip: number,
+  cacheTip: number,
+  indexRate: number | undefined,
+  cacheRate: number | undefined,
+  estimate: number | undefined,
+  synced: boolean,
+}>({
+  timestamp: 0,
+  indexerTip: 0,
+  cacheTip: 0,
+  indexRate: undefined,
+  cacheRate: undefined,
+  estimate: undefined,
+  synced: false,
+})
+
+export default SyncStateSubject

--- a/packages/neuron-wallet/src/models/subjects/sync-state-subject.ts
+++ b/packages/neuron-wallet/src/models/subjects/sync-state-subject.ts
@@ -2,16 +2,16 @@ import { BehaviorSubject } from 'rxjs'
 
 const SyncStateSubject = new BehaviorSubject<{
   timestamp: number,
-  indexerTip: number,
-  cacheTip: number,
+  indexerTipNumber: number,
+  cacheTipNumber: number,
   indexRate: number | undefined,
   cacheRate: number | undefined,
   estimate: number | undefined,
   synced: boolean,
 }>({
   timestamp: 0,
-  indexerTip: 0,
-  cacheTip: 0,
+  indexerTipNumber: 0,
+  cacheTipNumber: 0,
   indexRate: undefined,
   cacheRate: undefined,
   estimate: undefined,

--- a/packages/neuron-wallet/src/models/synced-block-number.ts
+++ b/packages/neuron-wallet/src/models/synced-block-number.ts
@@ -1,6 +1,5 @@
 import { getConnection } from 'typeorm'
 import SyncInfoEntity from 'database/chain/entities/sync-info'
-import SyncedBlockNumberSubject from 'models/subjects/node'
 import logger from 'utils/logger'
 
 // Keep track of synced block number.
@@ -16,8 +15,6 @@ export default class SyncedBlockNumber {
   }
 
   public async setNextBlock(current: bigint): Promise<void> {
-    SyncedBlockNumberSubject.getSubject().next(current.toString())
-
     const blockDiffAbs = Math.abs(Number(current) - Number(SyncedBlockNumber.lastSavedBlock))
     if (current === BigInt(0) || blockDiffAbs >= 10) {
       SyncedBlockNumber.lastSavedBlock = current

--- a/packages/neuron-wallet/tests/block-sync-render/index.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/index.test.ts
@@ -386,20 +386,12 @@ describe('block sync render', () => {
             expect(stubbedAddressDbChangedSubjectNext).toHaveBeenCalledWith(result)
           })
         });
-        describe('handles synced-block-number-updated event from child process', () => {
+        describe('handles sync-estimate-updated event from child process', () => {
           beforeEach(() => {
-            fakeSendMessageToMainProcess('synced-block-number-updated', result)
+            fakeSendMessageToMainProcess('sync-estimate-updated', result)
           });
           it('SyncApiController emiter message in the main process', ()=> {
-            expect(stubbedSyncApiControllerEmitter).toHaveBeenCalledWith('synced-block-number-updated', result)
-          })
-        });
-        describe('handles sync-states-updated event from child process', () => {
-          beforeEach(() => {
-            fakeSendMessageToMainProcess('sync-states-updated', result)
-          });
-          it('SyncApiController emiter message in the main process', ()=> {
-            expect(stubbedSyncApiControllerEmitter).toHaveBeenCalledWith('sync-states-updated', result)
+            expect(stubbedSyncApiControllerEmitter).toHaveBeenCalledWith('sync-estimate-updated', result)
           })
         });
         describe('handles wallet-deleted event from child process', () => {

--- a/packages/neuron-wallet/tests/block-sync-render/indexer-connector.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/indexer-connector.test.ts
@@ -212,6 +212,8 @@ describe('unit tests for IndexerConnector', () => {
       describe('#transactionsSubject', () => {
         let transactionsSubject: any
         beforeEach(() => {
+          stubbedTipFn.mockReturnValueOnce(fakeTip1)
+
           indexerConnector = new stubbedIndexerConnector(addressesToWatch, '', '')
           transactionsSubject = indexerConnector.transactionsSubject
         });
@@ -219,6 +221,7 @@ describe('unit tests for IndexerConnector', () => {
         describe('when there are transactions', () => {
           let txObserver: any
           beforeEach(() => {
+
             stubbedUpsertTxHashesFn.mockResolvedValueOnce([fakeTx1.transaction.hash, fakeTx2.transaction.hash])
             stubbedUpsertTxHashesFn.mockResolvedValueOnce([fakeTx3.transaction.hash])
 
@@ -380,11 +383,11 @@ describe('unit tests for IndexerConnector', () => {
           });
         });
       });
-      describe('#blockTipSubject', () => {
+      describe('#blockTipsSubject', () => {
         let tipObserver: any
         beforeEach(async () => {
           tipObserver = jest.fn()
-          indexerConnector.blockTipSubject.subscribe(tip => {
+          indexerConnector.blockTipsSubject.subscribe(tip => {
             tipObserver(tip)
           })
           stubbedTipFn.mockReturnValueOnce(fakeTip1)
@@ -398,7 +401,10 @@ describe('unit tests for IndexerConnector', () => {
         });
         it('observes an indexer tip', () => {
           expect(tipObserver).toHaveBeenCalledTimes(1)
-          expect(tipObserver).toHaveBeenCalledWith(fakeTip1)
+          expect(tipObserver).toHaveBeenCalledWith({
+            cacheTipNumber: parseInt(fakeTip1.block_number),
+            indexerTipNumber: parseInt(fakeTip1.block_number),
+          })
         });
         describe('fast forward the interval time', () => {
           describe('when there is no unprocessed blocks', () => {
@@ -409,7 +415,10 @@ describe('unit tests for IndexerConnector', () => {
             });
             it('observes another indexer tip', async () => {
               expect(tipObserver).toHaveBeenCalledTimes(2)
-              expect(tipObserver).toHaveBeenCalledWith(fakeTip2)
+              expect(tipObserver).toHaveBeenCalledWith({
+                cacheTipNumber: parseInt(fakeTip2.block_number),
+                indexerTipNumber: parseInt(fakeTip2.block_number),
+              })
             })
           });
           describe('when there are unprocessed blocks', () => {
@@ -424,9 +433,8 @@ describe('unit tests for IndexerConnector', () => {
             it('observes next unprocessed block tip', async () => {
               expect(tipObserver).toHaveBeenCalledTimes(2)
               expect(tipObserver).toHaveBeenCalledWith({
-                block_number: fakeBlock3.number,
-                block_hash: fakeBlock3.hash,
-                indexer_tip_number: fakeTip2.block_number,
+                cacheTipNumber: parseInt(fakeBlock3.number),
+                indexerTipNumber: parseInt(fakeTip2.block_number),
               })
             })
           });

--- a/packages/neuron-wallet/tests/block-sync-render/indexer-connector.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/indexer-connector.test.ts
@@ -130,8 +130,8 @@ describe('unit tests for IndexerConnector', () => {
     });
   });
   describe('#connect', () => {
-    const fakeTip1 = {block_number: '1', block_hash: 'hash1'}
-    const fakeTip2 = {block_number: '2', block_hash: 'hash2'}
+    const fakeTip1 = {block_number: '1', block_hash: 'hash1', indexer_tip_number: '1'}
+    const fakeTip2 = {block_number: '2', block_hash: 'hash2', indexer_tip_number: '2'}
     const fakeBlock1 = {number: '1', hash: '1', timestamp: '1'}
     const fakeBlock2 = {number: '2', hash: '2', timestamp: '2'}
     const fakeBlock3 = {number: '3', hash: '3', timestamp: '3'}
@@ -426,6 +426,7 @@ describe('unit tests for IndexerConnector', () => {
               expect(tipObserver).toHaveBeenCalledWith({
                 block_number: fakeBlock3.number,
                 block_hash: fakeBlock3.hash,
+                indexer_tip_number: fakeTip2.block_number,
               })
             })
           });

--- a/packages/neuron-wallet/tests/block-sync-render/queue.intg.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/queue.intg.test.ts
@@ -228,6 +228,8 @@ describe('integration tests for sync pipeline', () => {
           toArray: () => []
         })
 
+      stubbedTipFn.mockResolvedValue({block_number: '1'})
+
       queue.start()
       await flushPromises()
       await queue.waitForDrained()

--- a/packages/neuron-wallet/tests/block-sync-render/queue.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/queue.test.ts
@@ -109,21 +109,21 @@ describe('queue', () => {
   }
   const addresses = [addressInfo]
 
-  let stubbedBlockTipSubject: any
+  let stubbedBlockTipsSubject: any
   let stubbedTransactionsSubject: any
 
   beforeEach(async () => {
     resetMocks()
     jest.useFakeTimers()
 
-    stubbedBlockTipSubject = new Subject<Tip>()
+    stubbedBlockTipsSubject = new Subject<Tip>()
     stubbedTransactionsSubject = new Subject<Array<TransactionWithStatus>>()
     const stubbedIndexerConnector = jest.fn().mockImplementation(
       (...args) => {
         stubbedIndexerConnectorConstructor(...args)
         return {
           connect: stubbedConnectFn,
-          blockTipSubject: stubbedBlockTipSubject,
+          blockTipsSubject: stubbedBlockTipsSubject,
           transactionsSubject: stubbedTransactionsSubject,
           notifyCurrentBlockNumberProcessed: stubbedNotifyCurrentBlockNumberProcessedFn,
         }
@@ -184,12 +184,15 @@ describe('queue', () => {
     it('connects indexer', () => {
       expect(stubbedConnectFn).toHaveBeenCalled()
     });
-    describe('subscribes to IndexerConnector#blockTipSubject', () => {
+    describe('subscribes to IndexerConnector#blockTipsSubject', () => {
       describe('when new block tip emits from IndexerConnector', () => {
         it('notify latest block numbers', () => {
           const mock = jest.spyOn(process, 'send')
-          stubbedBlockTipSubject.next({ block_number: '3', block_hash: '0x' })
-          expect(mock).toHaveBeenCalledWith({ channel: 'synced-block-number-updated', result: '3' })
+          stubbedBlockTipsSubject.next({ cacheTipNumber: 3, indexerTipNumber: 3 })
+          expect(mock).toHaveBeenCalledWith({
+            channel: 'sync-estimate-updated',
+            result: {cacheTipNumber: 3, indexerTipNumber: 3, timestamp: expect.anything()}
+          })
           mock.mockRestore()
         })
       });

--- a/packages/neuron-wallet/tests/controllers/sync-api.test.ts
+++ b/packages/neuron-wallet/tests/controllers/sync-api.test.ts
@@ -149,7 +149,7 @@ describe('sync api', () => {
         describe('when advanced indexer tip is greater or equals to 50', () => {
           const fakeState1 = {
             cacheTipNumber,
-            indexerTipNumber: (bestKnownBlockNumber - 51).toString(),
+            indexerTipNumber: (bestKnownBlockNumber - 52).toString(),
             timestamp: '6000',
           }
           const fakeState2 = {
@@ -163,7 +163,7 @@ describe('sync api', () => {
             await flushPromises()
           });
           it('calculates estimation', () => {
-            const indexRate = 50 / (parseInt(fakeState2.timestamp) - parseInt(fakeState1.timestamp))
+            const indexRate = 51 / (parseInt(fakeState2.timestamp) - parseInt(fakeState1.timestamp))
             expect(stubbedSyncStateSubjectNext).toHaveBeenCalledWith({
               nodeUrl: fakeNodeUrl,
               timestamp: parseInt(fakeState2.timestamp),
@@ -172,7 +172,7 @@ describe('sync api', () => {
               indexerTipNumber: parseInt(fakeState2.indexerTipNumber),
               indexRate,
               cacheRate: undefined,
-              estimate: (bestKnownBlockNumber - parseInt(fakeState2.indexerTipNumber)) / indexRate,
+              estimate: Math.round((bestKnownBlockNumber - parseInt(fakeState2.indexerTipNumber)) / indexRate),
               synced: false,
             })
           })
@@ -226,7 +226,7 @@ describe('sync api', () => {
           }
           const fakeState3 = {
             cacheTipNumber,
-            indexerTipNumber: '6200',
+            indexerTipNumber: '6201',
             timestamp: '66000',
           }
           beforeEach(async () => {
@@ -247,7 +247,7 @@ describe('sync api', () => {
               cacheRate: undefined,
               cacheTipNumber: parseInt(fakeState3.cacheTipNumber),
               indexerTipNumber: parseInt(fakeState3.indexerTipNumber),
-              estimate: (bestKnownBlockNumber - parseInt(fakeState3.indexerTipNumber)) / indexRate,
+              estimate: Math.round((bestKnownBlockNumber - parseInt(fakeState3.indexerTipNumber)) / indexRate),
               synced: false,
             })
           })

--- a/packages/neuron-wallet/tests/controllers/sync-api.test.ts
+++ b/packages/neuron-wallet/tests/controllers/sync-api.test.ts
@@ -1,0 +1,283 @@
+import Emitter from 'events'
+import { flushPromises } from '../test-utils'
+
+const stubbedEmitter = jest.fn()
+const stubbedSyncedBlockNumber = jest.fn()
+const stubbedSyncStateSubjectNext = jest.fn()
+const stubbedSyncState = jest.fn()
+const stubbedNodeGetInstance = jest.fn()
+
+const resetMocks = () => {
+  stubbedEmitter.mockReset()
+  stubbedSyncedBlockNumber.mockReset()
+  stubbedSyncStateSubjectNext.mockReset()
+  stubbedSyncState.mockReset()
+  stubbedNodeGetInstance.mockReset()
+}
+
+describe('sync api', () => {
+  const emitter = new Emitter()
+  const fakeNodeUrl = 'http://fakenodeurl'
+  let controller: any
+
+  beforeEach(() => {
+    resetMocks()
+    jest.useFakeTimers()
+
+    jest.doMock('events', () => {
+      return stubbedEmitter
+    })
+    jest.doMock('models/synced-block-number', () => {
+      return stubbedSyncedBlockNumber
+    })
+    jest.doMock('models/subjects/sync-state-subject', () => {
+      return {next: stubbedSyncStateSubjectNext}
+    })
+    jest.doMock('services/node', () => {
+      return {
+        getInstance: stubbedNodeGetInstance
+      }
+    })
+
+    stubbedEmitter.mockImplementation(() => {
+      return emitter
+    })
+
+    emitter.removeAllListeners()
+    const SyncAPIController = require('../../src/controllers/sync-api').default
+    controller = new SyncAPIController()
+    controller.mount()
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers()
+  });
+
+  describe('on sync-states-updated', () => {
+    const bestKnownBlockNumber = 10000
+    beforeEach(() => {
+      jest
+        .spyOn(Date, 'now')
+        .mockImplementation(() => 66000);
+      stubbedSyncState.mockResolvedValue({bestKnownBlockNumber})
+      stubbedNodeGetInstance.mockImplementation(() => ({
+        ckb: {
+          rpc: {
+            syncState: stubbedSyncState
+          },
+          node: {
+            url: fakeNodeUrl
+          }
+        }
+      }))
+    });
+    describe('estimate based on rate of indexing', () => {
+      describe('when completed cache', () => {
+        const cacheTip = (bestKnownBlockNumber - 4).toString()
+        const fakeState1 = {
+          cacheTip,
+          indexerTip: (bestKnownBlockNumber - 50).toString(),
+          timestamp: '6000',
+        }
+        beforeEach(async () => {
+          emitter.emit('sync-states-updated', fakeState1)
+          await flushPromises()
+        });
+        it('indicates synced', () => {
+          expect(stubbedSyncStateSubjectNext).toHaveBeenCalledWith({
+            nodeUrl: fakeNodeUrl,
+            timestamp: parseInt(fakeState1.timestamp),
+            bestKnownBlockNumber,
+            cacheTip: parseInt(fakeState1.cacheTip),
+            indexerTip: parseInt(fakeState1.indexerTip),
+            indexRate: undefined,
+            cacheRate: undefined,
+            estimate: undefined,
+            synced: true,
+          })
+        })
+        describe('when advanced indexer tip is greater or equals to 50', () => {
+          const fakeState2 = {
+            cacheTip,
+            indexerTip: bestKnownBlockNumber.toString(),
+            timestamp: '7000',
+          }
+          beforeEach(async () => {
+            emitter.emit('sync-states-updated', fakeState2)
+            await flushPromises()
+          });
+          it('indicates synced', () => {
+            expect(stubbedSyncStateSubjectNext).toHaveBeenCalledWith({
+              nodeUrl: fakeNodeUrl,
+              timestamp: parseInt(fakeState2.timestamp),
+              bestKnownBlockNumber,
+              cacheTip: parseInt(fakeState2.cacheTip),
+              indexerTip: parseInt(fakeState2.indexerTip),
+              indexRate: undefined,
+              cacheRate: undefined,
+              estimate: undefined,
+              synced: true,
+            })
+          })
+        });
+      });
+      describe('when cache is still ongoing', () => {
+        const cacheTip = (bestKnownBlockNumber - 5).toString()
+        describe('with only one sample', () => {
+          const fakeState1 = {
+            cacheTip,
+            indexerTip: bestKnownBlockNumber.toString(),
+            timestamp: '6000',
+          }
+          beforeEach(async () => {
+            stubbedSyncStateSubjectNext.mockReset()
+            emitter.emit('sync-states-updated', fakeState1)
+            await flushPromises()
+          });
+          it('indicates either estimating or synced', () => {
+            expect(stubbedSyncStateSubjectNext).toHaveBeenCalledWith({
+              nodeUrl: fakeNodeUrl,
+              timestamp: parseInt(fakeState1.timestamp),
+              bestKnownBlockNumber,
+              cacheTip: parseInt(fakeState1.cacheTip),
+              indexerTip: parseInt(fakeState1.indexerTip),
+              indexRate: undefined,
+              cacheRate: undefined,
+              estimate: undefined,
+              synced: false,
+            })
+          })
+        });
+        describe('when advanced indexer tip is greater or equals to 50', () => {
+          const fakeState1 = {
+            cacheTip,
+            indexerTip: (bestKnownBlockNumber - 51).toString(),
+            timestamp: '6000',
+          }
+          const fakeState2 = {
+            cacheTip,
+            indexerTip: (bestKnownBlockNumber - 1).toString(),
+            timestamp: '7000',
+          }
+          beforeEach(async () => {
+            emitter.emit('sync-states-updated', fakeState1)
+            emitter.emit('sync-states-updated', fakeState2)
+            await flushPromises()
+          });
+          it('indicates synced', () => {
+            const indexRate = 50 / (parseInt(fakeState2.timestamp) - parseInt(fakeState1.timestamp))
+            expect(stubbedSyncStateSubjectNext).toHaveBeenCalledWith({
+              nodeUrl: fakeNodeUrl,
+              timestamp: parseInt(fakeState2.timestamp),
+              bestKnownBlockNumber,
+              cacheTip: parseInt(fakeState2.cacheTip),
+              indexerTip: parseInt(fakeState2.indexerTip),
+              indexRate,
+              cacheRate: undefined,
+              estimate: (bestKnownBlockNumber - parseInt(fakeState2.indexerTip)) / indexRate,
+              synced: false,
+            })
+          })
+        });
+        describe('when advanced indexer tip is less than 50', () => {
+          const fakeState1 = {
+            cacheTip,
+            indexerTip: (bestKnownBlockNumber - 50).toString(),
+            timestamp: '6000',
+          }
+          const fakeState2 = {
+            cacheTip,
+            indexerTip: (bestKnownBlockNumber - 1).toString(),
+            timestamp: '7000',
+          }
+          beforeEach(async () => {
+            emitter.emit('sync-states-updated', fakeState1)
+            emitter.emit('sync-states-updated', fakeState2)
+            await flushPromises()
+          });
+          it('indicates synced', () => {
+            expect(stubbedSyncStateSubjectNext).toHaveBeenCalledWith({
+              nodeUrl: fakeNodeUrl,
+              timestamp: parseInt(fakeState2.timestamp),
+              bestKnownBlockNumber,
+              cacheTip: parseInt(fakeState2.cacheTip),
+              indexerTip: parseInt(fakeState2.indexerTip),
+              indexRate: undefined,
+              cacheRate: undefined,
+              estimate: undefined,
+              synced: false,
+            })
+          })
+        });
+        describe('with samples spaning over 1 min', () => {
+          const fakeState1 = {
+            cacheTip,
+            indexerTip: '100',
+            timestamp: '1000',
+          }
+          const fakeState2 = {
+            cacheTip,
+            indexerTip: '200',
+            timestamp: '6000',
+          }
+          const fakeState3 = {
+            cacheTip,
+            indexerTip: '6200',
+            timestamp: '66000',
+          }
+          beforeEach(async () => {
+            emitter.emit('sync-states-updated', fakeState1)
+            emitter.emit('sync-states-updated', fakeState2)
+            emitter.emit('sync-states-updated', fakeState3)
+            await flushPromises()
+          });
+          it('estimates with samples in the last minute', () => {
+            const indexRate = (
+              parseInt(fakeState3.indexerTip) - parseInt(fakeState2.indexerTip)
+            ) / (parseInt(fakeState3.timestamp) - parseInt(fakeState2.timestamp))
+            expect(stubbedSyncStateSubjectNext).toHaveBeenCalledWith({
+              nodeUrl: fakeNodeUrl,
+              timestamp: parseInt(fakeState3.timestamp),
+              bestKnownBlockNumber,
+              indexRate,
+              cacheRate: undefined,
+              cacheTip: parseInt(fakeState3.cacheTip),
+              indexerTip: parseInt(fakeState3.indexerTip),
+              estimate: (bestKnownBlockNumber - parseInt(fakeState3.indexerTip)) / indexRate,
+              synced: false,
+            })
+          })
+          describe('when switching network', () => {
+            beforeEach(async () => {
+              stubbedNodeGetInstance.mockImplementation(() => ({
+                ckb: {
+                  rpc: {
+                    syncState: stubbedSyncState
+                  },
+                  node: {
+                    url: 'http://diffurl'
+                  }
+                }
+              }))
+              emitter.emit('sync-states-updated', fakeState3)
+              await flushPromises()
+            });
+            it('resets samples', () => {
+              expect(stubbedSyncStateSubjectNext).toHaveBeenCalledWith({
+                nodeUrl: 'http://diffurl',
+                timestamp: parseInt(fakeState3.timestamp),
+                bestKnownBlockNumber,
+                indexRate: undefined,
+                cacheRate: undefined,
+                cacheTip: parseInt(fakeState3.cacheTip),
+                indexerTip: parseInt(fakeState3.indexerTip),
+                estimate: undefined,
+                synced: false,
+              })
+            })
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/neuron-wallet/tests/controllers/sync-api.test.ts
+++ b/packages/neuron-wallet/tests/controllers/sync-api.test.ts
@@ -144,11 +144,10 @@ describe('sync api', () => {
             timestamp: '6000',
           }
           beforeEach(async () => {
-            stubbedSyncStateSubjectNext.mockReset()
             emitter.emit('sync-estimate-updated', fakeState1)
             await flushPromises()
           });
-          it('indicates either estimating or synced', () => {
+          it('should not calculate estimation', () => {
             expect(stubbedSyncStateSubjectNext).toHaveBeenCalledWith({
               nodeUrl: fakeNodeUrl,
               timestamp: parseInt(fakeState1.timestamp),
@@ -160,6 +159,9 @@ describe('sync api', () => {
               estimate: undefined,
               synced: false,
             })
+          })
+          it('stores next block number', () => {
+            expect(stubbedSetNextBlock).toHaveBeenCalledWith(BigInt(cacheTipNumber))
           })
         });
         describe('when advanced indexer tip is greater or equals to 50', () => {
@@ -178,7 +180,7 @@ describe('sync api', () => {
             emitter.emit('sync-estimate-updated', fakeState2)
             await flushPromises()
           });
-          it('indicates synced', () => {
+          it('calculates estimation', () => {
             const indexRate = 50 / (parseInt(fakeState2.timestamp) - parseInt(fakeState1.timestamp))
             expect(stubbedSyncStateSubjectNext).toHaveBeenCalledWith({
               nodeUrl: fakeNodeUrl,
@@ -191,6 +193,9 @@ describe('sync api', () => {
               estimate: (bestKnownBlockNumber - parseInt(fakeState2.indexerTipNumber)) / indexRate,
               synced: false,
             })
+          })
+          it('stores next block number', () => {
+            expect(stubbedSetNextBlock).toHaveBeenCalledWith(BigInt(cacheTipNumber))
           })
         });
         describe('when advanced indexer tip is less than 50', () => {
@@ -209,7 +214,7 @@ describe('sync api', () => {
             emitter.emit('sync-estimate-updated', fakeState2)
             await flushPromises()
           });
-          it('indicates synced', () => {
+          it('should not calculate estimation', () => {
             expect(stubbedSyncStateSubjectNext).toHaveBeenCalledWith({
               nodeUrl: fakeNodeUrl,
               timestamp: parseInt(fakeState2.timestamp),
@@ -221,6 +226,9 @@ describe('sync api', () => {
               estimate: undefined,
               synced: false,
             })
+          })
+          it('stores next block number', () => {
+            expect(stubbedSetNextBlock).toHaveBeenCalledWith(BigInt(cacheTipNumber))
           })
         });
         describe('with samples spaning over 1 min', () => {
@@ -260,6 +268,9 @@ describe('sync api', () => {
               estimate: (bestKnownBlockNumber - parseInt(fakeState3.indexerTipNumber)) / indexRate,
               synced: false,
             })
+          })
+          it('stores next block number', () => {
+            expect(stubbedSetNextBlock).toHaveBeenCalledWith(BigInt(cacheTipNumber))
           })
           describe('when switching network', () => {
             beforeEach(async () => {

--- a/packages/neuron-wallet/tests/controllers/sync-api.test.ts
+++ b/packages/neuron-wallet/tests/controllers/sync-api.test.ts
@@ -4,14 +4,14 @@ import { flushPromises } from '../test-utils'
 const stubbedEmitter = jest.fn()
 const stubbedSyncedBlockNumber = jest.fn()
 const stubbedSyncStateSubjectNext = jest.fn()
-const stubbedSyncState = jest.fn()
+const stubbedSDKMethod = jest.fn()
 const stubbedNodeGetInstance = jest.fn()
 
 const resetMocks = () => {
   stubbedEmitter.mockReset()
   stubbedSyncedBlockNumber.mockReset()
   stubbedSyncStateSubjectNext.mockReset()
-  stubbedSyncState.mockReset()
+  stubbedSDKMethod.mockReset()
   stubbedNodeGetInstance.mockReset()
 }
 
@@ -38,6 +38,13 @@ describe('sync api', () => {
         getInstance: stubbedNodeGetInstance
       }
     })
+    jest.doMock('@nervosnetwork/ckb-sdk-rpc/lib/method', () => {
+      return jest.fn().mockImplementation(() => {
+        return {
+          call: stubbedSDKMethod
+        }
+      })
+    })
 
     stubbedEmitter.mockImplementation(() => {
       return emitter
@@ -59,12 +66,12 @@ describe('sync api', () => {
       jest
         .spyOn(Date, 'now')
         .mockImplementation(() => 66000);
-      stubbedSyncState.mockResolvedValue({bestKnownBlockNumber})
+      stubbedSDKMethod.mockResolvedValue({best_known_block_number: bestKnownBlockNumber.toString(16)})
       stubbedNodeGetInstance.mockImplementation(() => ({
         ckb: {
-          rpc: {
-            syncState: stubbedSyncState
-          },
+          // rpc: {
+          //   syncState: stubbedSyncState
+          // },
           node: {
             url: fakeNodeUrl
           }
@@ -251,9 +258,6 @@ describe('sync api', () => {
             beforeEach(async () => {
               stubbedNodeGetInstance.mockImplementation(() => ({
                 ckb: {
-                  rpc: {
-                    syncState: stubbedSyncState
-                  },
                   node: {
                     url: 'http://diffurl'
                   }

--- a/packages/neuron-wallet/tests/models/synced-block-number.intg.test.ts
+++ b/packages/neuron-wallet/tests/models/synced-block-number.intg.test.ts
@@ -46,9 +46,6 @@ describe('SyncedBlockNumber model', () => {
       syncedBlockNumber = new SyncedBlockNumber()
       await syncedBlockNumber.setNextBlock(BigInt(0))
     })
-    it('emits next block number', () => {
-      expect(stubbedSyncedBlockNumberSubjectNext).toHaveBeenCalledWith('0')
-    });
     it('updates logs', () => {
       expect(stubbedLoggerInfo).toHaveBeenCalled()
     })
@@ -69,9 +66,6 @@ describe('SyncedBlockNumber model', () => {
         beforeEach(async () => {
           await syncedBlockNumber.setNextBlock(BigInt(9))
         });
-        it('emits next block number', () => {
-          expect(stubbedSyncedBlockNumberSubjectNext).toHaveBeenCalledWith('9')
-        });
         it('should not update logs', () => {
           expect(stubbedLoggerInfo).not.toHaveBeenCalled()
         })
@@ -88,9 +82,6 @@ describe('SyncedBlockNumber model', () => {
       describe('when setting to a block number having absolute difference with the previous one by greater or equals to 10', () => {
         beforeEach(async () => {
           await syncedBlockNumber.setNextBlock(BigInt(10))
-        });
-        it('emits next block number', () => {
-          expect(stubbedSyncedBlockNumberSubjectNext).toHaveBeenCalledWith('10')
         });
         it('updates logs', () => {
           expect(stubbedLoggerInfo).toHaveBeenCalled()


### PR DESCRIPTION
- Deprecated the `synced-block-number-updated` by `sync-estimate-updated`. 
- Updated the front end code to account for this change, so the sync status still works in this PR.
- `sync-estimate-updated` event has the following schema.
- For now, it uses a custom call to fetch sync state from node instead of using the built-in API of SDK +0.35. We will need to go through a refactor to get the code base adapted to typescript 4, which is required by SDK version greater than 0.35

```javascript
{
  nodeUrl: 'http://localhost:8224', // current node url
  timestamp: 1601044101705, // the time when delivered this estimation event
  indexerTipNumber: 369397, // current block tip on indexer
  cacheTipNumber: 367434, // current cached block tip 
  bestKnownBlockNumber: 493640, // best known block number from the network
  indexRate: 0.5230482154434903, // indexing rate [blocks/ms]
  cacheRate: undefined, // caching rate -- just a place holder for now
  estimate: 237536.4188837828, // estimated time (ms) for completing the indexing. If the value is undefined, it means estimation is in progress.
  synced: false // indicates if it is fully cached
}
```