### PR TITLE
fix: Restart or stop sync process by connectionStatusSubject.

### DIFF
--- a/packages/neuron-wallet/src/main.ts
+++ b/packages/neuron-wallet/src/main.ts
@@ -10,12 +10,14 @@ const appController = AppController.getInstance()
 const singleInstanceLock = app.requestSingleInstanceLock()
 if (singleInstanceLock) {
   app.on('ready', async () => {
+    logger.info('App:\tNeuron is starting')
     changeLanguage(SettingsService.getInstance().locale)
 
     appController.start()
   })
 
   app.on('before-quit', async () => {
+    logger.info('App:\tNeuron will exist')
     await appController.end()
   })
 

--- a/packages/neuron-wallet/src/services/ckb-runner.ts
+++ b/packages/neuron-wallet/src/services/ckb-runner.ts
@@ -6,7 +6,6 @@ import process from 'process'
 import logger from 'utils/logger'
 import SettingsService from './settings'
 import MigrateSubject from 'models/subjects/migrate-subject'
-import { resetSyncTaskQueue } from 'block-sync-renderer'
 import IndexerService from './indexer'
 
 const platform = (): string => {
@@ -126,14 +125,12 @@ export const startCkbNode = async () => {
     isLookingValidTarget = false
     ckb = null
   })
-  resetSyncTaskQueue.push(true)
 
   removeOldIndexerIfRunSuccess()
 }
 
 export const stopCkbNode = () => {
   return new Promise<void>(resolve => {
-    resetSyncTaskQueue.push(false)
     if (ckb) {
       logger.info('CKB:\tkilling node')
       ckb.once('close', () => resolve())


### PR DESCRIPTION
This pr will fix https://github.com/Magickbase/neuron-public-issues/issues/96. Here is why I changed the code like this:
When starting the sync process in `ckb-runner`, the network `genesisHash` has not refresh, so it will start a wrong sync process that connects the `mainnet` database and use the `testnet` data, so I remove the start and stop from `ckb-runner`. But after I remove the stop sync process from `ckb-runner`, `NetworksController` may delay stop the sync process because of `debounceTime`. We should stop the sync process right now when the `ckb` node is stopped otherwise the sync process may use the wrong net data. So I remove `debounceTime` from `NetworksController` otherwise the sync process may delay stopping.

### Here are the pr changes
1. Remove `debounceTime` because it has `distinctUntilChanged` unless the node connects or disconnects frequently.
3. Remove starting or stopping the sync process from `ckb-runner`, because it has control by `connectionStatusSubject`, when the `ckb` connection status changes, it will stop or start.
4. Add start and stop App logs to find the latest running log.