### PR TITLE
fix: fix error message of creating sudt/acp account

### DIFF
--- a/packages/neuron-ui/src/components/SUDTAccountList/index.tsx
+++ b/packages/neuron-ui/src/components/SUDTAccountList/index.tsx
@@ -181,6 +181,7 @@ const SUDTAccountList = () => {
     walletId,
     dispatch,
     onGenerated: onTransactionGenerated,
+    t,
   })
 
   const onOpenCreateDialog = useCallback(() => {

--- a/packages/neuron-ui/src/components/SUDTCreateDialog/index.tsx
+++ b/packages/neuron-ui/src/components/SUDTCreateDialog/index.tsx
@@ -138,7 +138,7 @@ const SUDTCreateDialog = ({
     existingAccountNames,
     t,
   })
-  const isAccountNameReady = info.accountName.trim() && !tokenErrors.accountName
+  const isAccountNameReady = info.accountName.trim() && !tokenErrors.accountName && accountType
 
   const isTokenReady =
     isAccountNameReady && Object.values(info).every(v => v.trim()) && Object.values(tokenErrors).every(e => !e)

--- a/packages/neuron-ui/src/utils/hooks/createSUDTAccount.ts
+++ b/packages/neuron-ui/src/utils/hooks/createSUDTAccount.ts
@@ -1,7 +1,14 @@
+// TODO: update eslint to use 'import type' syntax
+import { TFunction } from 'i18next'
 import { useEffect, useCallback } from 'react'
 import { AccountType, TokenInfo } from 'components/SUDTCreateDialog'
 import { AppActions, StateAction } from 'states'
-import { generateCreateSUDTAccountTransaction, openExternal, getSUDTTypeScriptHash } from 'services/remote'
+import {
+  generateCreateSUDTAccountTransaction,
+  openExternal,
+  getSUDTTypeScriptHash,
+  invokeShowErrorMessage,
+} from 'services/remote'
 import { getExplorerUrl } from 'utils'
 import { ErrorCode } from '../enums'
 import { isSuccessResponse } from '../is'
@@ -75,10 +82,12 @@ export const useOnGenerateNewAccountTransaction = ({
   walletId,
   dispatch,
   onGenerated,
+  t,
 }: {
   walletId: string
   dispatch: React.Dispatch<StateAction>
   onGenerated: () => void
+  t: TFunction
 }) =>
   useCallback(
     ({ tokenId, tokenName, accountName, symbol, decimal }: TokenInfo) => {
@@ -95,7 +104,7 @@ export const useOnGenerateNewAccountTransaction = ({
           if (isSuccessResponse(res)) {
             return res.result
           }
-          throw new Error(res.message.toString())
+          throw new Error(typeof res.message === 'string' ? res.message : res.message.content)
         })
         .then((res: Controller.GenerateCreateSUDTAccountTransaction.Response) => {
           dispatch({ type: AppActions.UpdateExperimentalParams, payload: res })
@@ -107,11 +116,11 @@ export const useOnGenerateNewAccountTransaction = ({
           return true
         })
         .catch(err => {
-          console.error(err)
+          invokeShowErrorMessage({ title: t('messages.error'), content: err.message })
           return false
         })
     },
-    [onGenerated, walletId, dispatch]
+    [onGenerated, walletId, dispatch, t]
   )
 
 export const useOpenSUDTTokenUrl = (tokenID: string, isMainnet?: boolean) =>


### PR DESCRIPTION
1. add an error message box to prompt the error message

![Screen Shot 2022-03-14 at 17 45 34](https://user-images.githubusercontent.com/7271329/158149189-2463a5b0-0f55-4e76-9cf6-7b77cad47c8a.png)

2. next button is disabled when account type is missing
3. 
Before:
![image](https://user-images.githubusercontent.com/7271329/158149443-a50e21a3-114d-40d4-adf2-85d167d29a67.png)

After:
![image](https://user-images.githubusercontent.com/7271329/158149264-17280312-b591-41b5-bd57-f3563f04d2c4.png)
