### PR TITLE
ci: check checksums after publishment

### DIFF
--- a/.github/workflows/check_checksums.yml
+++ b/.github/workflows/check_checksums.yml
@@ -1,0 +1,39 @@
+name: Check Checksums
+
+on: 
+  release:
+    types: [published, prereleased]
+
+jobs:
+  compare:
+    name: Compare checksums
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Generate checksums from artifacts
+        run: 
+          ruby ./scripts/release-checksums.rb ${{ github.event.release.tag_name }} | tee generated_checksums.txt
+
+      - name: Fetch checksums from release note
+        run: |
+          curl "https://api.github.com/repos/nervosnetwork/neuron/releases/tags/${{ github.event.release.tag_name }}" |\
+          python3 -c "import sys, json; print(\"\n\".join(json.load(sys.stdin)['body'].splitlines()[-9:]))" |\
+          tee release_note_checksums.txt
+
+      - name: Compare
+        run: diff generated_checksums.txt release_note_checksums.txt
+
+      - id: comment_body
+        run: |
+          body=$(cat generated_checksums.txt)
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}" 
+          echo ::set-output name=body::$body
+
+      - uses: peter-evans/commit-comment@v1
+        with:
+          body: ${{ steps.comment_body.outputs.body }}
+


### PR DESCRIPTION
This workflow compares checksums generated from release artifacts
with those listed in release note to check if artifacts are
valid.