### PR TITLE
fix: Add min-height avoid dialog truncation

### DIFF
--- a/packages/neuron-ui/src/components/SUDTUpdateDialog/sUDTUpdateDialog.module.scss
+++ b/packages/neuron-ui/src/components/SUDTUpdateDialog/sUDTUpdateDialog.module.scss
@@ -7,6 +7,7 @@
   left: 0;
   height: 100%;
   width: 100%;
+  min-height: 550px;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
1. before the change

<img width="1697" alt="image" src="https://github.com/nervosnetwork/neuron/assets/12881040/2f80cade-b360-4eae-abeb-d8fc8a6b8c39">

2. after the change

<img width="1716" alt="image" src="https://github.com/nervosnetwork/neuron/assets/12881040/61c17641-17ca-4bfe-85de-a498cf1a35dc">
