### PR TITLE
fix: release pipeline for both master and rc branches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ stages:
 
 - stage: release
   displayName: Release Binaries
-  condition: startsWith(variables['build.sourceBranch'], 'refs/heads/rc')
+  condition: or(startsWith(variables['build.sourceBranch'], 'refs/heads/master'), startsWith(variables['build.sourceBranch'], 'refs/heads/rc'))
   jobs:
   - job: release_mac
     displayName: Release macOS


### PR DESCRIPTION
@kellyshang 
Let's see if this `or` expression works on for both master and rc branches on the release pipeline.