### PR TITLE
Remove address column from key info table

### DIFF
--- a/packages/neuron-wallet/src/database/chain/entities/hd-public-key-info.ts
+++ b/packages/neuron-wallet/src/database/chain/entities/hd-public-key-info.ts
@@ -14,12 +14,6 @@ export default class HdPublicKeyInfo {
   @Index()
   walletId!: string
 
-  @Column({
-    type: 'varchar',
-  })
-  @Index()
-  address!: string
-
   @Column()
   addressType!: AddressType
 
@@ -48,7 +42,6 @@ export default class HdPublicKeyInfo {
     const publicKeyInfo = new HdPublicKeyInfo()
 
     publicKeyInfo.walletId = model.walletId
-    publicKeyInfo.address = model.address
     publicKeyInfo.addressType = model.addressType
     publicKeyInfo.addressIndex = model.addressIndex
     publicKeyInfo.publicKeyInBlake160 = model.publicKeyInBlake160

--- a/packages/neuron-wallet/src/database/chain/migrations/1601447406035-RemoveKeyInfoAddress.ts
+++ b/packages/neuron-wallet/src/database/chain/migrations/1601447406035-RemoveKeyInfoAddress.ts
@@ -1,0 +1,12 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class RemoveKeyInfoAddress1601447406035 implements MigrationInterface {
+  name = 'RemoveKeyInfoAddress1601447406035'
+
+  public async up(queryRunner: QueryRunner): Promise<any> {
+      await queryRunner.dropColumn(`hd_public_key_info`, 'address');
+  }
+
+  public async down(): Promise<any> {}
+
+}

--- a/packages/neuron-wallet/src/database/chain/ormconfig.ts
+++ b/packages/neuron-wallet/src/database/chain/ormconfig.ts
@@ -37,6 +37,7 @@ import { RemoveLiveCell1592781363749 } from './migrations/1592781363749-RemoveLi
 import { AddIndexerTxHashCache1592727615004 } from './migrations/1592727615004-AddIndexerTxHashCache'
 import { HDPublicKeyInfo1598087517643 } from './migrations/1598087517643-HDPublicKeyInfo'
 import { TxDescription1599441769473 } from './migrations/1599441769473-TxDescription'
+import { RemoveKeyInfoAddress1601447406035 } from './migrations/1601447406035-RemoveKeyInfoAddress'
 
 export const CONNECTION_NOT_FOUND_NAME = 'ConnectionNotFoundError'
 
@@ -90,6 +91,7 @@ const connectOptions = async (genesisBlockHash: string): Promise<SqliteConnectio
       AddIndexerTxHashCache1592727615004,
       HDPublicKeyInfo1598087517643,
       TxDescription1599441769473,
+      RemoveKeyInfoAddress1601447406035,
     ],
     logger: 'simple-console',
     logging,

--- a/packages/neuron-wallet/src/models/keys/hd-public-key-info.ts
+++ b/packages/neuron-wallet/src/models/keys/hd-public-key-info.ts
@@ -1,12 +1,22 @@
-import Address, { AddressType } from "./address"
+import AddressGenerator from "models/address-generator"
+import SystemScriptInfo from "models/system-script-info"
+import NetworksService from "services/networks"
+import Address, { AddressPrefix, AddressType } from "./address"
 
 export default class HdPublicKeyInfoModel {
   public walletId: string
-  public address: string
   public addressType: AddressType
   public addressIndex: number
   public publicKeyInBlake160: string
   public description?: string
+
+  public get address() {
+    const prefix = NetworksService.getInstance().isMainnet() ? AddressPrefix.Mainnet : AddressPrefix.Testnet
+    return AddressGenerator.toShort(
+      SystemScriptInfo.generateSecpScript(this.publicKeyInBlake160),
+      prefix
+    )
+  }
 
   public get path(): string {
     return Address.pathFor(this.addressType, this.addressIndex)
@@ -14,14 +24,12 @@ export default class HdPublicKeyInfoModel {
 
   constructor(
     walletId: string,
-    address: string,
     addressType: AddressType,
     addressIndex: number,
     publicKeyInBlake160: string,
     description?: string,
   ) {
     this.walletId = walletId
-    this.address = address
     this.addressType = addressType
     this.addressIndex = addressIndex
     this.publicKeyInBlake160 = publicKeyInBlake160
@@ -30,7 +38,6 @@ export default class HdPublicKeyInfoModel {
 
   public static fromObject(params: {
     walletId: string,
-    address: string,
     addressType: AddressType,
     addressIndex: number,
     publicKeyInBlake160: string,
@@ -38,7 +45,6 @@ export default class HdPublicKeyInfoModel {
   }): HdPublicKeyInfoModel {
     return new HdPublicKeyInfoModel (
       params.walletId,
-      params.address,
       params.addressType,
       params.addressIndex,
       params.publicKeyInBlake160,

--- a/packages/neuron-wallet/tests/models/keys/hd-public-key-info.test.ts
+++ b/packages/neuron-wallet/tests/models/keys/hd-public-key-info.test.ts
@@ -1,0 +1,81 @@
+import { AddressPrefix } from '@nervosnetwork/ckb-sdk-utils'
+import AddressGenerator from '../../../src/models/address-generator'
+import { AddressType } from '../../../src/models/keys/address'
+import KeyInfos from '../../setupAndTeardown/public-key-info.fixture'
+
+const stubbedIsMainnet = jest.fn()
+
+jest.doMock('services/networks', () => {
+  return {
+    getInstance: () => ({
+      isMainnet: stubbedIsMainnet
+    }),
+  }
+})
+
+const HdPublicKeyInfoModel = require('../../../src/models/keys/hd-public-key-info').default
+
+const resetMocks = () => {
+  stubbedIsMainnet.mockReset()
+}
+
+describe('HdPublicKeyInfoModel', () => {
+  const [keyInfo] = KeyInfos
+  let keyInfoModel: any
+
+  beforeEach(() => {
+    resetMocks()
+  });
+
+  describe('#address', () => {
+    describe('with mainnet', () => {
+      beforeEach(() => {
+        stubbedIsMainnet.mockReturnValue(true)
+        keyInfoModel = HdPublicKeyInfoModel.fromObject({
+          publicKeyInBlake160: keyInfo.publicKeyInBlake160,
+        })
+      });
+      it('generates mainnet address by property', () => {
+        const address = AddressGenerator.toShortByBlake160(keyInfo.publicKeyInBlake160, AddressPrefix.Mainnet)
+        expect(keyInfoModel.address).toEqual(address)
+      })
+    });
+    describe('with testnet', () => {
+      beforeEach(() => {
+        stubbedIsMainnet.mockReturnValue(false)
+        keyInfoModel = HdPublicKeyInfoModel.fromObject({
+          publicKeyInBlake160: keyInfo.publicKeyInBlake160,
+        })
+      });
+      it('generates testnet address by property', () => {
+        const address = AddressGenerator.toShortByBlake160(keyInfo.publicKeyInBlake160, AddressPrefix.Testnet)
+        expect(keyInfoModel.address).toEqual(address)
+      })
+    });
+  });
+
+  describe('#path', () => {
+    describe('with change address type', () => {
+      beforeEach(() => {
+        keyInfoModel = HdPublicKeyInfoModel.fromObject({
+          addressType: AddressType.Change,
+          addressIndex: 1
+        })
+      });
+      it('generates path by property', () => {
+        expect(keyInfoModel.path).toEqual("m/44'/309'/0'/1/1")
+      })
+    });
+    describe('with receive address type', () => {
+      beforeEach(() => {
+        keyInfoModel = HdPublicKeyInfoModel.fromObject({
+          addressType: AddressType.Receiving,
+          addressIndex: 1
+        })
+      });
+      it('generates path by property', () => {
+        expect(keyInfoModel.path).toEqual("m/44'/309'/0'/0/1")
+      })
+    });
+  });
+});

--- a/packages/neuron-wallet/tests/services/asset-account-service.test.ts
+++ b/packages/neuron-wallet/tests/services/asset-account-service.test.ts
@@ -88,7 +88,6 @@ describe('AssetAccountService', () => {
 
     const keyInfo = HdPublicKeyInfo.fromObject({
       walletId,
-      address: '',
       addressType: AddressType.Receiving,
       addressIndex: 0,
       publicKeyInBlake160: blake160,

--- a/packages/neuron-wallet/tests/services/cells.test.ts
+++ b/packages/neuron-wallet/tests/services/cells.test.ts
@@ -78,7 +78,6 @@ describe('CellsService', () => {
       HdPublicKeyInfo.fromObject({
         walletId: d.walletId,
         publicKeyInBlake160: d.lockScript.args,
-        address: d.address,
         addressType: 0,
         addressIndex: 0,
       })


### PR DESCRIPTION
Since the address can be derived from the `publicKeyInBlake160` column in the key info table, the `address` can be removed to better ensure data consistency.