### PR TITLE
ci: update runner in Merge released into develop action

### DIFF
--- a/.github/workflows/merge_released_into_develop.yml
+++ b/.github/workflows/merge_released_into_develop.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   merge-to-dev:
     name: Merge into develop
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - name: Request


### PR DESCRIPTION
use ubuntu-latest instead of ubuntu-16.04 since it's deprecated

![image](https://user-images.githubusercontent.com/7271329/131291965-474d1dd7-52af-4f7d-ab37-2856d37f146a.png)
