### PR TITLE
Release v0.103.3

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -43,7 +43,7 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-          key: 2022-05-07-${{ runner.os }}-${{ hashFiles('**/yarn.lock')}}
+          key: 2022-12-21-${{ runner.os }}-${{ hashFiles('**/yarn.lock')}}
 
       - name: Add msbuild to PATH
         if: matrix.os == 'windows-2019'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,7 +14,7 @@ jobs:
         node:
           - 16.10.0
         os:
-          - macos-latest
+          - macos-11
           - ubuntu-20.04
           - windows-2019
 
@@ -67,7 +67,7 @@ jobs:
           CI: false
 
       - name: Package for MacOS
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-11'
         run: |
           ./scripts/download-ckb.sh mac
           yarn release mac
@@ -99,14 +99,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Neuron App Zip
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-11'
         uses: actions/upload-artifact@v2
         with:
           name: Neuron-Mac
           path: release/Neuron-*-mac.zip
 
       - name: Upload Neuron Dmg
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-11'
         uses: actions/upload-artifact@v2
         with:
           name: Neuron-Dmg

--- a/.github/workflows/package_for_test.yml
+++ b/.github/workflows/package_for_test.yml
@@ -38,7 +38,7 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-          key: 2022-05-07-${{ runner.os }}-${{ hashFiles('**/yarn.lock')}}
+          key: 2022-12-21-${{ runner.os }}-${{ hashFiles('**/yarn.lock')}}
 
       - name: Add msbuild to PATH
         if: matrix.os == 'windows-2019'

--- a/.github/workflows/package_for_test.yml
+++ b/.github/workflows/package_for_test.yml
@@ -9,7 +9,7 @@ jobs:
         node:
           - 16.10.0
         os:
-          - macos-latest
+          - macos-11
           - ubuntu-20.04
           - windows-2019
 
@@ -62,7 +62,7 @@ jobs:
           CI: false
 
       - name: Package for MacOS
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-11'
         run: |
           ./scripts/download-ckb.sh mac
           yarn package:test mac
@@ -94,14 +94,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Neuron App Zip
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-11'
         uses: actions/upload-artifact@v2
         with:
           name: Neuron-Mac
           path: release/Neuron-*-mac.zip
 
       - name: Upload Neuron Dmg
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-11'
         uses: actions/upload-artifact@v2
         with:
           name: Neuron-Dmg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 0.103.3 (2022-12-21)
+
+### Certificate
+
+We've updated the certificate of Neuron for windows, which is issued by **DigiCert** and distributed to [Magickbase](https://github.com/Magickbase/), the active developer team of Neuron. With this update, a warning may appear on updating Neuron by `check for update` inside Neuron, please don't worry and download Neuron from [GitHub Release](https://github.com/nervosnetwork/neuron/releases) to adopt the new certificate.
+
+### Bug Fixes
+
+* #2551: Fix sending multisig tx when input cell's length is greater than 1.(@yanguoyu)
+
+
+**Full Changelog**: https://github.com/nervosnetwork/neuron/compare/v0.103.2...v0.103.3
+
+
+
 # 0.103.2 (2022-07-09)
 
 ### New features

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.103.2",
+  "version": "0.103.3",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/neuron-ui/package.json
+++ b/packages/neuron-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neuron-ui",
-  "version": "0.103.2",
+  "version": "0.103.3",
   "private": true,
   "author": {
     "name": "Nervos Core Dev",

--- a/packages/neuron-ui/src/components/PasswordRequest/index.tsx
+++ b/packages/neuron-ui/src/components/PasswordRequest/index.tsx
@@ -25,6 +25,7 @@ import {
   OfflineSignType,
   signAndExportTransaction,
   requestOpenInExplorer,
+  invokeShowErrorMessage,
 } from 'services/remote'
 import { PasswordIncorrectException } from 'exceptions'
 import DropdownButton from 'widgets/DropdownButton'
@@ -152,11 +153,16 @@ const PasswordRequest = () => {
               break
             }
             await sendTransaction({ walletID, tx: generatedTx, description, password, multisigConfig })(dispatch).then(
-              (res: { result: string; status: number }) => {
+              (res: { result: string; status: number; message: string | { content: string } }) => {
                 if (isSuccessResponse(res)) {
                   requestOpenInExplorer({ type: 'transaction', key: res.result })
                 } else if (res.status === ErrorCode.PasswordIncorrect) {
                   throw new PasswordIncorrectException()
+                } else {
+                  invokeShowErrorMessage({
+                    title: t('messages.error'),
+                    content: typeof res.message === 'string' ? res.message : res.message.content!,
+                  })
                 }
               }
             )

--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -3,7 +3,7 @@
   "productName": "Neuron",
   "description": "CKB Neuron Wallet",
   "homepage": "https://www.nervos.org/",
-  "version": "0.103.2",
+  "version": "0.103.3",
   "private": true,
   "author": {
     "name": "Nervos Core Dev",
@@ -91,7 +91,7 @@
     "eslint-plugin-prettier": "3.1.1",
     "jest-when": "2.7.2",
     "lint-staged": "9.2.5",
-    "neuron-ui": "0.103.2",
+    "neuron-ui": "0.103.3",
     "prettier": "1.19.1",
     "rimraf": "3.0.0",
     "ttypescript": "1.5.10",

--- a/packages/neuron-wallet/src/services/transaction-sender.ts
+++ b/packages/neuron-wallet/src/services/transaction-sender.ts
@@ -293,9 +293,6 @@ export default class TransactionSender {
       const lockArgs: string = input.lock!.args!
       const wit: WitnessArgs | string = tx.witnesses[index]
       const witnessArgs: WitnessArgs = wit instanceof WitnessArgs ? wit : WitnessArgs.generateEmpty()
-      if (typeof wit === 'string' && wit.length) {
-        witnessArgs.lock = wit
-      }
       return {
         witnessArgs,
         lockHash: input.lockHash!,


### PR DESCRIPTION
# 0.103.3 (2022-12-21)

### Certificate

We've updated the certificate of Neuron for windows, which is issued by **DigiCert** and distributed to [Magickbase](https://github.com/Magickbase/), the active developer team of Neuron. With this update, a warning may appear on updating Neuron by `check for update` inside Neuron, please don't worry and download Neuron from [GitHub Release](https://github.com/nervosnetwork/neuron/releases) to adopt the new certificate.

### Bug Fixes

* #2551: Fix sending multisig tx when input cell's length is greater than 1.(@yanguoyu)


**Full Changelog**: https://github.com/nervosnetwork/neuron/compare/v0.103.2...v0.103.3