### PR TITLE
fix: include legacy acp script for indexing

### DIFF
--- a/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-cache-service.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-cache-service.ts
@@ -88,7 +88,8 @@ export default class IndexerCacheService {
     for (const addressMeta of this.addressMetas) {
       const lockScripts = [
         addressMeta.generateDefaultLockScript(),
-        addressMeta.generateACPLockScript()
+        addressMeta.generateACPLockScript(),
+        addressMeta.generateLegacyACPLockScript()
       ]
 
       for (const lockScript of lockScripts) {

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
@@ -152,46 +152,44 @@ export default class Queue {
     }
 
     for (const [, tx] of transactions.entries()) {
-      const [shouldSave, , anyoneCanPayInfos] = await new TxAddressFinder(
+      const [, , anyoneCanPayInfos] = await new TxAddressFinder(
         this.lockHashes,
         this.anyoneCanPayLockHashes,
         tx,
         this.multiSignBlake160s
       ).addresses()
-      if (shouldSave) {
-        for (const [inputIndex, input] of tx.inputs.entries()) {
-          const previousTxHash = input.previousOutput!.txHash
-          const previousTxWithStatus: TransactionWithStatus | undefined = cachedPreviousTxs.get(previousTxHash)
-          if (!previousTxWithStatus) {
-            continue
-          }
+      for (const [inputIndex, input] of tx.inputs.entries()) {
+        const previousTxHash = input.previousOutput!.txHash
+        const previousTxWithStatus: TransactionWithStatus | undefined = cachedPreviousTxs.get(previousTxHash)
+        if (!previousTxWithStatus) {
+          continue
+        }
 
-          const previousTx = previousTxWithStatus!.transaction
-          const previousOutput = previousTx.outputs![+input.previousOutput!.index]
-          const previousOutputData = previousTx.outputsData![+input.previousOutput!.index]
-          input.setLock(previousOutput.lock)
-          previousOutput.type && input.setType(previousOutput.type)
-          input.setData(previousOutputData)
-          input.setCapacity(previousOutput.capacity)
-          input.setInputIndex(inputIndex.toString())
+        const previousTx = previousTxWithStatus!.transaction
+        const previousOutput = previousTx.outputs![+input.previousOutput!.index]
+        const previousOutputData = previousTx.outputsData![+input.previousOutput!.index]
+        input.setLock(previousOutput.lock)
+        previousOutput.type && input.setType(previousOutput.type)
+        input.setData(previousOutputData)
+        input.setCapacity(previousOutput.capacity)
+        input.setInputIndex(inputIndex.toString())
 
-          if (
-            previousOutput.type?.computeHash() === SystemScriptInfo.DAO_SCRIPT_HASH &&
-            previousTx.outputsData![+input.previousOutput!.index] === '0x0000000000000000'
-          ) {
-            const output = tx.outputs![inputIndex]
-            if (output) {
-              output.setDepositOutPoint(new OutPoint(
-                input.previousOutput!.txHash,
-                input.previousOutput!.index,
-              ))
-            }
+        if (
+          previousOutput.type?.computeHash() === SystemScriptInfo.DAO_SCRIPT_HASH &&
+          previousTx.outputsData![+input.previousOutput!.index] === '0x0000000000000000'
+        ) {
+          const output = tx.outputs![inputIndex]
+          if (output) {
+            output.setDepositOutPoint(new OutPoint(
+              input.previousOutput!.txHash,
+              input.previousOutput!.index,
+            ))
           }
         }
-        await TransactionPersistor.saveFetchTx(tx)
-        for (const info of anyoneCanPayInfos) {
-          await AssetAccountService.checkAndSaveAssetAccountWhenSync(info.tokenID, info.blake160)
-        }
+      }
+      await TransactionPersistor.saveFetchTx(tx)
+      for (const info of anyoneCanPayInfos) {
+        await AssetAccountService.checkAndSaveAssetAccountWhenSync(info.tokenID, info.blake160)
       }
 
       await this.checkAndGenerateAddressesByTx(tx)

--- a/packages/neuron-wallet/src/database/address/meta.ts
+++ b/packages/neuron-wallet/src/database/address/meta.ts
@@ -107,4 +107,9 @@ export default class AddressMeta implements Address {
     const assetAccountInfo = new AssetAccountInfo()
     return assetAccountInfo.generateAnyoneCanPayScript(this.blake160)
   }
+
+  public generateLegacyACPLockScript(): Script {
+    const assetAccountInfo = new AssetAccountInfo()
+    return assetAccountInfo.generateLegacyAnyoneCanPayScript(this.blake160)
+  }
 }

--- a/packages/neuron-wallet/src/models/asset-account-info.ts
+++ b/packages/neuron-wallet/src/models/asset-account-info.ts
@@ -12,6 +12,7 @@ export interface ScriptCellInfo {
 export default class AssetAccountInfo {
   private sudtInfo: ScriptCellInfo
   private anyoneCanPayInfo: ScriptCellInfo
+  private legacyAnyoneCanPayInfo: ScriptCellInfo
 
   private static MAINNET_GENESIS_BLOCK_HASH: string = '0x92b197aa1fba0f63633922c61c92375c9c074a93e85963554f5499fe1450d0e5'
 
@@ -37,6 +38,12 @@ export default class AssetAccountInfo {
         codeHash: process.env.MAINNET_ACP_SCRIPT_CODEHASH!,
         hashType: process.env.MAINNET_ACP_SCRIPT_HASHTYPE! as ScriptHashType
       }
+      this.legacyAnyoneCanPayInfo = {
+        cellDep: new CellDep(new OutPoint(process.env.LEGACY_MAINNET_ACP_DEP_TXHASH!, process.env.LEGACY_MAINNET_ACP_DEP_INDEX!),
+          process.env.LEGACY_MAINNET_ACP_DEP_TYPE! as DepType),
+        codeHash: process.env.LEGACY_MAINNET_ACP_SCRIPT_CODEHASH!,
+        hashType: process.env.LEGACY_MAINNET_ACP_SCRIPT_HASHTYPE! as ScriptHashType
+      }
     } else {
       this.sudtInfo = {
         cellDep: new CellDep(new OutPoint(process.env.TESTNET_SUDT_DEP_TXHASH!, process.env.TESTNET_SUDT_DEP_INDEX!),
@@ -49,6 +56,12 @@ export default class AssetAccountInfo {
           process.env.TESTNET_ACP_DEP_TYPE! as DepType),
         codeHash: process.env.TESTNET_ACP_SCRIPT_CODEHASH!,
         hashType: process.env.TESTNET_ACP_SCRIPT_HASHTYPE! as ScriptHashType
+      }
+      this.legacyAnyoneCanPayInfo = {
+        cellDep: new CellDep(new OutPoint(process.env.LEGACY_TESTNET_ACP_DEP_TXHASH!, process.env.LEGACY_TESTNET_ACP_DEP_INDEX!),
+          process.env.LEGACY_TESTNET_ACP_DEP_TYPE! as DepType),
+        codeHash: process.env.LEGACY_TESTNET_ACP_SCRIPT_CODEHASH!,
+        hashType: process.env.LEGACY_TESTNET_ACP_SCRIPT_HASHTYPE! as ScriptHashType
       }
     }
   }
@@ -71,6 +84,11 @@ export default class AssetAccountInfo {
 
   public generateAnyoneCanPayScript(args: string): Script {
     const info = this.anyoneCanPayInfo
+    return new Script(info.codeHash, args, info.hashType)
+  }
+
+  public generateLegacyAnyoneCanPayScript(args: string): Script {
+    const info = this.legacyAnyoneCanPayInfo
     return new Script(info.codeHash, args, info.hashType)
   }
 

--- a/packages/neuron-wallet/src/models/asset-account-info.ts
+++ b/packages/neuron-wallet/src/models/asset-account-info.ts
@@ -78,6 +78,10 @@ export default class AssetAccountInfo {
     return this.anyoneCanPayInfo.codeHash
   }
 
+  public getLegacyAnyoneCanPayInfo(): ScriptCellInfo {
+    return this.legacyAnyoneCanPayInfo
+  }
+
   public generateSudtScript(args: string): Script {
     return new Script(this.sudtInfo.codeHash, args, this.sudtInfo.hashType)
   }

--- a/packages/neuron-wallet/src/services/cells.ts
+++ b/packages/neuron-wallet/src/services/cells.ts
@@ -18,6 +18,7 @@ import Output from 'models/chain/output'
 import SystemScriptInfo from 'models/system-script-info'
 import Script, { ScriptHashType } from 'models/chain/script'
 import LiveCellService from './live-cell-service'
+import AssetAccountInfo from 'models/asset-account-info'
 
 export const MIN_CELL_CAPACITY = '6100000000'
 
@@ -846,13 +847,15 @@ export default class CellsService {
   }
 
   public static async gatherLegacyACPInputs (walletId: string) {
+    const assetAccountInfo = new AssetAccountInfo()
+    const legacyACPScriptInfo = assetAccountInfo.getLegacyAnyoneCanPayInfo()
     const outputs = await getConnection()
       .getRepository(OutputEntity)
       .createQueryBuilder('output')
       .where({
         status: OutputStatus.Live,
-        lockCodeHash: process.env.LEGACY_TESTNET_ACP_SCRIPT_CODEHASH,
-        lockHashType: process.env.LEGACY_TESTNET_ACP_SCRIPT_HASHTYPE,
+        lockCodeHash: legacyACPScriptInfo.codeHash,
+        lockHashType: legacyACPScriptInfo.hashType,
       })
       .andWhere(`
         lockArgs IN (

--- a/packages/neuron-wallet/tests/block-sync-render/indexer-cache-service.intg.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-render/indexer-cache-service.intg.test.ts
@@ -59,6 +59,7 @@ const addressMetas = [addressMeta]
 const defaultLockScript = addressMeta.generateDefaultLockScript()
 const singleMultiSignLockScript = addressMeta.generateSingleMultiSignLockScript()
 const acpLockScript = addressMeta.generateACPLockScript()
+const legacyAcpLockScript = addressMeta.generateLegacyACPLockScript()
 const formattedDefaultLockScript = {
   code_hash: defaultLockScript.codeHash,
   hash_type: defaultLockScript.hashType,
@@ -74,13 +75,19 @@ const formattedAcpLockScript = {
   hash_type: acpLockScript.hashType,
   args: acpLockScript.args
 }
+const formattedLegacyAcpLockScript = {
+  code_hash: legacyAcpLockScript.codeHash,
+  hash_type: legacyAcpLockScript.hashType,
+  args: legacyAcpLockScript.args
+}
 
 const mockGetTransactionHashes = (mocks: any[] = []) => {
   const stubbedConstructor = when(stubbedTransactionCollectorConstructor)
 
   for (const lock of [
     formattedDefaultLockScript,
-    formattedAcpLockScript
+    formattedAcpLockScript,
+    formattedLegacyAcpLockScript,
   ]) {
     const {hashes} = mocks.find(mock => mock.lock === lock) || {hashes: []}
     stubbedConstructor


### PR DESCRIPTION
It has to add indexing for the legacy acp cells, otherwise it couldn't correctly reconstruct the transaction history for a wallet in certain circumstances.