### PR TITLE
fix: fix layout of sync status in the navbar

### DIFF
--- a/packages/neuron-ui/src/containers/Navbar/navbar.module.scss
+++ b/packages/neuron-ui/src/containers/Navbar/navbar.module.scss
@@ -81,6 +81,7 @@ $left-padding: 15px;
   padding-left: $left-padding;
   color: var(--nervos-green);
   span {
+    flex: 1;
     padding-left: 3px;
   }
 }


### PR DESCRIPTION
This commit sets the sync-status-text fit in the rest space so that the ring-progress-bar will not be squeezed.