### PR TITLE
fix: Sometimes RPC timeout but ckb is living

### DIFF
--- a/packages/neuron-wallet/src/services/ckb-runner.ts
+++ b/packages/neuron-wallet/src/services/ckb-runner.ts
@@ -67,6 +67,10 @@ let lastLogTime: number
 export const getLookingValidTargetStatus = () => isLookingValidTarget
 
 export const startCkbNode = async () => {
+  if (ckb !== null) {
+    logger.info(`CKB:\tckb is not closed, close it before start...`)
+    await stopCkbNode()
+  }
   await initCkb()
 
   logger.info('CKB:\tstarting node...')

--- a/packages/neuron-wallet/src/services/monitor/base.ts
+++ b/packages/neuron-wallet/src/services/monitor/base.ts
@@ -35,7 +35,7 @@ export default abstract class Monitor {
     }
   }
 
-  async startMonitor(intervalTime: number = 10000, startNow: boolean = false) {
+  async startMonitor(intervalTime: number = 30000, startNow: boolean = false) {
     this.interval = interval(intervalTime)
     if (!this.subcription?.closed) {
       this.subcription?.unsubscribe()

--- a/packages/neuron-wallet/tests/services/ckb-runner.test.ts
+++ b/packages/neuron-wallet/tests/services/ckb-runner.test.ts
@@ -76,6 +76,7 @@ describe('ckb runner', () => {
   beforeEach(() => {
     resetMocks()
 
+    stubbedCkb.kill = jest.fn()
     stubbedCkb.stderr = new EventEmitter()
     stubbedCkb.stdout = new EventEmitter()
     stubbedSpawn.mockReturnValue(stubbedCkb)
@@ -95,7 +96,12 @@ describe('ckb runner', () => {
           stubbedExistsSync.mockReturnValue(true)
           await startCkbNode()
         })
-        it('should not init ckb config', () => {
+        afterEach(async () => {
+          const promise = stopCkbNode()
+          stubbedCkb.emit('close')
+          await promise
+        })
+        it('should not init ckb config', async () => {
           expect(stubbedSpawn).not.toHaveBeenCalledWith(expect.stringContaining('/ckb'), [
             'init',
             '--chain',
@@ -123,6 +129,11 @@ describe('ckb runner', () => {
           beforeEach(async () => {
             stubbedCkb.emit('close')
             await promise
+          })
+          afterEach(async () => {
+            const stopPromise = stopCkbNode()
+            stubbedCkb.emit('close')
+            await stopPromise
           })
           it('inits ckb config', () => {
             expect(stubbedSpawn).toHaveBeenCalledWith(expect.stringContaining(path.join(platformPath, 'ckb')), [


### PR DESCRIPTION
1. Try to check ckb is alive every 30s.
2. When startCkb try to check the ckb is null.