### PR TITLE
fix: fix some bugs

### DIFF
--- a/packages/neuron-wallet/src/block-sync-renderer/sync/light-connector.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/light-connector.ts
@@ -301,9 +301,6 @@ export default class LightConnector extends Connector<CKBComponents.Hash> {
   }
 
   async appendScript(scripts: AppendScript[]) {
-    if (!scripts.length) {
-      return
-    }
     this.initSyncProgress(scripts)
   }
 }

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
@@ -10,6 +10,7 @@ import AssetAccountInfo from 'models/asset-account-info'
 import { Address as AddressInterface } from "models/address"
 import AddressParser from 'models/address-parser'
 import Multisig from 'models/multisig'
+import BlockHeader from 'models/chain/block-header'
 import TxAddressFinder from './tx-address-finder'
 import IndexerConnector from './indexer-connector'
 import IndexerCacheService from './indexer-cache-service'
@@ -134,8 +135,11 @@ export default class Queue {
       blockHashes.map(v => ['getHeader', v])
     ).exec()
     headers.forEach((blockHeader, idx) => {
-      txs[idx].timestamp = blockHeader!.timestamp
-      txs[idx].blockNumber = blockHeader!.number
+      if (blockHeader) {
+        const header = BlockHeader.fromSDK(blockHeader)
+        txs[idx].timestamp = header.timestamp
+        txs[idx].blockNumber = header.number
+      }
     })
     return txs
   }

--- a/packages/neuron-wallet/src/database/chain/index.ts
+++ b/packages/neuron-wallet/src/database/chain/index.ts
@@ -18,7 +18,7 @@ export const clean = async () => {
         .getRepository(entity)
         .clear()
     }),
-    SyncProgressService.clear()
+    SyncProgressService.clearCurrentWalletProgress()
   ])
   MultisigOutputChangedSubject.getSubject().next('reset')
 

--- a/packages/neuron-wallet/src/database/chain/index.ts
+++ b/packages/neuron-wallet/src/database/chain/index.ts
@@ -1,23 +1,24 @@
 import { getConnection } from 'typeorm'
 import MultisigOutputChangedSubject from 'models/subjects/multisig-output-db-changed-subject'
+import SyncProgressService from 'services/sync-progress'
 import InputEntity from './entities/input'
 import OutputEntity from './entities/output'
 import TransactionEntity from './entities/transaction'
 import SyncInfoEntity from './entities/sync-info'
 import IndexerTxHashCache from './entities/indexer-tx-hash-cache'
 import MultisigOutput from './entities/multisig-output'
-import SyncProgress from './entities/sync-progress'
 
 /*
  * Clean local sqlite storage
  */
 export const clean = async () => {
   await Promise.all([
-    ...[InputEntity, OutputEntity, TransactionEntity, IndexerTxHashCache, MultisigOutput, SyncProgress].map(entity => {
+    ...[InputEntity, OutputEntity, TransactionEntity, IndexerTxHashCache, MultisigOutput].map(entity => {
       return getConnection()
         .getRepository(entity)
         .clear()
-    })
+    }),
+    SyncProgressService.clear()
   ])
   MultisigOutputChangedSubject.getSubject().next('reset')
 

--- a/packages/neuron-wallet/src/services/indexer.ts
+++ b/packages/neuron-wallet/src/services/indexer.ts
@@ -30,7 +30,7 @@ export default class IndexerService {
     }
 
     if (!NodeService.getInstance().isCkbNodeExternal) {
-      await startMonitor('ckb')
+      await startMonitor('ckb', true)
     }
   }
 

--- a/packages/neuron-wallet/src/services/multisig.ts
+++ b/packages/neuron-wallet/src/services/multisig.ts
@@ -11,6 +11,7 @@ import NetworksService from './networks'
 import Multisig from 'models/multisig'
 import SyncProgress, { SyncAddressType } from 'database/chain/entities/sync-progress'
 import { NetworkType } from 'models/network'
+import WalletService from './wallets'
 
 const max64Int = '0x' + 'f'.repeat(16)
 export default class MultisigService {
@@ -334,9 +335,13 @@ export default class MultisigService {
   }
 
   static async getMultisigConfigForLight() {
+    const currentWallet = WalletService.getInstance().getCurrent()
     const multisigConfigs = await getConnection()
       .getRepository(MultisigConfig)
       .createQueryBuilder()
+      .where({
+        walletId: currentWallet?.id
+      })
       .getMany()
     return multisigConfigs.map(v => ({
       walletId: v.walletId,

--- a/packages/neuron-wallet/src/services/sync-progress.ts
+++ b/packages/neuron-wallet/src/services/sync-progress.ts
@@ -109,7 +109,7 @@ export default class SyncProgressService {
       .getMany()
   }
 
-  static async clear() {
+  static async clearCurrentWalletProgress() {
     const currentWallet = WalletService.getInstance().getCurrent()
     await getConnection()
       .getRepository(SyncProgress)

--- a/packages/neuron-wallet/src/services/sync-progress.ts
+++ b/packages/neuron-wallet/src/services/sync-progress.ts
@@ -108,4 +108,11 @@ export default class SyncProgressService {
       .where({ hash: In(hashes) })
       .getMany()
   }
+
+  static async clear() {
+    const currentWallet = WalletService.getInstance().getCurrent()
+    await getConnection()
+      .getRepository(SyncProgress)
+      .delete({ walletId: currentWallet?.id })
+  }
 }

--- a/packages/neuron-wallet/tests/controllers/multisig.test.ts
+++ b/packages/neuron-wallet/tests/controllers/multisig.test.ts
@@ -18,6 +18,15 @@ jest.mock('electron', () => ({
     getFocusedWindow: jest.fn()
   }
 }))
+jest.mock('services/wallets', () => ({
+  getInstance() {
+    return {
+      getCurrent() {
+        return jest.fn()
+      }
+    }
+  }
+}))
 
 jest.mock('../../src/services/multisig')
 const MultiSigServiceMock = MultisigService as jest.MockedClass<typeof MultisigService>

--- a/packages/neuron-wallet/tests/controllers/sync-api.test.ts
+++ b/packages/neuron-wallet/tests/controllers/sync-api.test.ts
@@ -47,6 +47,9 @@ jest.doMock('services/ckb-runner', () => ({
 jest.mock('undici', () => ({
   request: () => jest.fn()()
 }))
+jest.mock('services/multisig', () => ({
+  syncMultisigOutput: () => jest.fn()
+}))
 
 describe('SyncApiController', () => {
   const emitter = new Emitter()

--- a/packages/neuron-wallet/tests/services/light-runner.test.ts
+++ b/packages/neuron-wallet/tests/services/light-runner.test.ts
@@ -19,6 +19,7 @@ const spawnMock = jest.fn()
 const loggerErrorMock = jest.fn()
 const loggerInfoMock = jest.fn()
 const transportsGetFileMock = jest.fn()
+const cleanMock = jest.fn()
 
 function resetMock() {
   mockFn.mockReset()
@@ -38,6 +39,7 @@ function resetMock() {
   loggerErrorMock.mockReset()
   loggerInfoMock.mockReset()
   transportsGetFileMock.mockReset()
+  cleanMock.mockReset()
 }
 
 jest.doMock('../../src/env', () => ({
@@ -65,6 +67,10 @@ jest.doMock('../../src/services/settings', () => ({
       get testnetLightDataPath() { return lightDataPathMock() }
     }
   }
+}))
+
+jest.doMock('../../src/database/chain', () => ({
+  clean: cleanMock
 }))
 
 jest.doMock('process', () => ({


### PR DESCRIPTION
1. When append scripts are empty means remove append scripts, so remove empty judgment
2. resultFormatters should not return null. Because the Method will ignore null or undefined.
3. When clear cache start monitor should start node right now and only delete current wallet sync progress.
4. Save decimal number to SQLite when the field is `timestamp` or `blockNumber`