### PR TITLE
fix: Fix when enter over 8 decimal crash.

### DIFF
--- a/packages/neuron-ui/src/components/NervosDAO/index.tsx
+++ b/packages/neuron-ui/src/components/NervosDAO/index.tsx
@@ -245,6 +245,8 @@ const NervosDAO = () => {
       }
     } catch (error) {
       // ignore error
+      // When the depositValue is invalid, it displays the error in the textField, but it will throw an exception when valid wheater it's big than the max deposit value
+      // and when the depositValue is invalid, it's no need to set max depositValue.
     }
   }, [maxDepositAmount, depositValue, setDepositValue])
 

--- a/packages/neuron-ui/src/components/NervosDAO/index.tsx
+++ b/packages/neuron-ui/src/components/NervosDAO/index.tsx
@@ -239,8 +239,12 @@ const NervosDAO = () => {
   }, [])
 
   useEffect(() => {
-    if (BigInt(CKBToShannonFormatter(depositValue)) > maxDepositAmount) {
-      setDepositValue(shannonToCKBFormatter(`${maxDepositAmount}`, false, ''))
+    try {
+      if (BigInt(CKBToShannonFormatter(depositValue)) > maxDepositAmount) {
+        setDepositValue(shannonToCKBFormatter(`${maxDepositAmount}`, false, ''))
+      }
+    } catch (error) {
+      // ignore error
     }
   }, [maxDepositAmount, depositValue, setDepositValue])
 


### PR DESCRIPTION
When the `depositValue` is invalid, it displays the error in the textField, but it will throw an exception when valid wheater it's big than the max deposit value, and when the `depositValue` is invalid, it's no need to set max `depositValue`.

https://user-images.githubusercontent.com/12881040/230840833-6f981c6f-22ba-4c8f-9985-88e35fa5495c.mov

