### PR TITLE
refactor: use github rest api to update labels

### DIFF
--- a/.github/workflows/add-replied-label.yml
+++ b/.github/workflows/add-replied-label.yml
@@ -7,9 +7,11 @@ on:
 jobs:
   add-label:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - id: check-access
-        name: Check if the commenter has write access
+        name: Check if the commenter is a collaborator
         uses: actions/github-script@v4
         with:
           script: |
@@ -18,7 +20,7 @@ jobs:
               repo: context.repo.repo,
               username: context.payload.comment.user.login,
             })
-            return { hasWriteAccess: response.data.permission === 'write' }
+            return response.status === 204
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -27,20 +29,27 @@ jobs:
         uses: actions/github-script@v4
         with:
           script: |
-            const response = await github.repos.issues.get({
+            const response = await github.issues.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
             })
-            return { isIssue: !response.data.pull_request }
+            return response.data.pull_request === undefined
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - id: add-label
         name: Add 'replied' label
-        if: ${{ steps.check-access.outputs.hasWriteAccess && steps.check-issue.outputs.isIssue }}
-        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ steps.check-access.outputs.result == 'true' && steps.check-issue.outputs.result == 'true' }}
+        uses: actions/github-script@v4
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          label: replied
+          script: |
+            await github.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: process.env.labels.split(', '),
+            })
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          labels: 'replied'


### PR DESCRIPTION
The external action is out-of-date on permission management in github action, so the label action is re-written in github rest api for maintenance.

Ref: https://github.com/actions-ecosystem/action-add-labels/issues/444