### PR TITLE
Fix updating address description

### DIFF
--- a/packages/neuron-wallet/src/services/addresses.ts
+++ b/packages/neuron-wallet/src/services/addresses.ts
@@ -330,6 +330,8 @@ export default class AddressService {
   }
 
   public static async updateDescription (walletId: string, address: string, description: string) {
+    const addresses = await this.getAddressesByWalletId(walletId);
+    const addressMeta = addresses.find(meta => meta.address === address)
     await getConnection()
       .createQueryBuilder()
       .update(HdPublicKeyInfo)
@@ -338,7 +340,8 @@ export default class AddressService {
       })
       .where({
         walletId,
-        address
+        addressType: addressMeta!.addressType,
+        addressIndex: addressMeta!.addressIndex
       })
       .execute()
   }

--- a/packages/neuron-wallet/tests/services/address.test.ts
+++ b/packages/neuron-wallet/tests/services/address.test.ts
@@ -561,11 +561,12 @@ describe('integration tests for AddressService', () => {
       it('saves description for a public key info matching with the address', async () => {
         const generatedAddresses1 = await AddressService.getAddressesByWalletId(walletId1)
 
-        const wallet1Addr = generatedAddresses1.find(
-          (addr: any) => addr.walletId === walletId1 && addr.address === addressToUpdate.address
+        const wallet1Addr = generatedAddresses1.filter(
+          (addr: any) => addr.walletId === walletId1 && addr.description === description
         )
-        expect(wallet1Addr!.description).toEqual(description)
 
+        expect(wallet1Addr.length).toEqual(1)
+        expect(wallet1Addr[0].address).toEqual(addressToUpdate.address)
       })
       it('should not description to the public key under other wallets even if the address is the same', async () => {
         const generatedAddresses2 = await AddressService.getAddressesByWalletId(walletId2)


### PR DESCRIPTION
It shouldn't look up the key info records using address anymore via `typeorm`, instead it should locate the record using address type/index in this case.