### PR TITLE
ci: add github action to manage stale issues

### DIFF
--- a/.github/workflows/update-issue-status.yml
+++ b/.github/workflows/update-issue-status.yml
@@ -1,0 +1,20 @@
+name: Update issue status
+on:
+  schedule:
+    - cron: '30 5 * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update stale issues
+        uses: actions/stale@v7
+        with:
+          any-of-issue-labels: replied
+          days-before-pr-close: -1
+          stale-issue-message: Mark this issue stale because no activity for 60 days
+          close-issue-message: Close this issue because it's inactive since marked stale
+          close-issue-reason: inactive


### PR DESCRIPTION
Add a github action to manage stale issues,
a replied issue will be marked stale if no
activity for 60 days and closed after 7 days
without updates.

The task is set to run on UTC 5:30 everyday

Ref: https://github.com/Magickbase/neuron-public-issues/issues/94