### PR TITLE
ci: set node version to 16.4.0

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         node:
-          - 16
+          - 16.4.0
         os:
           - macos-latest
           - ubuntu-20.04

--- a/.github/workflows/package_for_test.yml
+++ b/.github/workflows/package_for_test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         node:
-          - 16
+          - 16.4.0
         os:
           - macos-latest
           - ubuntu-20.04

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         node:
-          - 16
+          - 16.4.0
         os:
           - macos-latest
           - ubuntu-20.04


### PR DESCRIPTION
Node.js 16.14.2, which is default in GitHub Action, introduces
a bug of npm, and should be fixed in 2022/04/05 but actually not.

Specify Node.js to 16.4.0 to avoid this exception.

Ref: https://github.com/nodejs/node/issues/42397