### PR TITLE
fix: fix close-issue-reason in close stale issue action

### DIFF
--- a/.github/workflows/update-issue-status.yml
+++ b/.github/workflows/update-issue-status.yml
@@ -18,4 +18,4 @@ jobs:
           days-before-pr-close: -1
           stale-issue-message: Mark this issue stale because no activity for 60 days
           close-issue-message: Close this issue because it's inactive since marked stale
-          close-issue-reason: inactive
+          close-issue-reason: completed


### PR DESCRIPTION
The option close-issue-reason is an enum of completed and 
not_planned. I missed it and set it to a custom value which led 
to ci failure.

Ref: https://github.com/marketplace/actions/close-stale-issues#close-issue-reason