### PR TITLE
ci: fix the add-label action

### DIFF
--- a/.github/workflows/add-replied-label.yml
+++ b/.github/workflows/add-replied-label.yml
@@ -22,9 +22,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - id: check-issue
+        name: Check if the comment is replied in an issue
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const response = await github.repos.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            return { isIssue: !response.data.pull_request }
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - id: add-label
         name: Add 'replied' label
-        if: steps.check-access.outputs.hasWriteAccess
+        if: ${{ steps.check-access.outputs.hasWriteAccess && steps.check-issue.outputs.isIssue }}
         uses: actions-ecosystem/action-add-labels@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-replied-label.yml
+++ b/.github/workflows/add-replied-label.yml
@@ -25,7 +25,7 @@ jobs:
       - id: add-label
         name: Add 'replied' label
         if: steps.check-access.outputs.hasWriteAccess
-        uses: actions-ecosystem/action-add-label@v1
+        uses: actions-ecosystem/action-add-labels@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.issue.number }}


### PR DESCRIPTION
This action(https://github.com/nervosnetwork/neuron/actions/runs/4760813903)
was triggered by a comment in pull request because pull request
is also regarded as an issue in GitHub. And this action threw
an exception that `actions-ecosystem/action-add-label` is not
found.

This commit fixed the typo of `actions-ecosystem/action-add-labels`
And add a step to filter pull request out

Ref:
actions-ecosystem/action-add-labels: https://github.com/actions-ecosystem/action-add-labels