### PR TITLE
feat: add address format toggle in receive tabs

### DIFF
--- a/packages/neuron-ui/src/components/Receive/receive.module.scss
+++ b/packages/neuron-ui/src/components/Receive/receive.module.scss
@@ -13,6 +13,24 @@
   justify-content: center;
 }
 
+.addressToggle{
+  display: flex;
+  align-items: center;
+  appearance: none;
+  border: none;
+  background: none;
+  svg {
+    pointer-events: none;
+  }
+  &:hover {
+    g,
+    path {
+      stroke: var(--nervos-green);
+      fill: var(--nervos-green);
+    }
+  }
+}
+
 .copyBtn {
   appearance: none;
   border: none;

--- a/packages/neuron-ui/src/components/SUDTReceive/index.tsx
+++ b/packages/neuron-ui/src/components/SUDTReceive/index.tsx
@@ -1,7 +1,9 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import { addressToScript, bech32Address, AddressPrefix } from '@nervosnetwork/ckb-sdk-utils'
 import SUDTAvatar from 'widgets/SUDTAvatar'
+import { ReactComponent as AddressToggleIcon } from 'widgets/Icons/AddressTransform.svg'
 import { ReactComponent as Attention } from 'widgets/Icons/Attention.svg'
 import Breadcrum from 'widgets/Breadcrum'
 import QRCode from 'widgets/QRCode'
@@ -13,17 +15,32 @@ import { RoutePath, CONSTANTS } from 'utils'
 import styles from './sUDTReceive.module.scss'
 
 const { DEFAULT_SUDT_FIELDS } = CONSTANTS
+const toShortAddr = (addr: string) => {
+  try {
+    const script = addressToScript(addr)
+    const isMainnet = addr.startsWith('ckb')
+    return bech32Address(script.args, {
+      prefix: isMainnet ? AddressPrefix.Mainnet : AddressPrefix.Testnet,
+      codeHashOrCodeHashIndex: '0x02',
+    })
+  } catch {
+    return ''
+  }
+}
 
 const SUDTReceive = () => {
   const dispatch = useDispatch()
   const [t] = useTranslation()
   const { search } = useLocation()
+  const [isInShortFormat, setIsInShortFormat] = useState(false)
   const { address, accountName, tokenName, symbol } = Object.fromEntries([...new URLSearchParams(search)])
   const breakcrum = [{ label: t('navbar.s-udt'), link: RoutePath.SUDTAccountList }]
 
   if (!address) {
     return <div>Not Found</div>
   }
+
+  const displayedAddr = isInShortFormat ? toShortAddr(address) : address
 
   return (
     <div
@@ -41,11 +58,19 @@ const SUDTReceive = () => {
         <div className={styles.accountName}>{accountName || DEFAULT_SUDT_FIELDS.accountName}</div>
         <div className={styles.tokenName}>{tokenName || DEFAULT_SUDT_FIELDS.tokenName}</div>
       </div>
-      <QRCode value={address} size={220} includeMargin dispatch={dispatch} />
+      <QRCode value={displayedAddr} size={220} includeMargin dispatch={dispatch} />
       <div className={styles.address}>
-        <CopyZone content={address} name={t('receive.copy-address')} style={{ lineHeight: '1.625rem' }}>
-          {`${address.slice(0, 30)}...${address.slice(-30)}`}
+        <CopyZone content={displayedAddr} name={t('receive.copy-address')} style={{ lineHeight: '1.625rem' }}>
+          {displayedAddr}
         </CopyZone>
+        <button
+          type="button"
+          className={styles.addressToggle}
+          onClick={() => setIsInShortFormat(is => !is)}
+          title={t(isInShortFormat ? `receive.turn-into-full-version-fomrat` : `receive.turn-into-deprecated-format`)}
+        >
+          <AddressToggleIcon />
+        </button>
       </div>
       <p className={styles.notation}>
         <Attention />

--- a/packages/neuron-ui/src/components/SUDTReceive/sUDTReceive.module.scss
+++ b/packages/neuron-ui/src/components/SUDTReceive/sUDTReceive.module.scss
@@ -32,8 +32,30 @@
 }
 
 .address {
+  display: flex;
+  align-items: center;
+  width: max-content;
   margin: 14px auto 0;
-  text-align: center;
+}
+
+.addressToggle{
+  display: flex;
+  align-items: center;
+  appearance: none;
+  border: none;
+  background: none;
+
+  svg {
+    pointer-events: none;
+  }
+
+  &:hover {
+    g,
+    path {
+      stroke: var(--nervos-green);
+      fill: var(--nervos-green);
+    }
+  }
 }
 
 .notation {

--- a/packages/neuron-ui/src/locales/en.json
+++ b/packages/neuron-ui/src/locales/en.json
@@ -224,7 +224,9 @@
       "prompt": "Neuron picks a new receiving address for better privacy. Please go to the Address Book if you want to use a previously used receiving address.",
       "address-qrcode": "Address QR Code",
       "address": "{{network}} Address",
-      "verify-address": "Verify Address"
+      "verify-address": "Verify Address",
+      "turn-into-full-version-fomrat": "Turn into full version format",
+      "turn-into-deprecated-format": "Turn into deprecated format"
     },
     "history": {
       "meta": "Meta",

--- a/packages/neuron-ui/src/locales/zh-tw.json
+++ b/packages/neuron-ui/src/locales/zh-tw.json
@@ -217,7 +217,9 @@
       "prompt": "為了保護隱私，Neuron 會自動選擇一個新收款地址。如果您想使用舊的收款地址，請訪問地址簿頁面。",
       "address-qrcode": "地址二維碼",
       "address": "{{network}} 地址",
-      "verify-address": "驗證地址"
+      "verify-address": "驗證地址",
+      "turn-into-full-version-fomrat": "轉換為長地址格式",
+      "turn-into-deprecated-format": "轉換為廢棄地址格式"
     },
     "history": {
       "meta": "元信息",

--- a/packages/neuron-ui/src/locales/zh.json
+++ b/packages/neuron-ui/src/locales/zh.json
@@ -217,7 +217,9 @@
       "prompt": "为了保护隐私，Neuron 会自动选择一个新收款地址。如果您想使用旧的收款地址，请访问地址簿页面。",
       "address-qrcode": "地址二维码",
       "address": "{{network}} 地址",
-      "verify-address": "验证地址"
+      "verify-address": "验证地址",
+      "turn-into-full-version-fomrat": "转换为长地址格式",
+      "turn-into-deprecated-format": "转换为废弃地址格式"
     },
     "history": {
       "meta": "元信息",

--- a/packages/neuron-ui/src/widgets/Icons/AddressTransform.svg
+++ b/packages/neuron-ui/src/widgets/Icons/AddressTransform.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg t="1653993411632" class="icon" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="address-toggle" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16">
+  <path d="M844.18 235.29H502L469.82 118h-290c-34.7 0-62.83 31-62.83 69.26v537.35c0 38.24 28.13 69.25 62.83 69.25H505.9L554.18 906h290c34.7 0 62.83-30.77 62.83-68.72V304c-0.01-37.94-28.13-68.71-62.83-68.71zM197 713.86V198h211.8l10.2 37.29 91.4 333.6 6 22 33.68 122.93zM827 826H626.11L655 793.86l-55.6-202.92h157.53v-80H577.47l-13.11-47.85h192.57v-80H542.44l-18.57-67.79H827zM649.29 718.78h107.64v-80H649.29z" fill="#979797" p-id="20232"></path>
+</svg>


### PR DESCRIPTION
Add a button next to the address in receive tabs to toggle
address foramts between full version and deprecated version.

The switch is designed to be neglectable because the deprecated
format is discouraged.

Ref: https://github.com/Magickbase/neuron-public-issues/issues/22

https://user-images.githubusercontent.com/7271329/171185344-eef47104-d05a-4270-a1b1-e12717430de5.mov


