### PR TITLE
fix: Show some tips about light client.

### DIFF
--- a/packages/neuron-ui/src/components/SUDTSend/index.tsx
+++ b/packages/neuron-ui/src/components/SUDTSend/index.tsx
@@ -29,7 +29,15 @@ import {
 } from 'utils'
 import { AmountNotEnoughException, isErrorWithI18n } from 'exceptions'
 import { UANTokenName, UANTonkenSymbol } from 'components/UANDisplay'
-import { AddressLockType, getGenerator, useAddressLockType, useOnSumbit, useOptions, useSendType } from './hooks'
+import {
+  AddressLockType,
+  SendType,
+  getGenerator,
+  useAddressLockType,
+  useOnSumbit,
+  useOptions,
+  useSendType,
+} from './hooks'
 import styles from './sUDTSend.module.scss'
 
 const { INIT_SEND_PRICE, DEFAULT_SUDT_FIELDS } = CONSTANTS
@@ -404,6 +412,12 @@ const SUDTSend = () => {
                     <span className={styles.optionTooltip} data-tooltip={t(`s-udt.send.${v.tooltip}`, v?.params)}>
                       <TooltipIcon width={12} height={12} />
                     </span>
+                  ) : null}
+                  {v.key === SendType.secp256Cheque ? (
+                    <div className={styles.chequeWarning}>
+                      <Attention />
+                      {t('messages.light-client-cheque-warning')}
+                    </div>
                   ) : null}
                 </div>
               ))}

--- a/packages/neuron-ui/src/components/SUDTSend/sUDTSend.module.scss
+++ b/packages/neuron-ui/src/components/SUDTSend/sUDTSend.module.scss
@@ -178,6 +178,20 @@
         }
       }
     }
+
+    .chequeWarning {
+      padding: 0 8px;
+      margin-left: 8px;
+      background-color: rgb(255, 244, 206);
+      color: rgb(50, 49, 48);
+  
+      & > svg {
+        width: 14px;
+        height: 14px;
+        margin-right: 4px;
+        transform: translateY(20%);
+      }
+    }
   }
   .cheque {
     grid-area: option-0;

--- a/packages/neuron-ui/src/components/SendFieldset/index.tsx
+++ b/packages/neuron-ui/src/components/SendFieldset/index.tsx
@@ -163,6 +163,7 @@ const SendFieldset = ({
             <div className={styles.locktimeWarn}>
               <Attention />
               {t('send.locktime-warning')}
+              {t('messages.light-client-locktime-warning')}
             </div>
           )}
         </div>

--- a/packages/neuron-ui/src/locales/en.json
+++ b/packages/neuron-ui/src/locales/en.json
@@ -509,6 +509,8 @@
       "rebuild-sync": "For better user experience, Neuron has adopted a new storage, which requires a migrating of data (estimated 20 ~ 60min).\nSorry for the inconvenience.",
       "migrate": "Migrate",
       "secp256k1/blake160-address-required": "Secp256k1/blake160 address is required",
+      "light-client-locktime-warning": "Warning: Light client is not support show lock-time CKBytes.",
+      "light-client-cheque-warning": "Warning: Light client is not support show Cheque assets.",
       "fields": {
         "wallet": "Wallet",
         "name": "Name",

--- a/packages/neuron-ui/src/locales/zh-tw.json
+++ b/packages/neuron-ui/src/locales/zh-tw.json
@@ -501,6 +501,8 @@
       "rebuild-sync": "為了提供更好的用戶體驗，Neuron 採取了新的存儲方案，該方案需要壹次性遷移數據(預期同步時間為 20~60 分鐘)。\n抱歉給您帶來不便。",
       "migrate": "遷移",
       "secp256k1/blake160-address-required": "請輸入 secp256k1/blake160 地址",
+      "light-client-locktime-warning": "註意: 輕節點錢包不支持展示到期解鎖的 CKBytes。",
+      "light-client-cheque-warning": "註意: 輕節點錢包不支持展示 Cheque 資產。",
       "fields": {
         "wallet": "錢包",
         "name": "名稱",

--- a/packages/neuron-ui/src/locales/zh.json
+++ b/packages/neuron-ui/src/locales/zh.json
@@ -502,6 +502,8 @@
       "rebuild-sync": "为了提供更好的用户体验，Neuron 採取了新的存储方案，该方案需要一次性迁移数据(预期同步时间为 20~60 分钟)。\n抱歉给您带来不便。",
       "migrate": "迁移",
       "secp256k1/blake160-address-required": "请输入 secp256k1/blake160 地址",
+      "light-client-locktime-warning": "注意: 轻节点钱包不支持展示到期解锁的 CKBytes。",
+      "light-client-cheque-warning": "注意: 轻节点钱包不支持展示 Cheque 资产。",
       "fields": {
         "wallet": "钱包",
         "name": "名称",

--- a/packages/neuron-wallet/src/exceptions/anyone-can-pay.ts
+++ b/packages/neuron-wallet/src/exceptions/anyone-can-pay.ts
@@ -30,6 +30,12 @@ export class SudtAcpHaveDataError extends Error {
   }
 }
 
+export class LightClientNotSupportSendToACPError extends Error {
+  constructor() {
+    super(t('messages.light-client-sudt-acp-error'))
+  }
+}
+
 export default {
   TargetOutputNotFoundError,
   AcpSendSameAccountError

--- a/packages/neuron-wallet/src/locales/en.ts
+++ b/packages/neuron-wallet/src/locales/en.ts
@@ -134,7 +134,8 @@ export default {
       'sudt-acp-have-data': 'The destroying sUDT acp account have amount',
       'no-match-address-for-sign': 'Not found matched address',
       'target-lock-error': 'CKB asset account can only transfer to sepe256k1 or acp address',
-      'no-exist-ckb-node-data': '{{path}} has no CKB Node config and storage, press ok to synchronize from scratch'
+      'no-exist-ckb-node-data': '{{path}} has no CKB Node config and storage, press ok to synchronize from scratch',
+      'light-client-sudt-acp-error': "Light client is not support send assets to other's asset address"
     },
     messageBox: {
       button: {

--- a/packages/neuron-wallet/src/locales/zh-tw.ts
+++ b/packages/neuron-wallet/src/locales/zh-tw.ts
@@ -124,7 +124,8 @@ export default {
       'sudt-acp-have-data': '待銷毀的 sUDT 賬戶資產不為 0',
       'no-match-address-for-sign': '没有找到匹配的地址',
       'target-lock-error': 'CKB 資產只能轉賬到 secp256k1 或者 acp 地址',
-      'no-exist-ckb-node-data': '{{path}} 目錄下沒有找到 CKB Node 配置和數據, 點擊繼續重新同步'
+      'no-exist-ckb-node-data': '{{path}} 目錄下沒有找到 CKB Node 配置和數據, 點擊繼續重新同步',
+      'light-client-sudt-acp-error': '輕節點錢包不支持發送資產給資產賬戶地址'
     },
     messageBox: {
       button: {

--- a/packages/neuron-wallet/src/locales/zh.ts
+++ b/packages/neuron-wallet/src/locales/zh.ts
@@ -125,7 +125,8 @@ export default {
       'sudt-acp-have-data': '待销毁的 sUDT 账户资产不为 0',
       'no-match-address-for-sign': '没有找到匹配的地址',
       'target-lock-error': 'CKB 资产只能转账到 secp256k1 或者 acp 地址',
-      'no-exist-ckb-node-data': '{{path}} 目录下没有找到 CKB Node 配置和数据, 点击继续重新同步'
+      'no-exist-ckb-node-data': '{{path}} 目录下没有找到 CKB Node 配置和数据, 点击继续重新同步',
+      'light-client-sudt-acp-error': '轻节点钱包不支持发送资产给资产账户地址'
     },
     messageBox: {
       button: {

--- a/packages/neuron-wallet/src/services/anyone-can-pay.ts
+++ b/packages/neuron-wallet/src/services/anyone-can-pay.ts
@@ -6,7 +6,7 @@ import Output from 'models/chain/output'
 import LiveCell from 'models/chain/live-cell'
 import Transaction from 'models/chain/transaction'
 import AssetAccountEntity from 'database/chain/entities/asset-account'
-import { TargetLockError, TargetOutputNotFoundError } from 'exceptions'
+import { LightClientNotSupportSendToACPError, TargetLockError, TargetOutputNotFoundError } from 'exceptions'
 import { AcpSendSameAccountError } from 'exceptions'
 import Script from 'models/chain/script'
 import OutPoint from 'models/chain/out-point'
@@ -15,6 +15,8 @@ import WalletService from './wallets'
 import SystemScriptInfo from 'models/system-script-info'
 import CellsService from './cells'
 import { MIN_SUDT_CAPACITY } from 'utils/const'
+import NetworksService from './networks'
+import { NetworkType } from 'models/network'
 
 export default class AnyoneCanPayService {
   public static async generateAnyoneCanPayTx(
@@ -90,6 +92,9 @@ export default class AnyoneCanPayService {
     )
     if (new AssetAccountInfo().isAnyoneCanPayScript(lockScript)) {
       if (!targetOutputLiveCell) {
+        if (NetworksService.getInstance().getCurrent().type === NetworkType.Light) {
+          throw new LightClientNotSupportSendToACPError()
+        }
         throw new TargetOutputNotFoundError()
       }
       return Output.fromObject({


### PR DESCRIPTION
1. When users select send `ckb` with lock-time, will also prompt `light client` will not support showing `lock-time` cell.

<img width="1166" alt="image" src="https://user-images.githubusercontent.com/12881040/233525959-b74cf6b9-6cb4-4c19-bfe4-083b355bf59d.png">

2. Send `sudt` with Cheque

<img width="1128" alt="image" src="https://user-images.githubusercontent.com/12881040/233526572-1366a3a5-4f33-4b5a-8a0c-b451906221ca.png">

3. Send `sudt` to other users' ACP address

When sending `ckb` `sudt`
<img width="1693" alt="image" src="https://user-images.githubusercontent.com/12881040/233527055-f92975ba-6c8d-4782-9288-fc51bb1ef1de.png">

When sending other `sudt`, can only support sending extra 142 CKBytes when sending `sudt`.

<img width="1647" alt="image" src="https://user-images.githubusercontent.com/12881040/233527341-14491835-2e0c-4e89-bba4-6ebed8a0d259.png">
