### PR TITLE
fix: fix test which is broken due to deprecated dao api

### DIFF
--- a/packages/neuron-wallet/tests/services/tx/transaction-sender.test.ts
+++ b/packages/neuron-wallet/tests/services/tx/transaction-sender.test.ts
@@ -220,9 +220,9 @@ describe('TransactionSender Test', () => {
 
     //@ts-ignore
     NodeService.getInstance().ckb.rpc = {
-      calculateDaoMaximumWithdraw: stubbedCalculateDaoMaximumWithdraw,
       sendTransaction: stubbedSendTransaction
     }
+    NodeService.getInstance().ckb.calculateDaoMaximumWithdraw = stubbedCalculateDaoMaximumWithdraw
   })
 
   describe('sign', () => {


### PR DESCRIPTION
The mock in tests should be updated due to https://github.com/nervosnetwork/neuron/pull/2290/files#diff-6b4e52aade78db37f085688194f39382d8411f142f051ac17a199f52f6953babR547