### PR TITLE
fix: use linux portable for compatibility

### DIFF
--- a/scripts/download-ckb.sh
+++ b/scripts/download-ckb.sh
@@ -42,7 +42,7 @@ function download_linux() {
 
 function download_linux_light() {
   # macOS
-  CKB_FILENAME="ckb-light-client_${CKB_LIGHT_VERSION}-x86_64-linux"
+  CKB_FILENAME="ckb-light-client_${CKB_LIGHT_VERSION}-x86_64-linux-portable"
   cd $ROOT_DIR/packages/neuron-wallet/bin/linux
 
   curl -O -L "https://github.com/nervosnetwork/ckb-light-client/releases/download/${CKB_LIGHT_VERSION}/${CKB_FILENAME}.tar.gz"


### PR DESCRIPTION
ckb light client portable@v0.2.2 works on ubuntu 20.04 while ckb
light client@v0.2.2 doesn't due to openssl compatibility