### PR TITLE
fix: fix typo of migrate

### DIFF
--- a/packages/neuron-ui/src/locales/zh.json
+++ b/packages/neuron-ui/src/locales/zh.json
@@ -499,7 +499,7 @@
       "experimental-message-hardware": "本功能为实验性功能，请注意风险，谨慎使用。",
       "experimental-message": "本页面为实验性功能，可能随时变更。请谨慎使用。",
       "rebuild-sync": "为了提供更好的用户体验，Neuron 採取了新的存储方案，该方案需要一次性迁移数据(预期同步时间为 20~60 分钟)。\n抱歉给您带来不便。",
-      "migrate": "遷移",
+      "migrate": "迁移",
       "secp256k1/blake160-address-required": "请输入 secp256k1/blake160 地址",
       "fields": {
         "wallet": "钱包",


### PR DESCRIPTION
Simplified Chinese of "migrate" should be "迁移"