### PR TITLE
fix: fix parsing deposit time in nervos dao

### DIFF
--- a/packages/neuron-ui/src/components/NervosDAO/hooks.ts
+++ b/packages/neuron-ui/src/components/NervosDAO/hooks.ts
@@ -539,7 +539,7 @@ export const useUpdateDepositEpochList = ({
           const epochList = new Map()
           records.forEach(record => {
             const key = getRecordKey(record)
-            epochList.set(key, recordKeyIdxMap.get(key) ? res[recordKeyIdxMap.get(key)!]?.epoch : null)
+            epochList.set(key, recordKeyIdxMap.get(key) !== undefined ? res[recordKeyIdxMap.get(key)!]?.epoch : null)
           })
           setDepositEpochList(epochList)
         })


### PR DESCRIPTION
0 in the condition hits the negative branch but it should be treated as a positive one because 0 is a valid index of an array