### PR TITLE
fix: Fix ckb process kill unexpected.

### DIFF
--- a/packages/neuron-wallet/src/controllers/api.ts
+++ b/packages/neuron-wallet/src/controllers/api.ts
@@ -496,7 +496,7 @@ export default class ApiController {
     })
 
     handle('stop-process-monitor', async (_, monitorName: string) => {
-      await stopMonitor(monitorName)
+      await Promise.race([stopMonitor(monitorName), CommonUtils.sleep(1000)])
       return {
         status: ResponseCode.Success,
       }

--- a/packages/neuron-wallet/src/services/ckb-runner.ts
+++ b/packages/neuron-wallet/src/services/ckb-runner.ts
@@ -114,7 +114,7 @@ export const stopCkbNode = () => {
     if (ckb) {
       logger.info('CKB:\tkilling node')
       ckb.once('close', () => resolve())
-      ckb.kill()
+      ckb.kill(2)
       ckb = null
     } else {
       resolve()


### PR DESCRIPTION
1. Sometime ckb process does not emit close after calling` ckb.kill`, so wait 1 second when stop process monitor.
2. Use kill(2) to replace kill(), [kill(2)](https://man7.org/linux/man-pages/man7/signal.7.html) means `Sends a signal to a specified process, to all members of a specified process group, or to all processes on the system`.