### PR TITLE
fix device connection to ledger nano X

### DIFF
--- a/packages/neuron-wallet/src/services/hardware/ledger.ts
+++ b/packages/neuron-wallet/src/services/hardware/ledger.ts
@@ -97,7 +97,7 @@ export default class Ledger extends Hardware {
   public static async findDevices () {
     const devices = await Promise.all([
       Ledger.searchDevices(HID.listen, false),
-      Ledger.searchDevices(Bluetooth.listen, true)
+      // Ledger.searchDevices(Bluetooth.listen, true)
     ])
 
     return devices.flat()

--- a/packages/neuron-wallet/tests/controllers/hardware.test.ts
+++ b/packages/neuron-wallet/tests/controllers/hardware.test.ts
@@ -2,7 +2,7 @@ import { Manufacturer } from '../../src/services/hardware/common'
 import HardwareService from '../../src/services/hardware'
 import HardwareController from '../../src/controllers/hardware'
 import { ResponseCode } from '../../src/utils/const'
-import { ledgerNanoS, LedgerNanoX, LedgerCkbApp } from '../mock/hardware'
+import { ledgerNanoS, LedgerCkbApp } from '../mock/hardware'
 import { connectDeviceFailed } from '../../src/exceptions'
 
 describe('hardware controller', () => {
@@ -45,8 +45,8 @@ describe('hardware controller', () => {
    it('#detectDevice', async () => {
     const { result } = await hardwareControler.detectDevice({
       manufacturer: Manufacturer.Ledger,
-      product: 'Nano X'
+      product: 'Nano S'
     })
-    expect(result).toEqual([LedgerNanoX])
+    expect(result).toEqual([ledgerNanoS])
    })
 })

--- a/packages/neuron-wallet/tests/services/hardware.test.ts
+++ b/packages/neuron-wallet/tests/services/hardware.test.ts
@@ -1,13 +1,13 @@
 import { Manufacturer } from '../../src/services/hardware/common'
 import HardwareService from '../../src/services/hardware'
-import { ledgerNanoS, LedgerNanoX } from '../mock/hardware'
+import { ledgerNanoS } from '../mock/hardware'
 
 describe('HardwareWalletService', () => {
   describe('service', () => {
     describe('findDevice', () => {
       it('find all kind of device', async () => {
         const devices = await HardwareService.findDevices()
-        expect(devices).toEqual([ledgerNanoS, LedgerNanoX])
+        expect(devices).toEqual([ledgerNanoS])
       })
 
       it('find specific model device', async () => {
@@ -18,7 +18,7 @@ describe('HardwareWalletService', () => {
         expect(devices).toEqual([ledgerNanoS])
       })
 
-      it('can find bluetooth model', async () => {
+      it.skip('can find bluetooth model', async () => {
         const devices = await HardwareService.findDevices()
         expect(devices.some(d => d.isBluetooth)).toBe(true)
       })


### PR DESCRIPTION
Disable finding the bluetooth to get ledger nano X to work on Neuron. Somehow the `@ledgerhq/hw-transport-node-ble` throws error when attempting to search devices over the Bluetooth transport.
The Bluetooth dependency seem still in an experimental stage, and even the official ledger live desktop app doesn't support the Bluetooth connection with ledger nano X. So I think we remove the searching over the Bluetooth for now.