### PR TITLE
bump electron from 10.1.3 to 9.3.2

### DIFF
--- a/packages/neuron-ui/package.json
+++ b/packages/neuron-ui/package.json
@@ -79,7 +79,7 @@
     "@types/storybook__addon-storyshots": "5.1.2",
     "@types/styled-components": "4.4.0",
     "babel-jest": "25.1.0",
-    "electron": "10.1.3",
+    "electron": "9.3.2",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.2",
     "eslint-config-airbnb": "18.0.1",

--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -72,7 +72,7 @@
     "@zerollup/ts-transform-paths": "1.7.18",
     "axios": "0.19.0",
     "devtron": "1.4.0",
-    "electron": "10.1.3",
+    "electron": "9.3.2",
     "electron-build-env": "0.2.0",
     "electron-builder": "22.8.1",
     "electron-devtools-installer": "2.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8417,10 +8417,10 @@ electron-window-state@5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@9.1.2:
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-9.1.2.tgz#bfa26d6b192ea13abb6f1461371fd731a8358988"
-  integrity sha512-xEYadr3XqIqJ4ktBPo0lhzPdovv4jLCpiUUGc2M1frUhFhwqXokwhPaTUcE+zfu5+uf/ONDnQApwjzznBsRrgQ==
+electron@9.3.2:
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-9.3.2.tgz#afa2942e2642ee25b422b90f1497f7d9bbeec550"
+  integrity sha512-0lleEf9msAXGDi2GukAuiGdw3VDgSTlONOnJgqDEz1fuSEVsXz5RX+hNPKDsVDerLTFg/C34RuJf4LwHvkKcBA==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"
@@ -16182,10 +16182,17 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
-prismjs@^1.21.0, prismjs@~1.21.0:
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.21.0.tgz#36c086ec36b45319ec4218ee164c110f9fc015a3"
-  integrity sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==
+prismjs@^1.8.4:
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.22.0.tgz#73c3400afc58a823dd7eed023f8e1ce9fd8977fa"
+  integrity sha512-lLJ/Wt9yy0AiSYBf212kK3mM5L8ycwlyTlSxHBAneXLR0nzFMlZ5y7riFPF3E33zXOF2IH95xdY5jIyZbM9z/w==
+  optionalDependencies:
+    clipboard "^2.0.0"
+
+prismjs@~1.17.0:
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.17.1.tgz#e669fcbd4cdd873c35102881c33b14d0d68519be"
+  integrity sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==
   optionalDependencies:
     clipboard "^2.0.0"
 
@@ -16883,7 +16890,7 @@ react-syntax-highlighter@^11.0.2:
     "@babel/runtime" "^7.3.1"
     highlight.js "~9.13.0"
     lowlight "~1.11.0"
-    prismjs "^1.21.0"
+    prismjs "^1.8.4"
     refractor "^2.4.1"
 
 react-test-renderer@16.12.0, react-test-renderer@^16.0.0-0:
@@ -17200,7 +17207,7 @@ refractor@^2.4.1:
   dependencies:
     hastscript "^5.0.0"
     parse-entities "^1.1.2"
-    prismjs "~1.21.0"
+    prismjs "~1.17.0"
 
 regenerate-unicode-properties@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
Since `node-hid`(a core dep of ledgerjs) does not yet support Electron 10 [1][2], we are unable to upgrade to `electron@10` at this time.

We can use `electron@9.3.2` to fix Electron security vulnerability[3].

ref:
[1]: https://github.com/node-hid/node-hid/issues/392#issuecomment-689851753
[2]: https://dev.azure.com/nervosnetwork/neuron/_build/results?buildId=14339&view=logs&j=40a2506f-20a1-5aae-73bc-340188bb2ddc&t=c2e6b964-e27a-5612-839d-af8b35c5c1c4&l=107
[3]: https://github.com/electron/electron/security/advisories/GHSA-2q4g-w47c-4674