### PR TITLE
feat: support syncing cells those have script of hash type 'data1'

### DIFF
--- a/packages/neuron-wallet/src/models/chain/live-cell.ts
+++ b/packages/neuron-wallet/src/models/chain/live-cell.ts
@@ -2,6 +2,12 @@ import Script, { ScriptHashType } from './script'
 import OutPoint from './out-point'
 import { LumosCell } from 'block-sync-renderer/sync/indexer-connector'
 
+const LUMOS_HASH_TYPE_MAP: Record<string, ScriptHashType> = {
+  type: ScriptHashType.Type,
+  data1: ScriptHashType.Data1,
+  data: ScriptHashType.Data
+}
+
 export default class LiveCell {
   public txHash: string
   public outputIndex: string
@@ -53,7 +59,7 @@ export default class LiveCell {
       ? new Script(
           cell.cell_output.type.code_hash,
           cell.cell_output.type.args,
-          cell.cell_output.type.hash_type === 'data' ? ScriptHashType.Data : ScriptHashType.Type
+          LUMOS_HASH_TYPE_MAP[cell.cell_output.type.hash_type] ?? ScriptHashType.Data
         )
       : null
 
@@ -64,7 +70,7 @@ export default class LiveCell {
       new Script(
         cell.cell_output.lock.code_hash,
         cell.cell_output.lock.args,
-        cell.cell_output.lock.hash_type === 'data' ? ScriptHashType.Data : ScriptHashType.Type
+        LUMOS_HASH_TYPE_MAP[cell.cell_output.lock.hash_type] ?? ScriptHashType.Data
       ),
       type,
       cell.data ? cell.data : '0x'

--- a/packages/neuron-wallet/tests/models/chain/live-cell.test.ts
+++ b/packages/neuron-wallet/tests/models/chain/live-cell.test.ts
@@ -1,0 +1,146 @@
+import Script, { ScriptHashType } from '../../../src/models/chain/script'
+import { LumosCell } from '../../../src/block-sync-renderer/sync/indexer-connector'
+import LiveCell from "../../../src/models/chain/live-cell"
+
+describe('LiveCell Test', () => {
+  const INITIAL_DATA = {
+    txHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    outputIndex: '0x1',
+    capacity: '0x2',
+    lock: {
+      codeHash: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      hashType: ScriptHashType.Data,
+      args: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    },
+    type: {
+      codeHash: '0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+      hashType: ScriptHashType.Data1,
+      args: '0xdddddddddddddddddddddddddddddddddddddddd'
+    },
+    data: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  }
+
+  let liveCell: LiveCell
+
+  beforeAll(() => {
+    liveCell = new LiveCell(
+      INITIAL_DATA.txHash,
+      INITIAL_DATA.outputIndex,
+      INITIAL_DATA.capacity,
+      new Script(INITIAL_DATA.lock.codeHash, INITIAL_DATA.lock.args, INITIAL_DATA.lock.hashType),
+      new Script(INITIAL_DATA.type.codeHash, INITIAL_DATA.type.args, INITIAL_DATA.type.hashType),
+      INITIAL_DATA.data,
+    )
+  })
+
+  it('should have initial properties', () => {
+    expect(liveCell).toMatchObject({
+      txHash: INITIAL_DATA.txHash,
+      outputIndex: '1',
+      capacity: '2',
+      lockHash: '0xfd7dc5cc9794ff6563b53581a90c3896e2af54c64d27945559e05d36aca44698',
+      lockHashType: INITIAL_DATA.lock.hashType,
+      lockCodeHash: INITIAL_DATA.lock.codeHash,
+      lockArgs: INITIAL_DATA.lock.args,
+      typeHash: '0x0bbfd38af1bee8669d6718397348de27be18707c54880c4cb61527ec6074cc40',
+      typeHashType: INITIAL_DATA.type.hashType,
+      typeCodeHash: INITIAL_DATA.type.codeHash,
+      typeArgs: INITIAL_DATA.type.args,
+      data: INITIAL_DATA.data,
+    })
+  })
+
+  it('should have outpoint', () => {
+    expect(liveCell.outPoint()).toMatchObject({
+      txHash: INITIAL_DATA.txHash,
+      index: '1'
+    })
+  })
+
+  it('should have lock script', () => {
+    expect(liveCell.lock()).toMatchObject({
+      codeHash: INITIAL_DATA.lock.codeHash,
+      hashType: INITIAL_DATA.lock.hashType,
+      args: INITIAL_DATA.lock.args,
+    })
+  })
+
+  describe('type script', () => {
+    it('should have type', () => {
+      expect(liveCell.type()).toMatchObject({
+        codeHash: INITIAL_DATA.type.codeHash,
+        hashType: INITIAL_DATA.type.hashType,
+        args: INITIAL_DATA.type.args,
+      })
+    })
+
+    it('should have no type when type is null', () => {
+      const cell = new LiveCell(
+        INITIAL_DATA.txHash,
+        INITIAL_DATA.outputIndex,
+        INITIAL_DATA.capacity,
+        new Script(INITIAL_DATA.lock.codeHash, INITIAL_DATA.lock.args, INITIAL_DATA.lock.hashType),
+        null,
+        INITIAL_DATA.data,
+      )
+      expect(cell.type()).toBe(undefined)
+    })
+  })
+
+  describe('get cells from lumos cell', () => {
+    const LUMOS_CELL: LumosCell = {
+      block_hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      out_point: {
+        tx_hash: INITIAL_DATA.txHash,
+        index: INITIAL_DATA.outputIndex,
+      },
+      cell_output: {
+        capacity: INITIAL_DATA.capacity,
+        lock: {
+          code_hash: INITIAL_DATA.lock.codeHash,
+          hash_type: INITIAL_DATA.lock.hashType,
+          args: INITIAL_DATA.lock.args,
+        },
+        type: {
+          code_hash: INITIAL_DATA.type.codeHash,
+          hash_type: INITIAL_DATA.type.hashType,
+          args: INITIAL_DATA.type.args,
+        },
+      },
+      data: INITIAL_DATA.data,
+    }
+
+    it('have type script', () => {
+      const cell = LiveCell.fromLumos(LUMOS_CELL)
+      expect(cell).toMatchObject({
+        txHash: INITIAL_DATA.txHash,
+        outputIndex: '1',
+        capacity: '2',
+        lockHash: '0xfd7dc5cc9794ff6563b53581a90c3896e2af54c64d27945559e05d36aca44698',
+        lockHashType: INITIAL_DATA.lock.hashType,
+        lockCodeHash: INITIAL_DATA.lock.codeHash,
+        lockArgs: INITIAL_DATA.lock.args,
+        typeHash: '0x0bbfd38af1bee8669d6718397348de27be18707c54880c4cb61527ec6074cc40',
+        typeHashType: INITIAL_DATA.type.hashType,
+        typeCodeHash: INITIAL_DATA.type.codeHash,
+        typeArgs: INITIAL_DATA.type.args,
+        data: INITIAL_DATA.data,
+      })
+    })
+
+    it('should have no type script', () => {
+      const cell = LiveCell.fromLumos({ ...LUMOS_CELL, cell_output: { ...LUMOS_CELL.cell_output, type: undefined } })
+      expect(cell).toMatchObject({
+        txHash: INITIAL_DATA.txHash,
+        outputIndex: '1',
+        capacity: '2',
+        lockHash: '0xfd7dc5cc9794ff6563b53581a90c3896e2af54c64d27945559e05d36aca44698',
+        lockHashType: INITIAL_DATA.lock.hashType,
+        lockCodeHash: INITIAL_DATA.lock.codeHash,
+        lockArgs: INITIAL_DATA.lock.args,
+        data: INITIAL_DATA.data,
+      })
+
+    })
+  })
+})


### PR DESCRIPTION
Caveat: Since there're no scripts of hash type `data1`, on-chain testing is suspended.