### PR TITLE
Update config-overrides.js by fixing variable spelling

### DIFF
--- a/packages/neuron-ui/config-overrides.js
+++ b/packages/neuron-ui/config-overrides.js
@@ -1,7 +1,7 @@
 const path = require('path')
 
 module.exports = function override(config) {
-  const webpackCofnig = { ...config }
-  webpackCofnig.resolve.alias.electron = path.join(__dirname, 'src/electron-modules')
-  return webpackCofnig
+  const webpackConfig = { ...config }
+  webpackConfig.resolve.alias.electron = path.join(__dirname, 'src/electron-modules')
+  return webpackConfig
 }


### PR DESCRIPTION
Fix spelling of `webpackCofnig` -> `webpackConfig`