### PR TITLE
Disable github action for packaging

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   default:
+    if: false
     strategy:
       matrix:
         node:


### PR DESCRIPTION
Enable it when windows certificate is ready and Azure is disabled.