### PR TITLE
refactor: Optimize input and output storage

### DIFF
--- a/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-cache-service.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-cache-service.ts
@@ -4,6 +4,7 @@ import AddressMeta from '../../database/address/meta'
 import IndexerTxHashCache from '../../database/chain/entities/indexer-tx-hash-cache'
 import RpcService from '../../services/rpc-service'
 import TransactionWithStatus from '../../models/chain/transaction-with-status'
+import SyncInfoEntity from '../../database/chain/entities/sync-info'
 import { TransactionCollector, CellCollector, Indexer as CkbIndexer } from '@ckb-lumos/ckb-indexer'
 
 export default class IndexerCacheService {
@@ -11,6 +12,7 @@ export default class IndexerCacheService {
   private rpcService: RpcService
   private walletId: string
   private indexer: CkbIndexer
+  #cacheBlockNumberEntity?: SyncInfoEntity
 
   constructor(walletId: string, addressMetas: AddressMeta[], rpcService: RpcService, indexer: CkbIndexer) {
     for (const addressMeta of addressMetas) {
@@ -23,16 +25,6 @@ export default class IndexerCacheService {
     this.addressMetas = addressMetas
     this.rpcService = rpcService
     this.indexer = indexer
-  }
-
-  private async countTxHashes(): Promise<number> {
-    return getConnection()
-      .getRepository(IndexerTxHashCache)
-      .createQueryBuilder()
-      .where({
-        walletId: this.walletId,
-      })
-      .getCount()
   }
 
   private async getTxHashes(): Promise<IndexerTxHashCache[]> {
@@ -79,6 +71,8 @@ export default class IndexerCacheService {
   }
 
   private async fetchTxMapping(): Promise<Map<string, Array<{ address: string; lockHash: string }>>> {
+    const lastCacheBlockNumber = await this.getCachedBlockNumber()
+    const currentHeaderBlockNumber = await this.rpcService.getTipBlockNumber()
     const mappingsByTxHash = new Map()
     for (const addressMeta of this.addressMetas) {
       const lockScripts = [
@@ -88,9 +82,18 @@ export default class IndexerCacheService {
       ]
 
       for (const lockScript of lockScripts) {
-        const transactionCollector = new TransactionCollector(this.indexer, { lock: lockScript }, this.rpcService.url, {
-          includeStatus: false,
-        })
+        const transactionCollector = new TransactionCollector(
+          this.indexer,
+          {
+            lock: lockScript,
+            fromBlock: lastCacheBlockNumber.value,
+            toBlock: currentHeaderBlockNumber,
+          },
+          this.rpcService.url,
+          {
+            includeStatus: false,
+          }
+        )
 
         const fetchedTxHashes = await transactionCollector.getTransactionHashes()
         if (!fetchedTxHashes.length) {
@@ -126,6 +129,8 @@ export default class IndexerCacheService {
             args: lockScript.args.slice(0, 42),
           },
           argsLen,
+          fromBlock: lastCacheBlockNumber.value,
+          toBlock: currentHeaderBlockNumber,
         })
 
         for await (const cell of cellCollector.collect()) {
@@ -142,17 +147,33 @@ export default class IndexerCacheService {
     return mappingsByTxHash
   }
 
+  private async getCachedBlockNumber() {
+    if (!this.#cacheBlockNumberEntity) {
+      this.#cacheBlockNumberEntity = (await getConnection().getRepository(SyncInfoEntity).findOne({ name: SyncInfoEntity.getLastCachedKey(this.walletId) })) ?? 
+        SyncInfoEntity.fromObject({
+          name: SyncInfoEntity.getLastCachedKey(this.walletId),
+          value: '0x0'
+        })
+    }
+
+    return this.#cacheBlockNumberEntity
+  }
+
+  private async saveCacheBlockNumber(cacheBlockNumber: string) {
+    let cacheBlockNumberEntity = await this.getCachedBlockNumber()
+    cacheBlockNumberEntity.value = cacheBlockNumber
+    await getConnection().manager.save(cacheBlockNumberEntity)
+  }
+
   public async upsertTxHashes(): Promise<string[]> {
+    const tipBlockNumber = await this.rpcService.getTipBlockNumber()
     const mappingsByTxHash = await this.fetchTxMapping()
 
     const fetchedTxHashes = [...mappingsByTxHash.keys()]
-    const fetchedTxHashCount = fetchedTxHashes.reduce((sum, txHash) => sum + mappingsByTxHash.get(txHash)!.length, 0)
-
-    const txCount = await this.countTxHashes()
-    if (fetchedTxHashCount === txCount) {
+    if (!fetchedTxHashes.length) {
+      await this.saveCacheBlockNumber(tipBlockNumber)
       return []
     }
-
     const txMetasCaches = await this.getTxHashes()
     const cachedTxHashes = txMetasCaches.map(meta => meta.txHash.toString())
 
@@ -161,6 +182,7 @@ export default class IndexerCacheService {
     const newTxHashes = fetchedTxHashes.filter(hash => !cachedTxHashesSet.has(hash))
 
     if (!newTxHashes.length) {
+      await this.saveCacheBlockNumber(tipBlockNumber)
       return []
     }
 
@@ -208,6 +230,7 @@ export default class IndexerCacheService {
       }
     }
 
+    await this.saveCacheBlockNumber(tipBlockNumber)
     return newTxHashes
   }
 

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
@@ -30,6 +30,7 @@ export default class Queue {
   #rpcService: RpcService
   #indexerConnector: Connector | undefined
   #checkAndSaveQueue: QueueObject<{ txHashes: CKBComponents.Hash[]; params: unknown }> | undefined
+  #lockArgsSet: Set<string> = new Set()
 
   #multiSignBlake160s: string[]
   #anyoneCanPayLockHashes: string[]
@@ -44,6 +45,11 @@ export default class Queue {
     this.#lockHashes = AddressParser.batchToLockHash(this.#addresses.map(meta => meta.address))
 
     const blake160s = this.#addresses.map(meta => meta.blake160)
+    this.#lockArgsSet = new Set(blake160s.map(blake160 => [
+      blake160,
+      Multisig.hash([blake160]),
+      SystemScriptInfo.generateSecpScript(blake160).computeHash().slice(0, 42)
+    ]).flat())
     this.#multiSignBlake160s = blake160s.map(blake160 => Multisig.hash([blake160]))
     this.#anyoneCanPayLockHashes = blake160s.map(b =>
       this.#assetAccountInfo.generateAnyoneCanPayScript(b).computeHash()
@@ -216,7 +222,7 @@ export default class Queue {
           }
         }
       }
-      await TransactionPersistor.saveFetchTx(tx)
+      await TransactionPersistor.saveFetchTx(tx, this.#lockArgsSet)
       for (const info of anyoneCanPayInfos) {
         await AssetAccountService.checkAndSaveAssetAccountWhenSync(info.tokenID, info.blake160)
       }

--- a/packages/neuron-wallet/src/database/chain/entities/sync-info.ts
+++ b/packages/neuron-wallet/src/database/chain/entities/sync-info.ts
@@ -13,4 +13,18 @@ export default class SyncInfo {
     type: 'varchar',
   })
   value!: string
+  
+  static fromObject(params: {
+    name: string,
+    value: string
+  }) {
+    const res = new SyncInfo()
+    res.name = params.name
+    res.value = params.value
+    return res
+  }
+
+  static getLastCachedKey(walletId: string) {
+    return `lastCachedBlockNumber_${walletId}`
+  }
 }

--- a/packages/neuron-wallet/src/database/chain/entities/tx-lock.ts
+++ b/packages/neuron-wallet/src/database/chain/entities/tx-lock.ts
@@ -1,0 +1,24 @@
+import { BaseEntity, Entity, PrimaryColumn } from 'typeorm'
+
+@Entity()
+export default class TxLock extends BaseEntity {
+  @PrimaryColumn({
+    type: 'varchar'
+  })
+  transactionHash!: string
+
+  @PrimaryColumn({
+    type: 'varchar',
+  })
+  lockHash!: string
+  
+  static fromObject(obj: {
+    txHash: string
+    lockHash: string
+  }) {
+    const res = new TxLock()
+    res.transactionHash = obj.txHash
+    res.lockHash = obj.lockHash
+    return res
+  }
+}

--- a/packages/neuron-wallet/src/database/chain/index.ts
+++ b/packages/neuron-wallet/src/database/chain/index.ts
@@ -8,14 +8,17 @@ import SyncInfoEntity from './entities/sync-info'
 import IndexerTxHashCache from './entities/indexer-tx-hash-cache'
 import MultisigOutput from './entities/multisig-output'
 import SyncProgress from './entities/sync-progress'
+import TxLock from './entities/tx-lock'
 
 /*
  * Clean local sqlite storage
  */
 export const clean = async (clearAllLightClientData?: boolean) => {
   await Promise.all([
-    ...[InputEntity, OutputEntity, TransactionEntity, IndexerTxHashCache, MultisigOutput].map(entity => {
-      return getConnection().getRepository(entity).clear()
+    ...[InputEntity, OutputEntity, TransactionEntity, IndexerTxHashCache, MultisigOutput, TxLock].map(entity => {
+      return getConnection()
+        .getRepository(entity)
+        .clear()
     }),
     clearAllLightClientData
       ? getConnection().getRepository(SyncProgress).clear()

--- a/packages/neuron-wallet/src/database/chain/migrations/1684488676083-TxLock.ts
+++ b/packages/neuron-wallet/src/database/chain/migrations/1684488676083-TxLock.ts
@@ -1,0 +1,15 @@
+import {MigrationInterface, QueryRunner, TableIndex} from "typeorm";
+
+export class TxLock1684488676083 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(`CREATE TABLE "tx_lock" ("lockHash" varchar NOT NULL, "transactionHash" varchar NOT NULL, PRIMARY KEY ("transactionHash", "lockHash"))`)
+      await queryRunner.createIndex("tx_lock", new TableIndex({ columnNames: ['lockHash'] }))
+      await queryRunner.createIndex("tx_lock", new TableIndex({ columnNames: ['transactionHash'] }))
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(`DROP TABLE "tx_lock"`)
+    }
+
+}

--- a/packages/neuron-wallet/src/database/chain/ormconfig.ts
+++ b/packages/neuron-wallet/src/database/chain/ormconfig.ts
@@ -18,6 +18,7 @@ import AddressDescription from './entities/address-description'
 import MultisigConfig from './entities/multisig-config'
 import MultisigOuput from './entities/multisig-output'
 import SyncProgress from './entities/sync-progress'
+import TxLock from './entities/tx-lock'
 
 import { InitMigration1566959757554 } from './migrations/1566959757554-InitMigration'
 import { AddTypeAndHasData1567144517514 } from './migrations/1567144517514-AddTypeAndHasData'
@@ -51,6 +52,7 @@ import { UpdateOutputChequeLockHash1652945662504 } from './migrations/1652945662
 import { RemoveAddressesMultisigConfig1651820157100 } from './migrations/1651820157100-RemoveAddressesMultisigConfig'
 import { AddSyncProgress1676441837373 } from './migrations/1676441837373-AddSyncProgress'
 import { AddTypeSyncProgress1681360188494 } from './migrations/1681360188494-AddTypeSyncProgress'
+import { TxLock1684488676083 } from './migrations/1684488676083-TxLock'
 
 export const CONNECTION_NOT_FOUND_NAME = 'ConnectionNotFoundError'
 
@@ -84,6 +86,7 @@ const connectOptions = async (genesisBlockHash: string): Promise<SqliteConnectio
       MultisigConfig,
       MultisigOuput,
       SyncProgress,
+      TxLock,
     ],
     migrations: [
       InitMigration1566959757554,
@@ -118,6 +121,7 @@ const connectOptions = async (genesisBlockHash: string): Promise<SqliteConnectio
       RemoveAddressesMultisigConfig1651820157100,
       AddSyncProgress1676441837373,
       AddTypeSyncProgress1681360188494,
+      TxLock1684488676083,
     ],
     logger: 'simple-console',
     logging,

--- a/packages/neuron-wallet/src/utils/const.ts
+++ b/packages/neuron-wallet/src/utils/const.ts
@@ -9,6 +9,8 @@ export const DEFAULT_UDT_SYMBOL = 'Unknown'
 export const MIN_SUDT_CAPACITY = 142 * 10 ** 8
 export const MIN_CELL_CAPACITY = 61 * 10 ** 8
 export const START_WITHOUT_INDEXER = -4
+export const DEFAULT_ARGS_LENGTH = 42
+export const CHEQUE_ARGS_LENGTH = 82
 
 export enum ResponseCode {
   Fail,

--- a/packages/neuron-wallet/tests/block-sync-renderer/queue.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-renderer/queue.test.ts
@@ -250,7 +250,11 @@ describe('queue', () => {
                 tx.blockHash = fakeTxWithStatus2.txStatus.blockHash!
                 tx.blockNumber = BigInt(fakeTxWithStatus2.transaction.blockNumber!).toString()
                 tx.timestamp = BigInt(fakeTxWithStatus2.transaction.timestamp!).toString()
-                expect(stubbedSaveFetchFn).toHaveBeenCalledWith(tx)
+                expect(stubbedSaveFetchFn).toHaveBeenCalledWith(tx, new Set([
+                  addressInfo.blake160,
+                  Multisig.hash([addressInfo.blake160]),
+                  SystemScriptInfo.generateSecpScript(addressInfo.blake160).computeHash().slice(0, 42),
+                ]))
               }
             })
             it('checks and generate new addresses', () => {

--- a/packages/neuron-wallet/tests/services/tx/transaction-persistor.test.ts
+++ b/packages/neuron-wallet/tests/services/tx/transaction-persistor.test.ts
@@ -4,6 +4,10 @@ import initConnection from '../../../src/database/chain/ormconfig'
 import TransactionEntity from '../../../src/database/chain/entities/transaction'
 import { getConnection } from 'typeorm'
 import transactions from '../../setupAndTeardown/transactions.fixture'
+import AssetAccountInfo from '../../../src/models/asset-account-info'
+import SystemScriptInfo from '../../../src/models/system-script-info'
+import Multisig from '../../../src/models/multisig'
+import TxLockEntity from '../../../src/database/chain/entities/tx-lock'
 
 const [tx, tx2] = transactions
 
@@ -64,6 +68,97 @@ describe('TransactionPersistor', () => {
           })
         })
       })
+    })
+  })
+
+  describe('#convertTransactionAndSave with lockargs', () => {
+    beforeEach(async () => {
+      const connection = getConnection()
+      await connection.synchronize(true)
+    })
+    it('filter not current args', async () => {
+      await TransactionPersistor.convertTransactionAndSave(tx, TxSaveType.Fetch, new Set([tx.outputs[0].lock.args]))
+      const loadedTx = await getConnection()
+        .getRepository(TransactionEntity)
+        .createQueryBuilder('tx')
+        .leftJoinAndSelect('tx.inputs', 'input')
+        .leftJoinAndSelect('tx.outputs', 'output')
+        .where(`tx.hash = :txHash`, { txHash: tx.hash })
+        .getOne()
+      expect(loadedTx?.inputs.length).toBe(0)
+      expect(loadedTx?.outputs.length).toBe(1)
+      expect(loadedTx?.outputs[0].lockArgs).toBe(tx.outputs[0].lock.args)
+      const txLocks = await getConnection()
+        .getRepository(TxLockEntity)
+        .find({ transactionHash: tx.hash })
+      expect(txLocks.length).toBe(1)
+      expect(txLocks[0].lockHash).toBe(tx.inputs[0].lock?.computeHash())
+    })
+    it('all args is current', async () => {
+      const args = [...tx.inputs.map(v => v.lock?.args), ...tx.outputs.map(v => v.lock.args)].filter((v): v is string => !!v)
+      await TransactionPersistor.convertTransactionAndSave(tx, TxSaveType.Fetch, new Set(args))
+      const loadedTx = await getConnection()
+        .getRepository(TransactionEntity)
+        .createQueryBuilder('tx')
+        .leftJoinAndSelect('tx.inputs', 'input')
+        .leftJoinAndSelect('tx.outputs', 'output')
+        .where(`tx.hash = :txHash`, { txHash: tx.hash })
+        .getOne()
+      expect(loadedTx?.inputs.length).toBe(1)
+      expect(loadedTx?.outputs.length).toBe(2)
+      const txLocks = await getConnection()
+        .getRepository(TxLockEntity)
+        .find({ transactionHash: tx.hash })
+      expect(txLocks.length).toBe(0)
+    })
+    it('filter with receive cheque and send cheque', async () => {
+      const assetAccountInfo = new AssetAccountInfo()
+      const txWithCheque = Transaction.fromObject(tx)
+      const outputReceiveChequeLock = assetAccountInfo.generateChequeScript(txWithCheque.outputs[0].lockHash, `0x${'0'.repeat(42)}`)
+      const outputSendChequeLock = assetAccountInfo.generateChequeScript(`0x${'0'.repeat(42)}`, txWithCheque.outputs[0].lockHash)
+      txWithCheque.outputs[0].setLock(outputReceiveChequeLock)
+      txWithCheque.outputs[1].setLock(outputSendChequeLock)
+      const args = [...tx.inputs.map(v => v.lock?.args), ...tx.outputs.map(v => v.lock.args)].filter((v): v is string => !!v).map(v => [
+        v,
+        SystemScriptInfo.generateSecpScript(v).computeHash().slice(0, 42),
+      ]).flat()
+      await TransactionPersistor.convertTransactionAndSave(txWithCheque, TxSaveType.Fetch, new Set(args))
+      const loadedTx = await getConnection()
+        .getRepository(TransactionEntity)
+        .createQueryBuilder('tx')
+        .leftJoinAndSelect('tx.inputs', 'input')
+        .leftJoinAndSelect('tx.outputs', 'output')
+        .where(`tx.hash = :txHash`, { txHash: tx.hash })
+        .getOne()
+      expect(loadedTx?.inputs.length).toBe(1)
+      expect(loadedTx?.outputs.length).toBe(2)
+      const txLocks = await getConnection()
+        .getRepository(TxLockEntity)
+        .find({ transactionHash: tx.hash })
+      expect(txLocks.length).toBe(0)
+    })
+    it('filter with multi lock time', async () => {
+      const txWithCheque = Transaction.fromObject(tx)
+      const multisigLockTimeLock = SystemScriptInfo.generateMultiSignScript(Multisig.hash([txWithCheque.outputs[0].lock.args]))
+      txWithCheque.outputs[0].setLock(multisigLockTimeLock)
+      const args = [...tx.inputs.map(v => v.lock?.args), ...tx.outputs.map(v => v.lock.args)].filter((v): v is string => !!v).map(v => [
+        v,
+        Multisig.hash([v]),
+      ]).flat()
+      await TransactionPersistor.convertTransactionAndSave(txWithCheque, TxSaveType.Fetch, new Set(args))
+      const loadedTx = await getConnection()
+        .getRepository(TransactionEntity)
+        .createQueryBuilder('tx')
+        .leftJoinAndSelect('tx.inputs', 'input')
+        .leftJoinAndSelect('tx.outputs', 'output')
+        .where(`tx.hash = :txHash`, { txHash: tx.hash })
+        .getOne()
+      expect(loadedTx?.inputs.length).toBe(1)
+      expect(loadedTx?.outputs.length).toBe(2)
+      const txLocks = await getConnection()
+        .getRepository(TxLockEntity)
+        .find({ transactionHash: tx.hash })
+      expect(txLocks.length).toBe(0)
     })
   })
 })

--- a/packages/neuron-wallet/tests/services/tx/transaction-service.test.ts
+++ b/packages/neuron-wallet/tests/services/tx/transaction-service.test.ts
@@ -1,4 +1,4 @@
-import os from 'os'
+  import os from 'os'
 import fs from 'fs'
 import path from 'path'
 import TransactionService, { SearchType } from '../../../src/services/tx/transaction-service'
@@ -9,6 +9,11 @@ import accounts from '../../setupAndTeardown/accounts.fixture'
 import transactions from '../../setupAndTeardown/transactions.fixture'
 import { getConnection } from 'typeorm'
 import HdPublicKeyInfo from '../../../src/database/chain/entities/hd-public-key-info'
+import TransactionPersistor, { TxSaveType } from '../../../src/services/tx/transaction-persistor'
+import SystemScriptInfo from '../../../src/models/system-script-info'
+import { scriptToAddress } from '@nervosnetwork/ckb-sdk-utils'
+import Input from '../../../src/models/chain/input'
+import OutPoint from '../../../src/models/chain/out-point'
 
 jest.mock('../../../src/models/asset-account-info', () => {
   const originalModule = jest.requireActual('../../../src/models/asset-account-info').default
@@ -16,6 +21,37 @@ jest.mock('../../../src/models/asset-account-info', () => {
     return new originalModule('0x92b197aa1fba0f63633922c61c92375c9c074a93e85963554f5499fe1450d0e5')
   }
 })
+
+const getTransactionMock = jest.fn()
+
+jest.mock('../../../src/services/rpc-service', () => {
+  return function() {
+    return {
+      getTransaction: getTransactionMock
+    }
+  }
+})
+
+const ckbRpcExecMock = jest.fn()
+
+jest.mock('@nervosnetwork/ckb-sdk-core', () => {
+  return function() {
+    return {
+      rpc: {
+        createBatchRequest() {
+          return {
+            exec: ckbRpcExecMock
+          }
+        }
+      }
+    }
+  }
+})
+
+function resetMock() {
+  getTransactionMock.mockReset()
+  ckbRpcExecMock.mockReset()
+}
 
 describe('Test TransactionService', () => {
   beforeAll(async () => {
@@ -196,9 +232,12 @@ describe('Test TransactionService', () => {
         const DESCRIPTION = 'new description'
         stubProvider.hash = HASH
         stubProvider.description = DESCRIPTION
+        resetMock()
       })
 
       it('Should update the description', async () => {
+        getTransactionMock.mockResolvedValue({ transaction: transactions[0] })
+        ckbRpcExecMock.mockResolvedValue([])
         const origin = await TransactionService.get(stubProvider.hash)
         expect(origin!.description).toBe('')
         await TransactionService.updateDescription(stubProvider.hash, stubProvider.description)
@@ -235,11 +274,32 @@ describe('Test TransactionService', () => {
       beforeEach(() => {
         const HASH = '0x230ab250ee0ae681e88e462102e5c01a9994ac82bf0effbfb58d6c11a86579f1'
         stubProvider.hash = HASH
+        resetMock()
       })
 
       it('Should return a transaction', async () => {
+        getTransactionMock.mockResolvedValue({ transaction: transactions[0] })
+        ckbRpcExecMock.mockResolvedValue([])
         const actual = await TransactionService.get(stubProvider.hash)
         expect(actual).not.toBeUndefined()
+      })
+
+      it('Get input and outputs from rpc', async () => {
+        getTransactionMock.mockResolvedValue({ transaction: Transaction.fromObject(transactions[0]) })
+        ckbRpcExecMock.mockResolvedValue([{ transaction: { outputs: [{ capacity: '0x100', lock: transactions[0].inputs[0].lock } ]} }])
+        const actual = await TransactionService.get(stubProvider.hash)
+        expect(actual).not.toBeUndefined()
+        expect(actual?.inputs.length).toBe(transactions[0].inputs.length)
+        expect(actual?.inputs[0].capacity).toBe((+'0x100').toString())
+      })
+
+      it('Get input and outputs from rpc no tx', async () => {
+        getTransactionMock.mockResolvedValue({ transaction: Transaction.fromObject(transactions[0]) })
+        ckbRpcExecMock.mockResolvedValue([])
+        const actual = await TransactionService.get(stubProvider.hash)
+        expect(actual).not.toBeUndefined()
+        expect(actual?.inputs.length).toBe(transactions[0].inputs.length)
+        expect(actual?.inputs[0].capacity).toBeUndefined()
       })
     })
 
@@ -405,6 +465,17 @@ describe('Test TransactionService', () => {
             const actual = await TransactionService.getAllByAddresses(stubProvider, stubProvider.searchValue)
             expect(actual.totalCount).toBe(2)
           })
+
+          it('find from tx lock', async () => {
+            const tx = Transaction.fromObject(transactions[0])
+            tx.hash = `0x01${'0'.repeat(62)}`
+            const args = `0x${'0'.repeat(42)}`
+            const script = SystemScriptInfo.generateSecpScript(args)
+            tx.inputs[0].setLock(script)
+            await TransactionPersistor.convertTransactionAndSave(tx, TxSaveType.Fetch, new Set([tx.outputs[0].lock.args, tx.outputs[1].lock.args]))
+            const actual = await TransactionService.getAllByAddresses(stubProvider, scriptToAddress(script))
+            expect(actual.totalCount).toBe(1)
+          })
         })
       })
 
@@ -490,6 +561,95 @@ describe('Test TransactionService', () => {
           expect(actual.totalCount).toBe(0)
         })
       })
+    })
+  })
+
+  describe('fillInputFields', () => {
+    it('inputs is empty', async () => {
+      const inputs: Input[] = []
+      //@ts-ignore private-method
+      const actual = await TransactionService.fillInputFields(inputs)
+      expect(actual).toBe(inputs)
+    })
+    it('inputs without txHash', async () => {
+      const inputs = [
+        Input.fromObject({
+          previousOutput: null
+        })
+      ]
+      //@ts-ignore private-method
+      const actual = await TransactionService.fillInputFields(inputs)
+      expect(actual).toBe(inputs)
+    })
+    it('can not get output', async () => {
+      const inputs = [
+        Input.fromObject({
+          previousOutput: new OutPoint(`0x${'0'.repeat(64)}`, '0x0')
+        })
+      ]
+      ckbRpcExecMock.mockResolvedValueOnce([])
+      //@ts-ignore private-method
+      const actual = await TransactionService.fillInputFields(inputs)
+      expect(actual).toStrictEqual(inputs)
+    })
+    it('success fill input fields without type', async () => {
+      const inputs = [
+        Input.fromObject({
+          previousOutput: new OutPoint(`0x${'0'.repeat(64)}`, '0x0')
+        })
+      ]
+      const transactionWithStatus = {
+        transaction: {
+          outputs: [
+            {
+              capacity: '0x1000',
+              lock: {
+                codeHash: `0x${'0'.repeat(64)}`,
+                hashType: 'data',
+                args: '0x0'
+              },
+            }
+          ]
+        }
+      }
+      ckbRpcExecMock.mockResolvedValueOnce([transactionWithStatus])
+      //@ts-ignore private-method
+      const actual = await TransactionService.fillInputFields(inputs)
+      expect(actual[0].capacity).toBe('4096')
+      expect(actual[0].lock?.toSDK()).toStrictEqual(transactionWithStatus.transaction.outputs[0].lock)
+      expect(actual[0].type).toBeUndefined()
+    })
+    it('success fill input fields with type', async () => {
+      const inputs = [
+        Input.fromObject({
+          previousOutput: new OutPoint(`0x${'0'.repeat(64)}`, '0x0')
+        })
+      ]
+      const transactionWithStatus = {
+        transaction: {
+          outputs: [
+            {
+              capacity: '0x1000',
+              lock: {
+                codeHash: `0x${'0'.repeat(64)}`,
+                hashType: 'data',
+                args: '0x0'
+              },
+              type: {
+                codeHash: `0x${'1'.repeat(64)}`,
+                hashType: 'data',
+                args: '0x1'
+              }
+            }
+          ]
+        }
+      }
+      ckbRpcExecMock.mockResolvedValueOnce([transactionWithStatus])
+      //@ts-ignore private-method
+      const actual = await TransactionService.fillInputFields(inputs)
+      expect(actual[0].capacity).toBe('4096')
+      expect(actual[0].lock?.toSDK()).toStrictEqual(transactionWithStatus.transaction.outputs[0].lock)
+      expect(actual[0].type?.toSDK()).toStrictEqual(transactionWithStatus.transaction.outputs[0].type)
     })
   })
 })


### PR DESCRIPTION
To search others' addresses at the history page, I create a table `tx_lock` to save `tx_hash` map `lockHash`

1. Only save local wallets' lock into `input` and `output`, and save others' cell lockHash to `tx_lock`
2. When searching by address, search addresses from `input`, `output` and `tx_lock`.
3. When getting transaction detail, get the transaction detail from RPC.
4. Record the last block number when caching tx to `indexer_tx_hash_cache`