### PR TITLE
chore: bump sqlite3 to 5.0.8

### DIFF
--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -60,8 +60,8 @@
     "reflect-metadata": "0.1.13",
     "rxjs": "6.5.3",
     "sha3": "2.0.7",
-    "sqlite3": "5.0.3",
-    "subleveldown": "^4.1.4",
+    "sqlite3": "5.0.8",
+    "subleveldown": "4.1.4",
     "typeorm": "0.2.25",
     "uuid": "8.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -20340,10 +20340,10 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sqlite3@5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-5.0.3.tgz#0c8303bcb8fbd6198a9f9645e7f363c191091483"
-  integrity sha512-/cDwes7XtTOtKH5zYeJSuiavuaJ6jXxPjebw9lDFxBAwR/DvP0tnJ5MPZQ3zpnNzJBa1G6mPTpB+5O1T+AoSdQ==
+sqlite3@5.0.8:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-5.0.8.tgz#b4b7eab7156debec80866ef492e01165b4688272"
+  integrity sha512-f2ACsbSyb2D1qFFcqIXPfFscLtPVOWJr5GmUzYxf4W+0qelu5MWrR+FAQE1d5IUArEltBrzSDxDORG8P/IkqyQ==
   dependencies:
     "@mapbox/node-pre-gyp" "^1.0.0"
     node-addon-api "^4.2.0"
@@ -20761,7 +20761,7 @@ stylehacks@^5.1.0:
     browserslist "^4.16.6"
     postcss-selector-parser "^6.0.4"
 
-subleveldown@^4.1.4:
+subleveldown@4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/subleveldown/-/subleveldown-4.1.4.tgz#3579563e4de4b811008046ad33280679bc39dba4"
   integrity sha512-njpSBP/Bxh7EahraG6IhR6goOH2ffMTMVt7Ud+k/OhNFHrrmuvK+XYfauI8KnjCm0w381cUF43pejlWeJMZChA==


### PR DESCRIPTION
sqlite3@5.0.3 doesn't work on Mint 19.1 and 20.3 while sqlite3@5.0.8 and sqlite3@5.0.2 work, this commit upgrades sqlite3 to 5.0.8 to fix issue https://github.com/nervosnetwork/neuron/issues/2380