### PR TITLE
fix: typeorm validation

### DIFF
--- a/packages/neuron-wallet/tests/services/asset-account-service.test.ts
+++ b/packages/neuron-wallet/tests/services/asset-account-service.test.ts
@@ -725,7 +725,7 @@ describe('AssetAccountService', () => {
 
     it('assetAccount exists', async () => {
       const assetAccountEntity = AssetAccountEntity.fromModel(assetAccount)
-      await getConnection().manager.save([assetAccountEntity.sudtTokenInfo, assetAccount])
+      await getConnection().manager.save([assetAccountEntity.sudtTokenInfo, assetAccountEntity])
       const aae = await getConnection()
         .getRepository(AssetAccountEntity)
         .createQueryBuilder('aa')


### PR DESCRIPTION
After upgrading to 0.2.4, typeorm's `findMetadata` method no longer accepts normal JavaScript objects.
This pr should fix https://github.com/nervosnetwork/neuron/pull/2022

ref: https://github.com/typeorm/typeorm/issues/5676#issuecomment-599008952