### PR TITLE
fix: style of release note

### DIFF
--- a/packages/neuron-ui/src/components/GeneralSetting/style.module.scss
+++ b/packages/neuron-ui/src/components/GeneralSetting/style.module.scss
@@ -100,6 +100,8 @@ $action-button-width: 11.25rem;
 
   .releaseNotesStyle {
     grid-area: release-note;
+    width: 100%;
+    box-sizing: border-box;
     overflow: scroll;
     min-height: 200px;
     height: calc(100vh - 400px);


### PR DESCRIPTION
This commit fixes overflow of release note.

Before:
![image](https://user-images.githubusercontent.com/7271329/171324532-61507eb5-1a2e-4582-992c-26e24bb4ae9a.png)

After:
![image](https://user-images.githubusercontent.com/7271329/171324544-4f3e7c1e-dc3b-4e23-b637-ef8bf99578f2.png)
