### PR TITLE
fix: filter invalid token info out

### DIFF
--- a/packages/neuron-wallet/src/services/asset-account-service.ts
+++ b/packages/neuron-wallet/src/services/asset-account-service.ts
@@ -1,4 +1,4 @@
-import { getConnection, In } from "typeorm"
+import { getConnection, In, Not } from "typeorm"
 import BufferUtils from "utils/buffer"
 import OutputEntity from "database/chain/entities/output"
 import Transaction, { TransactionStatus } from "models/chain/transaction"
@@ -346,7 +346,14 @@ export default class AssetAccountService {
 
   public static getTokenInfoList() {
     const repo = getConnection().getRepository(SudtTokenInfoEntity)
-    return repo.find().then(list => list.map(item => item.toModel()))
+    return repo.find({
+      where: {
+        tokenID: Not(''),
+        tokenName: Not(''),
+        symbol: Not(''),
+        decimal: Not('')
+      }
+    }).then(list => list.map(item => item.toModel()))
   }
 
 

--- a/packages/neuron-wallet/tests/services/asset-account-service.test.ts
+++ b/packages/neuron-wallet/tests/services/asset-account-service.test.ts
@@ -910,6 +910,12 @@ describe('AssetAccountService', () => {
           symbol: 'udt',
           tokenName: 'udt',
           decimal: '0',
+        },
+        {
+          tokenID: 'invalid token info',
+          symbol: '',
+          tokenName: '',
+          decimal: '',
         }
       ]
       const repo = getConnection().getRepository(SudtTokenInfoEntity)
@@ -923,6 +929,13 @@ describe('AssetAccountService', () => {
       expect(list.find((item: any) => item.tokenID === tokenID)).toBeTruthy()
     })
 
+    it('Filter invalid token info out', async () => {
+      const repo = getConnection().getRepository(SudtTokenInfoEntity)
+      const count = await repo.count()
+      expect(count).toBe(3)
+      const list = await AssetAccountService.getTokenInfoList()
+      expect(list).toHaveLength(2)
+    })
   })
 
   describe('#generateCreateChequeTx', () => {


### PR DESCRIPTION
This commit filters invalid token info(empty token info) out of the token info list