### PR TITLE
fix: Fix some bugs.

### DIFF
--- a/packages/neuron-wallet/src/block-sync-renderer/sync/light-connector.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/light-connector.ts
@@ -61,7 +61,7 @@ export default class LightConnector extends Connector<CKBComponents.Hash> {
     this.fetchDepCell()
   }
 
-  private async fetchDepCell() {
+  private async getDepTxs(): Promise<string[]> {
     const assetAccountInfo = new AssetAccountInfo()
     const fetchCellDeps = [
       assetAccountInfo.anyoneCanPayCellDep,
@@ -75,30 +75,36 @@ export default class LightConnector extends Connector<CKBComponents.Hash> {
     const fetchTxHashes = fetchCellDeps
       .map(v => v.outPoint.txHash)
       .map<[string, string]>(v => ['fetchTransaction', v])
-    let txs = await this.lightRpc
-      .createBatchRequest<any, string[], (CKBComponents.TransactionWithStatus | null)[]>(fetchTxHashes)
+    const txs = await this.lightRpc
+      .createBatchRequest<any, string[], (CKBComponents.TransactionWithStatus | { status: 'fetching' | 'added' | 'not_found' })[]>(fetchTxHashes)
       .exec()
-    if (txs.some(v => !v)) {
-      // if some txs fetch to added, then fetch the actural txs
-      txs = await this.lightRpc
-        .createBatchRequest<any, string[], (CKBComponents.TransactionWithStatus | null)[]>(fetchTxHashes)
-        .exec()
+    if (txs.some(v => 'status' in v && !!v.status)) {
+      // wait for light client sync the dep cell
+      await scheduler.wait(10000)
+      return await this.getDepTxs()
     }
-    const depGroupOutputsData: string[] = fetchCellDeps
+    return fetchCellDeps
       .map((v, idx) => {
         if (v.depType === DepType.DepGroup) {
-          return txs[idx]?.transaction?.outputsData?.[+v.outPoint.index]
+          const tx = txs[idx]
+          return 'status' in tx ? undefined : tx?.transaction?.outputsData?.[+v.outPoint.index]
         }
       })
       .filter<string>((v): v is string => !!v)
+  }
+
+  private async fetchDepCell() {
+    const depGroupOutputsData: string[] = await this.getDepTxs()
     const depGroupTxHashes = [
       ...new Set(depGroupOutputsData.map(v => unpackGroup.unpack(v).map(v => v.tx_hash.toHexString())).flat())
     ]
-    await this.lightRpc
-      .createBatchRequest<any, string[], (CKBComponents.TransactionWithStatus | null)[]>(
-        depGroupTxHashes.map(v => ['fetchTransaction', v])
-      )
-      .exec()
+    if (depGroupTxHashes.length) {
+      await this.lightRpc
+        .createBatchRequest<any, string[], (CKBComponents.TransactionWithStatus | { status: 'fetching' | 'added' | 'not_found' })[]>(
+          depGroupTxHashes.map(v => ['fetchTransaction', v])
+        )
+        .exec()
+    }
   }
 
   private async synchronize() {
@@ -154,9 +160,9 @@ export default class LightConnector extends Connector<CKBComponents.Hash> {
     if (!this.addressMetas.length && !appendScripts?.length) {
       return
     }
-    const sycnScripts = await this.lightRpc.getScripts()
+    const syncScripts = await this.lightRpc.getScripts()
     const existSyncscripts: Record<string, LightScriptFilter> = {}
-    sycnScripts.forEach(v => {
+    syncScripts.forEach(v => {
       existSyncscripts[scriptToHash(v.script)] = v
     })
     const currentWalletId = WalletService.getInstance().getCurrent()?.id

--- a/packages/neuron-wallet/src/controllers/app/index.ts
+++ b/packages/neuron-wallet/src/controllers/app/index.ts
@@ -59,8 +59,10 @@ export default class AppController {
     if (env.isTestMode) {
       return
     }
-    await stopCkbNode()
-    await CKBLightRunner.getInstance().stop()
+    await Promise.all([
+      stopCkbNode(),
+      CKBLightRunner.getInstance().stop(),
+    ])
   }
 
   public registerChannels(win: BrowserWindow, channels: string[]) {

--- a/packages/neuron-wallet/src/controllers/networks/index.ts
+++ b/packages/neuron-wallet/src/controllers/networks/index.ts
@@ -26,7 +26,7 @@ export default class NetworksController {
           await this.connectToNetwork(true)
         } else {
           logger.debug('Network:\tconnection dropped')
-          resetSyncTaskQueue.push(false)
+          resetSyncTaskQueue.asyncPush(false)
         }
       })
 

--- a/packages/neuron-wallet/src/services/ckb-runner.ts
+++ b/packages/neuron-wallet/src/services/ckb-runner.ts
@@ -1,12 +1,13 @@
 import env from '../env'
 import path from 'path'
 import fs from 'fs'
-import { ChildProcess, spawn } from 'child_process'
+import { ChildProcess, StdioNull, StdioPipe, spawn } from 'child_process'
 import process from 'process'
 import logger from '../utils/logger'
 import SettingsService from './settings'
 import MigrateSubject from '../models/subjects/migrate-subject'
 import IndexerService from './indexer'
+import { resetSyncTaskQueue } from '../block-sync-renderer'
 
 const platform = (): string => {
   switch (process.platform) {
@@ -83,35 +84,33 @@ export const startCkbNode = async () => {
 
   logger.info('CKB:\tstarting node...')
   const options = ['run', '-C', SettingsService.getInstance().ckbDataPath, '--indexer']
+  const stdio: (StdioNull | StdioPipe)[] = ['ignore', 'ignore', 'pipe']
   if (app.isPackaged && process.env.CKB_NODE_ASSUME_VALID_TARGET) {
     options.push('--assume-valid-target', process.env.CKB_NODE_ASSUME_VALID_TARGET)
+    stdio[1] = 'pipe'
   }
-  ckb = spawn(ckbBinary(), options, { stdio: ['ignore', 'pipe', 'pipe'] })
+  ckb = spawn(ckbBinary(), options, { stdio })
 
-  ckb.stderr &&
-    ckb.stderr.on('data', data => {
-      const dataString: string = data.toString()
-      logger.error('CKB:\trun fail:', dataString)
-      if (dataString.includes('CKB wants to migrate the data into new format')) {
-        MigrateSubject.next({ type: 'need-migrate' })
-      }
-    })
-  if (app.isPackaged && process.env.CKB_NODE_ASSUME_VALID_TARGET) {
-    ckb.stdout &&
-      ckb.stdout.on('data', data => {
-        const dataString: string = data.toString()
-        if (
-          dataString.includes(
-            `can't find assume valid target temporarily, hash: Byte32(${process.env.CKB_NODE_ASSUME_VALID_TARGET})`
-          )
-        ) {
-          isLookingValidTarget = true
-          lastLogTime = Date.now()
-        } else if (lastLogTime && Date.now() - lastLogTime > 10000) {
-          isLookingValidTarget = false
-        }
-      })
-  }
+  ckb.stderr?.on('data', data => {
+    const dataString: string = data.toString()
+    logger.error('CKB:\trun fail:', dataString)
+    if (dataString.includes('CKB wants to migrate the data into new format')) {
+      MigrateSubject.next({ type: 'need-migrate' })
+    }
+  })
+  ckb.stdout?.on('data', data => {
+    const dataString: string = data.toString()
+    if (
+      dataString.includes(
+        `can't find assume valid target temporarily, hash: Byte32(${process.env.CKB_NODE_ASSUME_VALID_TARGET})`
+      )
+    ) {
+      isLookingValidTarget = true
+      lastLogTime = Date.now()
+    } else if (lastLogTime && Date.now() - lastLogTime > 10000) {
+      isLookingValidTarget = false
+    }
+  })
 
   ckb.on('error', error => {
     logger.error('CKB:\trun fail:', error)
@@ -133,7 +132,7 @@ export const stopCkbNode = () => {
     if (ckb) {
       logger.info('CKB:\tkilling node')
       ckb.once('close', () => resolve())
-      ckb.kill('SIGKILL')
+      ckb.kill()
       ckb = null
     } else {
       resolve()
@@ -148,6 +147,7 @@ export const clearCkbNodeCache = async () => {
   await stopCkbNode()
   fs.rmSync(SettingsService.getInstance().ckbDataPath, { recursive: true, force: true })
   await startCkbNode()
+  resetSyncTaskQueue.asyncPush(true)
 }
 
 export function migrateCkbData() {

--- a/packages/neuron-wallet/src/services/indexer.ts
+++ b/packages/neuron-wallet/src/services/indexer.ts
@@ -6,6 +6,7 @@ import { clean as cleanChain } from '../database/chain'
 import SettingsService from './settings'
 import startMonitor, { stopMonitor } from './monitor'
 import NodeService from './node'
+import { resetSyncTaskQueue } from '../block-sync-renderer'
 
 export default class IndexerService {
   private constructor() {}
@@ -19,19 +20,15 @@ export default class IndexerService {
   }
 
   static clearCache = async (clearIndexerFolder = false) => {
-    if (!NodeService.getInstance().isCkbNodeExternal) {
-      await stopMonitor('ckb')
-    }
     await cleanChain()
 
-    if (clearIndexerFolder) {
+    if (!NodeService.getInstance().isCkbNodeExternal && clearIndexerFolder) {
+      await stopMonitor('ckb')
       IndexerService.getInstance().clearData()
       await new SyncedBlockNumber().setNextBlock(BigInt(0))
-    }
-
-    if (!NodeService.getInstance().isCkbNodeExternal) {
       await startMonitor('ckb', true)
     }
+    resetSyncTaskQueue.asyncPush(true)
   }
 
   static cleanOldIndexerData() {

--- a/packages/neuron-wallet/src/services/light-runner.ts
+++ b/packages/neuron-wallet/src/services/light-runner.ts
@@ -5,6 +5,7 @@ import env from '../env'
 import logger from '../utils/logger'
 import SettingsService from '../services/settings'
 import { clean } from '../database/chain'
+import { resetSyncTaskQueue } from '../block-sync-renderer'
 
 const { app } = env
 
@@ -53,7 +54,7 @@ abstract class NodeRunner {
       if (this.runnerProcess) {
         logger.info('Runner:\tkilling node')
         this.runnerProcess.once('close', () => resolve())
-        this.runnerProcess.kill('SIGKILL')
+        this.runnerProcess.kill()
         this.runnerProcess = undefined
       } else {
         resolve()
@@ -167,5 +168,6 @@ export class CKBLightRunner extends NodeRunner {
     fs.rmSync(SettingsService.getInstance().testnetLightDataPath, { recursive: true, force: true })
     await clean()
     await this.start()
+    resetSyncTaskQueue.asyncPush(true)
   }
 }

--- a/packages/neuron-wallet/src/services/monitor/ckb-monitor.ts
+++ b/packages/neuron-wallet/src/services/monitor/ckb-monitor.ts
@@ -13,8 +13,10 @@ export default class CkbMonitor extends BaseMonitor {
   }
 
   async stop(): Promise<void> {
-    await stopCkbNode()
-    await CKBLightRunner.getInstance().stop()
+    await Promise.all([
+      stopCkbNode(),
+      CKBLightRunner.getInstance().stop()
+    ])
   }
 
   name: string = 'ckb'

--- a/packages/neuron-wallet/src/utils/common.ts
+++ b/packages/neuron-wallet/src/utils/common.ts
@@ -1,14 +1,5 @@
 import logger from '../utils/logger'
 
-//TODO remove it after typescript upgrade to above 4.5
-type Awaited<T> = T extends null | undefined
-  ? T // special case for `null | undefined` when not in `--strictNullChecks` mode
-  : T extends object & { then(onfulfilled: infer F, ...args: infer _): any } // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
-  ? F extends (value: infer V, ...args: infer _) => any // if the argument to `then` is callable, extracts the first argument
-    ? Awaited<V> // recursively unwrap the value
-    : never // the argument to `then` was not callable
-  : T // non-object or non-thenable
-
 export default class CommonUtils {
   public static sleep = (ms: number): Promise<void> => {
     return new Promise(resolve => setTimeout(resolve, ms))

--- a/packages/neuron-wallet/tests/services/indexer.test.ts
+++ b/packages/neuron-wallet/tests/services/indexer.test.ts
@@ -4,6 +4,7 @@ const existsSyncMock = jest.fn()
 const rmSyncMock = jest.fn()
 const isCkbNodeExternalMock = jest.fn()
 const stopMonitorMock = jest.fn()
+const checkNodeMock = jest.fn()
 
 jest.mock('fs', () => {
   return {
@@ -26,6 +27,9 @@ jest.mock('../../src/services/settings', () => {
         set indexerDataPath(value: string) {
           setIndexerDataPathMock(value)
         },
+        get ckbDataPath() {
+          return jest.fn().mockReturnValue('')()
+        }
       }
     }
   }
@@ -35,7 +39,13 @@ jest.mock('../../src/utils/logger', () => ({
   debug: () => jest.fn(),
 }))
 
-jest.mock('../../src/models/synced-block-number', () => ({}))
+jest.mock('../../src/models/synced-block-number', () => {
+  return function() {
+    return {
+      setNextBlock: jest.fn()
+    }
+  }
+})
 
 jest.mock('../../src/database/chain', () => ({
   clean: () => jest.fn()
@@ -53,8 +63,16 @@ jest.mock('../../src/services/node', () => ({
       get isCkbNodeExternal() {
         return isCkbNodeExternalMock()
       },
+      checkNode: checkNodeMock,
     }
   },
+}))
+
+const resetSyncTaskQueueAsyncPushMock = jest.fn()
+jest.mock('../../src/block-sync-renderer', () => ({
+  resetSyncTaskQueue: {
+    asyncPush: () => resetSyncTaskQueueAsyncPushMock()
+  }
 }))
 
 describe('test IndexerService', () => {
@@ -88,15 +106,32 @@ describe('test IndexerService', () => {
   })
 
   describe('test clear cache', () => {
-    it('is external ckb node', () => {
-      isCkbNodeExternalMock.mockReturnValue(true)
-      IndexerService.clearCache()
-      expect(stopMonitorMock).toBeCalledTimes(0)
+    beforeEach(() => {
+      resetSyncTaskQueueAsyncPushMock.mockReset()
     })
-    it('is internal ckb node', () => {
+    it('is external ckb node', async () => {
+      isCkbNodeExternalMock.mockReturnValue(true)
+      await IndexerService.clearCache()
+      expect(stopMonitorMock).toBeCalledTimes(0)
+      expect(resetSyncTaskQueueAsyncPushMock).toBeCalledTimes(1)
+    })
+    it('is internal ckb node', async () => {
       isCkbNodeExternalMock.mockReturnValue(false)
-      IndexerService.clearCache()
+      await IndexerService.clearCache()
+      expect(stopMonitorMock).toBeCalledTimes(0)
+      expect(resetSyncTaskQueueAsyncPushMock).toBeCalledTimes(1)
+    })
+    it('clear indexer data with internal ckb node', async () => {
+      isCkbNodeExternalMock.mockReturnValue(false)
+      await IndexerService.clearCache(true)
       expect(stopMonitorMock).toBeCalledTimes(1)
+      expect(resetSyncTaskQueueAsyncPushMock).toBeCalledTimes(1)
+    })
+    it('clear indexer data with external ckb node', async () => {
+      isCkbNodeExternalMock.mockReturnValue(true)
+      await IndexerService.clearCache(true)
+      expect(stopMonitorMock).toBeCalledTimes(0)
+      expect(resetSyncTaskQueueAsyncPushMock).toBeCalledTimes(1)
     })
   })
 })

--- a/packages/neuron-wallet/tests/services/light-runner.test.ts
+++ b/packages/neuron-wallet/tests/services/light-runner.test.ts
@@ -20,6 +20,7 @@ const loggerErrorMock = jest.fn()
 const loggerInfoMock = jest.fn()
 const transportsGetFileMock = jest.fn()
 const cleanMock = jest.fn()
+const resetSyncTaskQueueAsyncPushMock = jest.fn()
 
 function resetMock() {
   mockFn.mockReset()
@@ -40,6 +41,7 @@ function resetMock() {
   loggerInfoMock.mockReset()
   transportsGetFileMock.mockReset()
   cleanMock.mockReset()
+  resetSyncTaskQueueAsyncPushMock.mockReset()
 }
 
 jest.doMock('../../src/env', () => ({
@@ -71,6 +73,12 @@ jest.doMock('../../src/services/settings', () => ({
 
 jest.doMock('../../src/database/chain', () => ({
   clean: cleanMock
+}))
+
+jest.doMock('../../src/block-sync-renderer', () => ({
+  resetSyncTaskQueue: {
+    asyncPush: resetSyncTaskQueueAsyncPushMock
+  }
 }))
 
 jest.doMock('process', () => ({
@@ -282,7 +290,7 @@ describe('test light runner', () => {
       CKBLightRunner.getInstance().runnerProcess = emitter
       mockFn.mockImplementation(() => { emitter.emit('close') })
       await CKBLightRunner.getInstance().stop()
-      expect(mockFn).toBeCalledWith('SIGKILL')
+      expect(mockFn).toBeCalledWith()
       expect(CKBLightRunner.getInstance().runnerProcess).toBeUndefined()
     })
   })


### PR DESCRIPTION
1. When the light client just started, some dep cells should wait for a moment to get. So if the current light client can not get the dep cells, wait for 10 seconds and try it again.
2. If process. stdout is `pipe`, it should add event listener, otherwise when call process. kill, we need to destroy the stdout
3. If we clean data without cleaning the indexer data, we should not restart the ckb node.
4. When we clean data, restart the sync task to avoid the check node skipping.