### PR TITLE
fix: fix address truncation in addresses book

### DIFF
--- a/packages/neuron-ui/src/components/Addresses/addresses.module.scss
+++ b/packages/neuron-ui/src/components/Addresses/addresses.module.scss
@@ -116,14 +116,12 @@ $change-color: #6666cc;
         display: none;
       }
 
-      @media screen and (max-width: 1365px) {
+      @media screen and (max-width: 1680px) {
+        width: 20vw;
+
         .ellipsis {
           display: inline;
         }
-      }
-
-      @media screen and (max-width: 1680px) {
-        width: 20vw;
 
         &::after {
           position: absolute;


### PR DESCRIPTION
Fix the missing of ellipsis in a truncated address when width
of window is in (1365, 1680]

Before
![image](https://user-images.githubusercontent.com/7271329/136543429-382365a4-0932-452c-bff9-463ae3732043.png)
After
![image](https://user-images.githubusercontent.com/7271329/136543548-3e85f036-f3e3-4eaf-a341-f8ffe707d007.png)
