### PR TITLE
feat: handle 'migrate-acp' command in UI

### DIFF
--- a/packages/neuron-ui/src/components/PasswordRequest/index.tsx
+++ b/packages/neuron-ui/src/components/PasswordRequest/index.tsx
@@ -14,6 +14,7 @@ import {
   sendTransaction,
   deleteWallet,
   backupWallet,
+  migrateAcp,
   sendCreateSUDTAccountTransaction,
   sendSUDTTransaction,
 } from 'states'
@@ -119,6 +120,16 @@ const PasswordRequest = () => {
           case 'backup': {
             await backupWallet({ id: walletID, password })(dispatch).then(status => {
               if (status === ErrorCode.PasswordIncorrect) {
+                throw new PasswordIncorrectException()
+              }
+            })
+            break
+          }
+          case 'migrate-acp': {
+            await migrateAcp({ id: walletID, password })(dispatch).then(status => {
+              if (isSuccessResponse({ status })) {
+                history.push(RoutePath.History)
+              } else if (status === ErrorCode.PasswordIncorrect) {
                 throw new PasswordIncorrectException()
               }
             })
@@ -274,7 +285,7 @@ const PasswordRequest = () => {
     <dialog ref={dialogRef} className={styles.dialog}>
       <form onSubmit={onSubmit}>
         <h2 className={styles.title}>{t(`password-request.${actionType}.title`)}</h2>
-        {['unlock', 'create-sudt-account', 'send-sudt', 'send-acp'].includes(actionType ?? '') ? null : (
+        {['unlock', 'create-sudt-account', 'send-sudt', 'send-acp', 'migrate-acp'].includes(actionType ?? '') ? null : (
           <div className={styles.walletName}>{wallet ? wallet.name : null}</div>
         )}
         <TextField

--- a/packages/neuron-ui/src/containers/Main/hooks.ts
+++ b/packages/neuron-ui/src/containers/Main/hooks.ts
@@ -229,6 +229,16 @@ export const useSubscription = ({
             })
             break
           }
+          case 'migrate-acp': {
+            dispatch({
+              type: AppActions.RequestPassword,
+              payload: {
+                walletID: payload || '',
+                actionType: 'migrate-acp',
+              },
+            })
+            break
+          }
           case 'load-transaction-json': {
             if (payload) {
               const { url, json, filePath } = JSON.parse(payload)

--- a/packages/neuron-ui/src/services/remote/remoteApiWrapper.ts
+++ b/packages/neuron-ui/src/services/remote/remoteApiWrapper.ts
@@ -100,6 +100,7 @@ type Action =
   | 'generate-send-all-to-anyone-can-pay-tx'
   | 'send-to-anyone-can-pay'
   | 'get-token-info-list'
+  | 'migrate-acp'
   // Hardware Wallet
   | 'detect-device'
   | 'get-device-ckb-app-version'

--- a/packages/neuron-ui/src/services/remote/sudt.ts
+++ b/packages/neuron-ui/src/services/remote/sudt.ts
@@ -27,3 +27,5 @@ export const generateSendAllSUDTTransaction = remoteApi<Controller.GenerateSendA
 )
 
 export const sendSUDTTransaction = remoteApi<Controller.SendSUDTTransaction.Params>('send-to-anyone-can-pay')
+
+export const migrateAcp = remoteApi<Controller.MigrateAcp.Params>('migrate-acp')

--- a/packages/neuron-ui/src/types/App/index.d.ts
+++ b/packages/neuron-ui/src/types/App/index.d.ts
@@ -89,6 +89,7 @@ declare namespace State {
       | 'create-sudt-account'
       | 'send-sudt'
       | 'send-acp'
+      | 'migrate-acp'
       | null
     readonly walletID: string
   }

--- a/packages/neuron-ui/src/types/Controller/index.d.ts
+++ b/packages/neuron-ui/src/types/Controller/index.d.ts
@@ -276,6 +276,13 @@ declare namespace Controller {
     type Response = Hash
   }
 
+  namespace MigrateAcp {
+    interface Params {
+      id: string
+      password: string
+    }
+  }
+
   namespace ExportTransactions {
     interface Params {
       walletID: string

--- a/packages/neuron-ui/src/types/Subject/index.d.ts
+++ b/packages/neuron-ui/src/types/Subject/index.d.ts
@@ -7,7 +7,13 @@ interface NeuronWalletSubject<T = any> {
 }
 
 declare namespace Command {
-  type Type = 'navigate-to-url' | 'delete-wallet' | 'backup-wallet' | 'import-hardware' | 'load-transaction-json'
+  type Type =
+    | 'navigate-to-url'
+    | 'delete-wallet'
+    | 'backup-wallet'
+    | 'import-hardware'
+    | 'load-transaction-json'
+    | 'migrate-acp'
   type Payload = string | null
 }
 


### PR DESCRIPTION
Add 'migrate-acp' handler in the PasswordRequest Component to send acp-migration transaction with wallet_id and password.