### PR TITLE
fix: remove useless token id prompt when account type is ckb

### DIFF
--- a/packages/neuron-ui/src/components/SUDTCreateDialog/index.tsx
+++ b/packages/neuron-ui/src/components/SUDTCreateDialog/index.tsx
@@ -289,7 +289,7 @@ const SUDTCreateDialog = ({
                   error={tokenErrors[field.key]}
                   className={accountType === AccountType.CKB ? styles.ckbField : undefined}
                   hint={
-                    !tokenErrors[field.key] && field.key === 'tokenId'
+                    !tokenErrors[field.key] && field.key === 'tokenId' && accountType === AccountType.SUDT
                       ? t(`s-udt.create-dialog.placeholder.${field.label}`)
                       : undefined
                   }


### PR DESCRIPTION
Only `sudt account type` needs the hint of `token id`