### PR TITLE
feat: add 'contact us' in the menu -> help submenu

### DIFF
--- a/packages/neuron-wallet/src/controllers/app/menu.ts
+++ b/packages/neuron-wallet/src/controllers/app/menu.ts
@@ -404,27 +404,47 @@ const updateApplicationMenu = (mainWindow: BrowserWindow | null) => {
     {
       label: t('application-menu.help.contact-us'),
       click: async () => {
-        try {
-          await shell.openExternal(
-            `mailto:${ExternalURL.MailUs}?body=${encodeURIComponent(
-              t('application-menu.help.contact-us-message') as string
-            )}`
-          )
-        } catch {
-          dialog
-            .showMessageBox(BrowserWindow.getFocusedWindow()!, {
-              type: 'info',
-              message: t(`messageBox.fail-to-open-mail.message`),
-              buttons: [t(`messageBox.button.discard`), t(`messageBox.fail-to-open-mail.copy-mail-addr`)],
-              defaultId: 1,
-              cancelId: 0
-            })
-            .then(({ response }) => {
-              if (response === 1) {
+        const { response: methodId } = await dialog.showMessageBox(BrowserWindow.getFocusedWindow()!, {
+          type: 'info',
+          message: t(`messageBox.mail-us.message`),
+          buttons: [
+            t(`messageBox.button.discard`),
+            t(`messageBox.mail-us.copy-mail-addr`),
+            t(`messageBox.mail-us.open-client`)
+          ],
+          defaultId: 1,
+          cancelId: 0
+        })
+
+        switch (methodId) {
+          case 1: {
+            clipboard.writeText(ExternalURL.MailUs)
+            return
+          }
+          case 2: {
+            try {
+              await shell.openExternal(
+                `mailto:${ExternalURL.MailUs}?body=${encodeURIComponent(
+                  t('application-menu.help.contact-us-message') as string
+                )}`
+              )
+            } catch {
+              const { response: subMethodId } = await dialog.showMessageBox(BrowserWindow.getFocusedWindow()!, {
+                type: 'info',
+                message: t(`messageBox.mail-us.fail-message`),
+                buttons: [t(`messageBox.button.discard`), t(`messageBox.mail-us.copy-mail-addr`)],
+                defaultId: 1,
+                cancelId: 0
+              })
+              if (subMethodId === 1) {
                 clipboard.writeText(ExternalURL.MailUs)
-                return
               }
-            })
+            }
+            return
+          }
+          default: {
+            return
+          }
         }
       }
     },

--- a/packages/neuron-wallet/src/controllers/app/menu.ts
+++ b/packages/neuron-wallet/src/controllers/app/menu.ts
@@ -31,7 +31,8 @@ enum ExternalURL {
   Website = 'https://www.nervos.org/',
   Repository = 'https://github.com/nervosnetwork/neuron',
   Issues = 'https://github.com/nervosnetwork/neuron/issues',
-  Doc = 'https://docs.nervos.org/docs/basics/tools#neuron-wallet'
+  Doc = 'https://docs.nervos.org/docs/basics/tools#neuron-wallet',
+  MailUs = 'mailto:neuron@magickbase.com'
 }
 
 const separator: MenuItemConstructorOptions = {
@@ -398,6 +399,14 @@ const updateApplicationMenu = (mainWindow: BrowserWindow | null) => {
       label: t('application-menu.help.report-issue'),
       click: () => {
         shell.openExternal(ExternalURL.Issues)
+      }
+    },
+    {
+      label: t('application-menu.help.contact-us'),
+      click: () => {
+        shell.openExternal(
+          `${ExternalURL.MailUs}?body=${encodeURIComponent(t('application-menu.help.contact-us-message') as string)}`
+        )
       }
     },
     {

--- a/packages/neuron-wallet/src/locales/en.ts
+++ b/packages/neuron-wallet/src/locales/en.ts
@@ -199,8 +199,10 @@ export default {
         message:
           'In order to adapt to the latest version of CKB, Neuron will resynchronize the data on the chain, and the whole synchronization may take a long time.'
       },
-      'fail-to-open-mail': {
-        message:
+      'mail-us': {
+        message: 'Please mail us with debug information exported by "Menu" -> "Help" -> "Export Debug Information".',
+        'open-client': 'Open Mail Client',
+        'fail-message':
           'Unable to launch mail client, please copy the mail address, append debug information exported by "Menu" -> "Help" -> "Export Debug Information" and send us.',
         'copy-mail-addr': 'Copy mail address'
       }

--- a/packages/neuron-wallet/src/locales/en.ts
+++ b/packages/neuron-wallet/src/locales/en.ts
@@ -50,6 +50,9 @@ export default {
         'nervos-website': 'Nervos Website',
         'source-code': 'Source Code',
         'report-issue': 'Report Issue',
+        'contact-us': 'Contact Us',
+        'contact-us-message':
+          '> Please append debug information exported by "Menu" -> "Help" -> "Export Debug Information".',
         documentation: 'Documentation',
         settings: 'Settings',
         'export-debug-info': 'Export Debug Information'

--- a/packages/neuron-wallet/src/locales/en.ts
+++ b/packages/neuron-wallet/src/locales/en.ts
@@ -198,6 +198,10 @@ export default {
       'hard-fork-migrate': {
         message:
           'In order to adapt to the latest version of CKB, Neuron will resynchronize the data on the chain, and the whole synchronization may take a long time.'
+      },
+      'fail-to-open-mail': {
+        message: 'Unable to launch mail client, please copy the mail address',
+        'copy-mail-addr': 'Copy mail address'
       }
     },
     prompt: {

--- a/packages/neuron-wallet/src/locales/en.ts
+++ b/packages/neuron-wallet/src/locales/en.ts
@@ -200,7 +200,8 @@ export default {
           'In order to adapt to the latest version of CKB, Neuron will resynchronize the data on the chain, and the whole synchronization may take a long time.'
       },
       'fail-to-open-mail': {
-        message: 'Unable to launch mail client, please copy the mail address',
+        message:
+          'Unable to launch mail client, please copy the mail address, append debug information exported by "Menu" -> "Help" -> "Export Debug Information" and send us.',
         'copy-mail-addr': 'Copy mail address'
       }
     },

--- a/packages/neuron-wallet/src/locales/zh-tw.ts
+++ b/packages/neuron-wallet/src/locales/zh-tw.ts
@@ -50,6 +50,8 @@ export default {
         'nervos-website': 'Nervos 官方網站',
         'source-code': '原始程式碼',
         'report-issue': '回報問題',
+        'contact-us': '聯繫我們',
+        'contact-us-message': '> 請通過 "菜單" -> "幫助" -> "導出調試信息" 獲得 Neuron 的調試信息並附在郵件中.',
         documentation: '使用說明',
         settings: '設定',
         'export-debug-info': '導出除錯信息'

--- a/packages/neuron-wallet/src/locales/zh-tw.ts
+++ b/packages/neuron-wallet/src/locales/zh-tw.ts
@@ -188,8 +188,10 @@ export default {
       'hard-fork-migrate': {
         message: '為適配最新版本的 CKB 節點，Neuron 將會重新同步鏈上數據，整個同步可能時間較長'
       },
-      'fail-to-open-mail': {
-        message:
+      'mail-us': {
+        message: '請將問題及調試信息通過郵件發給我們, 調試信息可以通過 "菜單" -> "幫助" -> "導出調試信息" 獲得',
+        'open-client': '打開郵件客戶端',
+        'fail-message':
           '未能打開郵件客戶端, 請複製郵件地址, 並通過 "菜單" -> "幫助" -> "導出調試信息" 獲得 Neuron 的調試信息附在郵件中發送給我們',
         'copy-mail-addr': '複製郵件地址'
       }

--- a/packages/neuron-wallet/src/locales/zh-tw.ts
+++ b/packages/neuron-wallet/src/locales/zh-tw.ts
@@ -187,6 +187,10 @@ export default {
       },
       'hard-fork-migrate': {
         message: '為適配最新版本的 CKB 節點，Neuron 將會重新同步鏈上數據，整個同步可能時間較長'
+      },
+      'fail-to-open-mail': {
+        message: '未能打開郵件客戶端, 請複製郵件地址',
+        'copy-mail-addr': '複製郵件地址'
       }
     },
     prompt: {

--- a/packages/neuron-wallet/src/locales/zh-tw.ts
+++ b/packages/neuron-wallet/src/locales/zh-tw.ts
@@ -189,7 +189,8 @@ export default {
         message: '為適配最新版本的 CKB 節點，Neuron 將會重新同步鏈上數據，整個同步可能時間較長'
       },
       'fail-to-open-mail': {
-        message: '未能打開郵件客戶端, 請複製郵件地址',
+        message:
+          '未能打開郵件客戶端, 請複製郵件地址, 並通過 "菜單" -> "幫助" -> "導出調試信息" 獲得 Neuron 的調試信息附在郵件中發送給我們',
         'copy-mail-addr': '複製郵件地址'
       }
     },

--- a/packages/neuron-wallet/src/locales/zh.ts
+++ b/packages/neuron-wallet/src/locales/zh.ts
@@ -190,7 +190,8 @@ export default {
         message: '为适配最新版本的 CKB 节点，Neuron 将会重新同步链上数据，整个同步可能时间较长'
       },
       'fail-to-open-mail': {
-        message: '未能打开邮件客户端, 请复制邮件地址',
+        message:
+          '未能打开邮件客户端, 请复制邮件地址, 并通过 "菜单" -> "帮助" -> "导出调试信息" 获得 Neuron 的调试信息附在邮件中发送给我们',
         'copy-mail-addr': '复制邮件地址'
       }
     },

--- a/packages/neuron-wallet/src/locales/zh.ts
+++ b/packages/neuron-wallet/src/locales/zh.ts
@@ -50,6 +50,8 @@ export default {
         'nervos-website': 'Nervos 网站',
         'source-code': '源代码',
         'report-issue': '报告问题',
+        'contact-us': '联系我们',
+        'contact-us-message': '> 请通过 "菜单" -> "帮助" -> "导出调试信息" 获得 Neuron 的调试信息并附在邮件中.',
         documentation: '使用文档',
         settings: '设置',
         'export-debug-info': '导出调试信息'

--- a/packages/neuron-wallet/src/locales/zh.ts
+++ b/packages/neuron-wallet/src/locales/zh.ts
@@ -188,6 +188,10 @@ export default {
       },
       'hard-fork-migrate': {
         message: '为适配最新版本的 CKB 节点，Neuron 将会重新同步链上数据，整个同步可能时间较长'
+      },
+      'fail-to-open-mail': {
+        message: '未能打开邮件客户端, 请复制邮件地址',
+        'copy-mail-addr': '复制邮件地址'
       }
     },
     prompt: {

--- a/packages/neuron-wallet/src/locales/zh.ts
+++ b/packages/neuron-wallet/src/locales/zh.ts
@@ -189,8 +189,10 @@ export default {
       'hard-fork-migrate': {
         message: '为适配最新版本的 CKB 节点，Neuron 将会重新同步链上数据，整个同步可能时间较长'
       },
-      'fail-to-open-mail': {
-        message:
+      'mail-us': {
+        message: '请将问题及调试信息通过邮件发给我们, 调试信息可以通过 "菜单" -> "帮助" -> "导出调试信息" 获得',
+        'open-client': '打开邮件客户端',
+        'fail-message':
           '未能打开邮件客户端, 请复制邮件地址, 并通过 "菜单" -> "帮助" -> "导出调试信息" 获得 Neuron 的调试信息附在邮件中发送给我们',
         'copy-mail-addr': '复制邮件地址'
       }


### PR DESCRIPTION
This PR adds an extra contact method via mail for users who
are not programmers and don't know GitHub.

A sub-menu named 'Contact Us' is added in "Menu -> Help" that
invokes a local mail client to send help request to
"neuron@magickbase.com"

![image](https://user-images.githubusercontent.com/7271329/179479080-8f6d3dd0-c9ee-40a2-8d72-8efa8e498853.png)
![image](https://user-images.githubusercontent.com/7271329/179479086-b220be4e-bb1f-4fe0-94f4-1f53815b3724.png)
![image](https://user-images.githubusercontent.com/7271329/179897558-e23467d4-ca35-47f0-9d20-f6a9b778fd90.png)
![image](https://user-images.githubusercontent.com/7271329/179897569-8c6843ed-aab3-4b61-9296-cd172e6d8452.png)


Ref: https://github.com/Magickbase/neuron-public-issues/issues/30