### PR TITLE
fix: fix link to nervos dao

### DIFF
--- a/packages/neuron-ui/src/components/NervosDAO/index.tsx
+++ b/packages/neuron-ui/src/components/NervosDAO/index.tsx
@@ -31,8 +31,7 @@ import styles from './nervosDAO.module.scss'
 
 const { MIN_DEPOSIT_AMOUNT } = CONSTANTS
 
-const DAO_DOCS_URL =
-  'https://docs.nervos.org/docs/basics/guides/neuron#5-deposit-your-nervos-ckbyte-tokens-into-nervos-dao'
+const DAO_DOCS_URL = 'https://docs.nervos.org/docs/basics/guides/crypto%20wallets/neuron/#deposit-ckb-into-nervos-dao'
 
 const NervosDAO = () => {
   const [focusedRecord, setFocusedRecord] = useState('')


### PR DESCRIPTION
https://docs.nervos.org/docs/basics/guides/neuron#5-deposit-your-nervos-ckbyte-tokens-into-nervos-dao is outdated
the active one is https://docs.nervos.org/docs/basics/guides/crypto%20wallets/neuron/#deposit-ckb-into-nervos-dao

Ref: https://github.com/nervosnetwork/neuron/issues/2435