### PR TITLE
fix: Use batch rpc to request result. Optimization sql search.

### DIFF
--- a/packages/neuron-ui/src/components/NervosDAO/hooks.ts
+++ b/packages/neuron-ui/src/components/NervosDAO/hooks.ts
@@ -451,9 +451,7 @@ export const useUpdateWithdrawList = ({
       .then(txs => {
         const committedTx = txs.filter(v => v.txStatus.status === 'committed')
         committedTx.forEach((tx, idx) => {
-          if (tx.txStatus.status === 'committed') {
-            txMap.set(depositOutPointHashes[idx], tx)
-          }
+          txMap.set(depositOutPointHashes[idx], tx)
         })
         const blockHashes = [
           ...(committedTx.map(v => v.txStatus.blockHash).filter(v => !!v) as string[]),
@@ -468,9 +466,7 @@ export const useUpdateWithdrawList = ({
           .exec()
           .then(blockHeaders => {
             blockHeaders.forEach((header, idx) => {
-              if (header?.dao) {
-                hashHeaderMap.set(blockHashes[idx], header.dao)
-              }
+              hashHeaderMap.set(blockHashes[idx], header.dao)
             })
             const withdrawList = new Map()
             records.forEach(record => {

--- a/packages/neuron-ui/src/components/NervosDAO/hooks.ts
+++ b/packages/neuron-ui/src/components/NervosDAO/hooks.ts
@@ -20,8 +20,9 @@ import {
   generateDaoDepositTx,
   generateDaoClaimTx,
 } from 'services/remote'
-import { ckbCore, getHeaderByNumber, calculateDaoMaximumWithdraw } from 'services/chain'
+import { ckbCore, getHeaderByNumber } from 'services/chain'
 import { isErrorWithI18n } from 'exceptions'
+import { calculateMaximumWithdraw } from '@nervosnetwork/ckb-sdk-utils'
 
 const {
   MIN_AMOUNT,
@@ -91,7 +92,7 @@ export const useInitData = ({
     updateNervosDaoData({ walletID: wallet.id })(dispatch)
     const intervalId = setInterval(() => {
       updateNervosDaoData({ walletID: wallet.id })(dispatch)
-    }, 3000)
+    }, 10000)
     updateDepositValue(
       `${
         BigInt(wallet.balance) > BigInt(CKBToShannonFormatter(`${MIN_DEPOSIT_AMOUNT}`))
@@ -436,35 +437,79 @@ export const useUpdateWithdrawList = ({
   setWithdrawList: React.Dispatch<React.SetStateAction<Map<string, string | null>>>
 }) =>
   useEffect(() => {
-    Promise.all(
-      records.map(async ({ outPoint, depositOutPoint, blockHash }) => {
-        if (!tipBlockHash) {
-          return null
-        }
-        const withdrawBlockHash = depositOutPoint ? blockHash : tipBlockHash
-        const formattedDepositOutPoint = depositOutPoint
-          ? {
-              txHash: depositOutPoint.txHash,
-              index: `0x${BigInt(depositOutPoint.index).toString(16)}`,
-            }
-          : {
-              txHash: outPoint.txHash,
-              index: `0x${BigInt(outPoint.index).toString(16)}`,
-            }
-        return calculateDaoMaximumWithdraw(formattedDepositOutPoint, withdrawBlockHash).catch(() => null)
-      })
-    )
-      .then(res => {
-        const withdrawList = new Map()
-        if (tipBlockHash) {
-          records.forEach((record, idx) => {
-            const key = getRecordKey(record)
-            withdrawList.set(key, res[idx])
+    if (!tipBlockHash) {
+      setWithdrawList(new Map())
+      return
+    }
+    const depositOutPointHashes = records.map(v => v.depositOutPoint?.txHash ?? v.outPoint.txHash)
+    const txMap = new Map<CKBComponents.Hash, CKBComponents.TransactionWithStatus>()
+    ckbCore.rpc
+      .createBatchRequest<'getTransaction', string[], CKBComponents.TransactionWithStatus[]>(
+        depositOutPointHashes.map(v => ['getTransaction', v])
+      )
+      .exec()
+      .then(txs => {
+        const committedTx = txs.filter(v => v.txStatus.status === 'committed')
+        committedTx.forEach((tx, idx) => {
+          if (tx.txStatus.status === 'committed') {
+            txMap.set(depositOutPointHashes[idx], tx)
+          }
+        })
+        const blockHashes = [
+          ...(committedTx.map(v => v.txStatus.blockHash).filter(v => !!v) as string[]),
+          ...(records.map(v => (v.depositOutPoint ? v.blockHash : null)).filter(v => !!v) as string[]),
+          tipBlockHash,
+        ]
+        const hashHeaderMap = new Map<CKBComponents.Hash, string>()
+        return ckbCore.rpc
+          .createBatchRequest<'getHeader', string[], CKBComponents.BlockHeader[]>(
+            blockHashes.map(v => ['getHeader', v])
+          )
+          .exec()
+          .then(blockHeaders => {
+            blockHeaders.forEach((header, idx) => {
+              if (header?.dao) {
+                hashHeaderMap.set(blockHashes[idx], header.dao)
+              }
+            })
+            const withdrawList = new Map()
+            records.forEach(record => {
+              const key = getRecordKey(record)
+              const withdrawBlockHash = record.depositOutPoint ? record.blockHash : tipBlockHash
+              const formattedDepositOutPoint = record.depositOutPoint
+                ? {
+                    txHash: record.depositOutPoint.txHash,
+                    index: `0x${BigInt(record.depositOutPoint.index).toString(16)}`,
+                  }
+                : {
+                    txHash: record.outPoint.txHash,
+                    index: `0x${BigInt(record.outPoint.index).toString(16)}`,
+                  }
+              const tx = txMap.get(formattedDepositOutPoint.txHash)
+              if (!tx) {
+                return
+              }
+              const depositDAO = hashHeaderMap.get(tx.txStatus.blockHash!)
+              const withdrawDAO = hashHeaderMap.get(withdrawBlockHash)
+              if (!depositDAO || !withdrawDAO) {
+                return
+              }
+              withdrawList.set(
+                key,
+                calculateMaximumWithdraw(
+                  tx.transaction.outputs[+formattedDepositOutPoint.index],
+                  tx.transaction.outputsData[+formattedDepositOutPoint.index],
+                  depositDAO,
+                  withdrawDAO
+                )
+              )
+            })
+            setWithdrawList(withdrawList)
           })
-        }
-        setWithdrawList(withdrawList)
       })
-      .catch(console.error)
+      .catch(() => {
+        setWithdrawList(new Map())
+      })
   }, [records, tipBlockHash, setWithdrawList])
 
 export const useUpdateDepositEpochList = ({
@@ -478,24 +523,28 @@ export const useUpdateDepositEpochList = ({
 }) =>
   useEffect(() => {
     if (connectionStatus === 'online') {
-      Promise.all(
-        records.map(({ daoData, depositOutPoint, blockNumber }) => {
-          const depositBlockNumber = depositOutPoint ? ckbCore.utils.toUint64Le(daoData) : blockNumber
-          if (!depositBlockNumber) {
-            return null
-          }
-          return getHeaderByNumber(BigInt(depositBlockNumber))
-            .then(header => header.epoch)
-            .catch(() => null)
-        })
-      ).then(res => {
-        const epochList = new Map()
-        records.forEach((record, idx) => {
-          const key = getRecordKey(record)
-          epochList.set(key, res[idx])
-        })
-        setDepositEpochList(epochList)
+      const recordKeyIdxMap = new Map<string, number>()
+      const batchParams: ['getHeaderByNumber', bigint][] = []
+      records.forEach((record, idx) => {
+        const depositBlockNumber = record.depositOutPoint
+          ? ckbCore.utils.toUint64Le(record.daoData)
+          : record.blockNumber
+        if (depositBlockNumber) {
+          batchParams.push(['getHeaderByNumber', BigInt(depositBlockNumber)])
+          recordKeyIdxMap.set(getRecordKey(record), idx)
+        }
       })
+      ckbCore.rpc
+        .createBatchRequest<'getHeaderByNumber', any, CKBComponents.BlockHeader[]>(batchParams)
+        .exec()
+        .then(res => {
+          const epochList = new Map()
+          records.forEach(record => {
+            const key = getRecordKey(record)
+            epochList.set(key, recordKeyIdxMap.get(key) ? res[recordKeyIdxMap.get(key)!]?.epoch : null)
+          })
+          setDepositEpochList(epochList)
+        })
     }
   }, [records, setDepositEpochList, connectionStatus])
 

--- a/packages/neuron-wallet/src/services/cells.ts
+++ b/packages/neuron-wallet/src/services/cells.ts
@@ -131,7 +131,7 @@ export default class CellsService {
     return uniqueLockArgs
   }
 
-  private static async addUnLockInfo(cells: Cell[]): Promise<Cell[]> {
+  private static async addUnlockInfo(cells: Cell[]): Promise<Cell[]> {
     // find unlock info
     const unlockTxHashes: string[] = cells
       .filter(v => v.outPoint && (v.status === OutputStatus.Dead || v.status === OutputStatus.Pending))
@@ -247,7 +247,7 @@ export default class CellsService {
       return cell
     })
 
-    await Promise.all([CellsService.addDepositInfo(cells), CellsService.addUnLockInfo(cells)])
+    await Promise.all([CellsService.addDepositInfo(cells), CellsService.addUnlockInfo(cells)])
 
     return cells
   }

--- a/packages/neuron-wallet/src/services/cells.ts
+++ b/packages/neuron-wallet/src/services/cells.ts
@@ -131,6 +131,65 @@ export default class CellsService {
     return uniqueLockArgs
   }
 
+  private static async addUnLockInfo(cells: Cell[]): Promise<Cell[]> {
+    // find unlock info
+    const unlockTxHashes: string[] = cells
+      .filter(v => v.outPoint && (v.status === OutputStatus.Dead || v.status === OutputStatus.Pending))
+      .map(o => o.outPoint!.txHash)
+    const inputs: InputEntity[] = await getConnection()
+      .getRepository(InputEntity)
+      .createQueryBuilder('input')
+      .leftJoinAndSelect('input.transaction', 'tx')
+      .where({
+        outPointTxHash: In(unlockTxHashes)
+      })
+      .getMany()
+    const unlockTxMap = new Map<string, TransactionEntity>()
+    inputs.forEach(i => {
+      const key = i.outPointTxHash + ':' + i.outPointIndex
+      unlockTxMap.set(key, i.transaction!)
+    })
+    cells.forEach(cell => {
+      // if unlocked, set unlockInfo
+      const key = cell.outPoint?.txHash + ':' + cell.outPoint?.index
+      const unlockTx = key ? unlockTxMap.get(key) : undefined
+      if (unlockTx && (cell.status === OutputStatus.Dead || cell.status === OutputStatus.Pending)) {
+        cell.setUnlockInfo({
+          txHash: unlockTx.hash,
+          timestamp: unlockTx.timestamp!
+        })
+      }
+    })
+    return cells
+  }
+
+  private static async addDepositInfo(cells: Cell[]): Promise<Cell[]> {
+    // find deposit info
+    const depositTxHashes = cells.map(cells => cells.depositOutPoint?.txHash).filter(hash => !!hash)
+    const depositTxs = await getConnection()
+      .getRepository(TransactionEntity)
+      .createQueryBuilder('tx')
+      .where({
+        hash: In(depositTxHashes)
+      })
+      .getMany()
+    const depositTxMap = new Map<string, TransactionEntity>()
+    depositTxs.forEach(tx => {
+      depositTxMap.set(tx.hash, tx)
+    })
+    cells.forEach(cell => {
+      if (cell.depositOutPoint?.txHash && depositTxMap.has(cell.depositOutPoint.txHash)) {
+        const depositTx = depositTxMap.get(cell.depositOutPoint.txHash)!
+        cell.setDepositTimestamp(depositTx.timestamp!)
+        cell.setDepositInfo({
+          txHash: depositTx.hash,
+          timestamp: depositTx.timestamp!
+        })
+      }
+    })
+    return cells
+  }
+
   public static async getDaoCells(walletId: string): Promise<Cell[]> {
     const outputs: OutputEntity[] = await getConnection()
       .getRepository(OutputEntity)
@@ -169,36 +228,6 @@ export default class CellsService {
       .addOrderBy('tx.timestamp', 'ASC')
       .getMany()
 
-    // find deposit info
-    const depositTxHashes = outputs.map(output => output.depositTxHash).filter(hash => !!hash)
-    const depositTxs = await getConnection()
-      .getRepository(TransactionEntity)
-      .createQueryBuilder('tx')
-      .where({
-        hash: In(depositTxHashes)
-      })
-      .getMany()
-    const depositTxMap = new Map<string, TransactionEntity>()
-    depositTxs.forEach(tx => {
-      depositTxMap.set(tx.hash, tx)
-    })
-
-    // find unlock info
-    const unlockTxKeys: string[] = outputs.map(o => o.outPointTxHash + ':' + o.outPointIndex)
-    const inputs: InputEntity[] = await getConnection()
-      .getRepository(InputEntity)
-      .createQueryBuilder('input')
-      .leftJoinAndSelect('input.transaction', 'tx')
-      .where(`input.outPointTxHash || ':' || input.outPointIndex IN (:...infos)`, {
-        infos: unlockTxKeys
-      })
-      .getMany()
-    const unlockTxMap = new Map<string, TransactionEntity>()
-    inputs.forEach(i => {
-      const key = i.outPointTxHash + ':' + i.outPointIndex
-      unlockTxMap.set(key, i.transaction!)
-    })
-
     const cells: Cell[] = outputs.map(output => {
       const cell = output.toModel()
       if (!output.depositTxHash) {
@@ -208,34 +237,17 @@ export default class CellsService {
           timestamp: output.transaction!.timestamp!
         })
       } else {
-        // if not deposit cell, set deposit timestamp info, depositInfo, withdrawInfo
-        const depositTx = depositTxMap.get(output.depositTxHash)!
-        cell.setDepositTimestamp(depositTx.timestamp!)
-
-        cell.setDepositInfo({
-          txHash: depositTx.hash,
-          timestamp: depositTx.timestamp!
-        })
-
+        // if not deposit cell, set withdrawInfo
         const withdrawTx = output.transaction
         cell.setWithdrawInfo({
           txHash: withdrawTx!.hash,
           timestamp: withdrawTx!.timestamp!
         })
-
-        if (output.status === OutputStatus.Dead || output.status === OutputStatus.Pending) {
-          // if unlocked, set unlockInfo
-          const key = output.outPointTxHash + ':' + output.outPointIndex
-          const unlockTx = unlockTxMap.get(key)!
-          cell.setUnlockInfo({
-            txHash: unlockTx.hash,
-            timestamp: unlockTx.timestamp!
-          })
-        }
       }
-
       return cell
     })
+
+    await Promise.all([CellsService.addDepositInfo(cells), CellsService.addUnLockInfo(cells)])
 
     return cells
   }

--- a/packages/neuron-wallet/src/services/tx/transaction-service.ts
+++ b/packages/neuron-wallet/src/services/tx/transaction-service.ts
@@ -484,16 +484,22 @@ export class TransactionsService {
       .createQueryBuilder('transaction')
       .where('transaction.hash is :hash', { hash })
       .leftJoinAndSelect('transaction.inputs', 'input')
-      .leftJoinAndSelect('transaction.outputs', 'output')
       .orderBy({
         'input.id': 'ASC'
       })
+      .getOne()
+    const txwithOutput = await getConnection()
+      .getRepository(TransactionEntity)
+      .createQueryBuilder('transaction')
+      .where('transaction.hash is :hash', { hash })
+      .leftJoinAndSelect('transaction.outputs', 'output')
       .getOne()
 
     if (!tx) {
       return undefined
     }
 
+    tx.outputs = txwithOutput?.outputs || []
     return tx.toModel()
   }
 

--- a/packages/neuron-wallet/src/services/tx/transaction-service.ts
+++ b/packages/neuron-wallet/src/services/tx/transaction-service.ts
@@ -488,18 +488,19 @@ export class TransactionsService {
         'input.id': 'ASC'
       })
       .getOne()
-    const txwithOutput = await getConnection()
-      .getRepository(TransactionEntity)
-      .createQueryBuilder('transaction')
-      .where('transaction.hash is :hash', { hash })
-      .leftJoinAndSelect('transaction.outputs', 'output')
-      .getOne()
+    const txOutpus = await getConnection()
+      .getRepository(OutputEntity)
+      .createQueryBuilder()
+      .where({
+        outPointTxHash: hash
+      })
+      .getMany()
 
     if (!tx) {
       return undefined
     }
 
-    tx.outputs = txwithOutput?.outputs || []
+    tx.outputs = txOutpus
     return tx.toModel()
   }
 

--- a/packages/neuron-wallet/src/services/tx/transaction-service.ts
+++ b/packages/neuron-wallet/src/services/tx/transaction-service.ts
@@ -488,7 +488,7 @@ export class TransactionsService {
         'input.id': 'ASC'
       })
       .getOne()
-    const txOutpus = await getConnection()
+    const txOutputs = await getConnection()
       .getRepository(OutputEntity)
       .createQueryBuilder()
       .where({
@@ -500,7 +500,7 @@ export class TransactionsService {
       return undefined
     }
 
-    tx.outputs = txOutpus
+    tx.outputs = txOutputs
     return tx.toModel()
   }
 


### PR DESCRIPTION
1. For the nerovs dao page, there are many rpc requests, use batch request.
2. Because some users have many relations with others cells, left join twice to search inputs and outputs.
3. Find unlock transactions with the status that equal Dead or Pending.