### PR TITLE
fix: Fix send multisig tx when input cell's length is more than 1. 

### DIFF
--- a/packages/neuron-ui/src/components/PasswordRequest/index.tsx
+++ b/packages/neuron-ui/src/components/PasswordRequest/index.tsx
@@ -25,6 +25,7 @@ import {
   OfflineSignType,
   signAndExportTransaction,
   requestOpenInExplorer,
+  invokeShowErrorMessage,
 } from 'services/remote'
 import { PasswordIncorrectException } from 'exceptions'
 import DropdownButton from 'widgets/DropdownButton'
@@ -144,11 +145,16 @@ const PasswordRequest = () => {
               break
             }
             await sendTransaction({ walletID, tx: generatedTx, description, password, multisigConfig })(dispatch).then(
-              (res: { result: string; status: number }) => {
+              (res: { result: string; status: number; message: string | { content: string } }) => {
                 if (isSuccessResponse(res)) {
                   requestOpenInExplorer({ type: 'transaction', key: res.result })
                 } else if (res.status === ErrorCode.PasswordIncorrect) {
                   throw new PasswordIncorrectException()
+                } else {
+                  invokeShowErrorMessage({
+                    title: t('messages.error'),
+                    content: typeof res.message === 'string' ? res.message : res.message.content!,
+                  })
                 }
               }
             )

--- a/packages/neuron-wallet/src/services/transaction-sender.ts
+++ b/packages/neuron-wallet/src/services/transaction-sender.ts
@@ -293,9 +293,6 @@ export default class TransactionSender {
       const lockArgs: string = input.lock!.args!
       const wit: WitnessArgs | string = tx.witnesses[index]
       const witnessArgs: WitnessArgs = wit instanceof WitnessArgs ? wit : WitnessArgs.generateEmpty()
-      if (typeof wit === 'string' && wit.length) {
-        witnessArgs.lock = wit
-      }
       return {
         witnessArgs,
         lockHash: input.lockHash!,

--- a/packages/neuron-wallet/tests/services/tx/transaction-sender.test.ts
+++ b/packages/neuron-wallet/tests/services/tx/transaction-sender.test.ts
@@ -995,6 +995,47 @@ describe('TransactionSender Test', () => {
           expect(res.witnesses[0]).toBe(expectedValue)
         })
       })
+
+      it(`input cell's length is 2`, async() => {
+        const addresses = [
+          'ckt1qyq89x5ggpt0a5epm2k2gyxeffwkgfdxeg0s543mh4',
+          'ckt1qyqql0vgjyxjxjxknkj6nq8jxa485xsyl66sy7c5f6'
+        ]
+        const [multiArgs, multisigConfig] = createMultisigConfig(1, 1, addresses)
+        const addr = {
+          walletId: fakeWallet.id,
+          path: `m/44'/309'/0'/0/0`,
+          blake160: addressToScript(addresses[0]).args,
+          version: 'testnet'
+        }
+
+        const mockGAI = jest.fn()
+        mockGAI.mockReturnValueOnce([addr])
+        transactionSender.getAddressInfos = mockGAI.bind(transactionSender)
+        const tx = Transaction.fromObject(transcationObject)
+        tx.inputs[0]!.setLock(SystemScriptInfo.generateMultiSignScript(multiArgs))
+        tx.inputs.push(
+          Input.fromObject({
+            previousOutput: OutPoint.fromObject({
+              txHash: '0x1879851943fa686af29bed5c95acd566d0244e7b3ca89cf7c435622a5a5b4cb3',
+              index: '0x0'
+            }),
+            since: '0x0',
+            lock: Script.fromObject({
+              args: multiArgs,
+              codeHash: SystemScriptInfo.MULTI_SIGN_CODE_HASH,
+              hashType: SystemScriptInfo.MULTI_SIGN_HASH_TYPE
+            })
+          })
+        )
+        tx.witnesses = ['0x', '0x']
+        const res = await transactionSender.signMultisig(fakeWallet.id, tx, '1234', [multisigConfig])
+        expect(res.witnesses).toHaveLength(2)
+        expect(res.witnesses[1]).toBe('0x')
+        expect(res.witnesses[0]).toBe(
+          '0x810000001000000081000000810000006d00000000010102729a884056fed321daaca410d94a5d6425a6ca1f0fbd88910d2348d69da5a980f2376a7a1a04feb595163e5edf15f297453a64f3248c69823afcfdaabc6771b088e4f6250e2e2f91136f5c6a9cbf49a79d955644d7381481f3c5c8ab93bcc52a71de4b072e0697c001'
+        )
+      })
     })
   })
 })


### PR DESCRIPTION
…2450)

* fix: Same group cell witness should be 0x. If witness's lock set as 0x. it will be serialized that not equal 0x

* fix: If some unexpected error happen, it should display

* fix: Fix send multisig tx when input cell's length is more than 1.

same group cell witness should be 0x. If witness's lock set as 0x. it will be serialized that not equal 0x

* fix: If some unexpected error happen, it should display

Co-authored-by: Cedar <cedarfortest@gmail.com>