### PR TITLE
fix: hardware wallet windows compatibility

### DIFF
--- a/packages/neuron-ui/src/services/remote/index.ts
+++ b/packages/neuron-ui/src/services/remote/index.ts
@@ -38,7 +38,7 @@ export const getVersion = () => {
 }
 
 export const getPlatform = () => {
-  return ipcRenderer.sendSync('get-version') ?? 'Unknown'
+  return ipcRenderer.sendSync('get-platform') ?? 'Unknown'
 }
 
 export const getWinID = () => {

--- a/packages/neuron-ui/src/utils/enums.ts
+++ b/packages/neuron-ui/src/utils/enums.ts
@@ -104,6 +104,8 @@ export enum ErrorCode {
   UnknownError = 405,
   SignMessageFailed = 406,
   UnsupportedManufacturer = 407,
+  // offline
+  DeviceInSleep = 501,
 }
 
 export enum SyncStatus {

--- a/packages/neuron-wallet/src/services/transaction-sender.ts
+++ b/packages/neuron-wallet/src/services/transaction-sender.ts
@@ -81,6 +81,9 @@ export default class TransactionSender {
       try {
         return await device.signTx(walletID, tx, txHash, skipLastInputs, context)
       } catch (err) {
+        if (err instanceof TypeError) {
+          throw err
+        }
         throw new SignTransactionFailed(err.message)
       }
     }


### PR DESCRIPTION
* If the connection to the device fails, win32 needs to search the device again to get the correct status
* fix the device calls the `getDeviceCkbAppVersion` API in sleep mode, renderer process loses response