### PR TITLE
feat: insert ellipsis if asset account address is too long

### DIFF
--- a/packages/neuron-ui/src/components/SUDTReceive/index.tsx
+++ b/packages/neuron-ui/src/components/SUDTReceive/index.tsx
@@ -44,7 +44,7 @@ const SUDTReceive = () => {
       <QRCode value={address} size={220} includeMargin dispatch={dispatch} />
       <div className={styles.address}>
         <CopyZone content={address} name={t('receive.copy-address')} style={{ lineHeight: '1.625rem' }}>
-          <span className={styles.addressValue}>{address}</span>
+          {address.length > 50 ? `${address.substr(0, 45)}...${address.slice(-4)}` : address}
         </CopyZone>
       </div>
       <p className={styles.notation}>

--- a/packages/neuron-ui/src/components/SUDTReceive/sUDTReceive.module.scss
+++ b/packages/neuron-ui/src/components/SUDTReceive/sUDTReceive.module.scss
@@ -34,17 +34,6 @@
 .address {
   margin: 14px auto 0;
   text-align: center;
-
-  .addressValue {
-    text-align: center;
-    display: block;
-    max-width: 60vw;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    word-break: break-all;
-    margin: 0 auto;
-  }
 }
 
 .notation {


### PR DESCRIPTION
Address: `ckt1q9gry5zg8stq8ruq5wfz3lm5wn2k7qw3ulsfmdhe98f2j1`

![image](https://user-images.githubusercontent.com/7271329/94367854-a9d13a80-0113-11eb-9fd7-767022f4e70a.png)

Address: `ckt1q9gry5zg8stq8ruq5wfz3lm5wn2k7qw3ulsfmdhe98f2j11`
![image](https://user-images.githubusercontent.com/7271329/94367845-a5a51d00-0113-11eb-866c-9055e381010f.png)
