### PR TITLE
Fix:resolve cannot open electron window automatically after update node version to v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bootstrap": "npx cross-env lerna bootstrap && lerna link",
     "start:ui": "cd packages/neuron-ui && yarn run start",
     "start:wallet": "cd packages/neuron-wallet && yarn run start:debug",
-    "start": "concurrently \"cross-env BROWSER=none yarn run start:ui\" \"wait-on http://localhost:3000 && yarn run start:wallet\"",
+    "start": "concurrently \"cross-env BROWSER=none yarn run start:ui\" \"wait-on http://127.0.0.1:3000 && yarn run start:wallet\"",
     "clean": "lerna run --stream clean",
     "prebuild": "yarn clean",
     "build": "lerna run --stream build",

--- a/packages/neuron-ui/src/widgets/GlobalDialog/index.tsx
+++ b/packages/neuron-ui/src/widgets/GlobalDialog/index.tsx
@@ -20,7 +20,7 @@ const RebuildSync = ({ onDismiss, onOk }: { onDismiss: React.MouseEventHandler; 
     <div style={{ fontWeight: 200 }}>
       {t('messages.rebuild-sync')
         .split('\n')
-        .map(s => (
+        .map((s: string) => (
           <p key={s}>{s}</p>
         ))}
       <div style={{ textAlign: 'right' }}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10877,10 +10877,10 @@ eslint@8.25.0:
     strip-json-comments "^3.1.0"
     text-table "^0.2.0"
 
-eslint@8.27.0:
-  version "8.27.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.27.0.tgz#d547e2f7239994ad1faa4bb5d84e5d809db7cf64"
-  integrity sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==
+eslint@8.28.0:
+  version "8.28.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.28.0.tgz#81a680732634677cc890134bcdd9fdfea8e63d6e"
+  integrity sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==
   dependencies:
     "@eslint/eslintrc" "^1.3.3"
     "@humanwhocodes/config-array" "^0.11.6"


### PR DESCRIPTION
What problem does this PR solve?
------
After updating our node version to v18, we got a problem that the neuron client cannot be opened automatically.

Ref: https://github.com/Magickbase/neuron-public-issues/issues/80

before: 
<img width="500" alt="image" src="https://user-images.githubusercontent.com/22511289/204983906-fbfe8622-d284-46c4-8d31-aacbd426dfa8.png">

after:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/22511289/204984033-97cab38a-93ae-4ea4-94e9-7b67ecb9371c.png">


Check List
------

### Test
e2e Test
### Task
none
