### PR TITLE
fix: fix code of error

### DIFF
--- a/packages/neuron-wallet/src/controllers/api.ts
+++ b/packages/neuron-wallet/src/controllers/api.ts
@@ -549,7 +549,7 @@ export default class ApiController {
           err.code = NODE_DISCONNECTED_CODE
         }
 
-        if (!Number.isNaN(err.message?.code)) {
+        if (err.message?.code !== undefined && !Number.isNaN(err.message.code)) {
           err.code = err.message.code
         }
 


### PR DESCRIPTION
The error.code was covered even error.message.code was undefined,
with that some errors are not handled by UI. This commit fix
this bug by adding a pre-condition that error.message.code
should not be undefined

![image](https://user-images.githubusercontent.com/7271329/157819595-4daa9545-7f3c-4d69-9365-dd0ac742f37b.png)
