### PR TITLE
Fix clean cache and network display

### DIFF
--- a/packages/neuron-ui/src/components/NetworkStatus/index.tsx
+++ b/packages/neuron-ui/src/components/NetworkStatus/index.tsx
@@ -57,7 +57,7 @@ const NetworkStatus = ({
       ) : null}
       {isMigrate && <div className={styles.tooltip}>{t('network-status.migrating')}</div>}
       {network ? (
-        <div>
+        <div className={styles.networkDisplay}>
           <NetworkTypeLabel type={network.chain} />
           <span className={styles.name}>{network.name}</span>
         </div>

--- a/packages/neuron-ui/src/components/NetworkStatus/networkStatus.module.scss
+++ b/packages/neuron-ui/src/components/NetworkStatus/networkStatus.module.scss
@@ -9,13 +9,17 @@ $hover-bg-color: #3cc68a4d;
   font-size: 0.8rem;
   font-weight: bold;
 
-  .name {
-    position: relative;
-    display: flex;
-    align-items: center;
-    line-height: 1em;
-    word-break: break-all;
-    margin-top: 3px;
+  .networkDisplay {
+    max-width: 100%;
+
+    .name {
+      position: relative;
+      display: block;
+      line-height: 16px;
+      word-break: break-all;
+      overflow-wrap: break-word;
+      margin-top: 3px;
+    }
   }
 
   /* keep the tooltip popped to make it more obvious */

--- a/packages/neuron-wallet/src/database/chain/index.ts
+++ b/packages/neuron-wallet/src/database/chain/index.ts
@@ -7,18 +7,19 @@ import TransactionEntity from './entities/transaction'
 import SyncInfoEntity from './entities/sync-info'
 import IndexerTxHashCache from './entities/indexer-tx-hash-cache'
 import MultisigOutput from './entities/multisig-output'
+import SyncProgress from './entities/sync-progress'
 
 /*
  * Clean local sqlite storage
  */
-export const clean = async () => {
+export const clean = async (clearAllLightClientData?: boolean) => {
   await Promise.all([
     ...[InputEntity, OutputEntity, TransactionEntity, IndexerTxHashCache, MultisigOutput].map(entity => {
       return getConnection()
         .getRepository(entity)
         .clear()
     }),
-    SyncProgressService.clearCurrentWalletProgress()
+    clearAllLightClientData ? getConnection().getRepository(SyncProgress).clear() : SyncProgressService.clearCurrentWalletProgress()
   ])
   MultisigOutputChangedSubject.getSubject().next('reset')
 

--- a/packages/neuron-wallet/src/services/light-runner.ts
+++ b/packages/neuron-wallet/src/services/light-runner.ts
@@ -166,7 +166,7 @@ export class CKBLightRunner extends NodeRunner {
   async clearNodeCache(): Promise<void> {
     await this.stop()
     fs.rmSync(SettingsService.getInstance().testnetLightDataPath, { recursive: true, force: true })
-    await clean()
+    await clean(true)
     await this.start()
     resetSyncTaskQueue.asyncPush(true)
   }

--- a/packages/neuron-wallet/src/services/sync-progress.ts
+++ b/packages/neuron-wallet/src/services/sync-progress.ts
@@ -1,4 +1,4 @@
-import { getConnection, In, Not } from 'typeorm'
+import { Equal, getConnection, In, Not } from 'typeorm'
 import { scriptToHash } from '@nervosnetwork/ckb-sdk-utils'
 import { HexString } from '@ckb-lumos/base'
 import SyncProgress, { SyncAddressType } from '../database/chain/entities/sync-progress'
@@ -129,5 +129,11 @@ export default class SyncProgressService {
     await getConnection()
       .getRepository(SyncProgress)
       .delete({ walletId: currentWallet?.id })
+    await getConnection()
+      .createQueryBuilder()
+      .update(SyncProgress)
+      .set({ blockEndNumber: 0, cursor: undefined })
+      .where({ walletId: Not(Equal(currentWallet?.id)) })
+      .execute()
   }
 }


### PR DESCRIPTION
1. When cleaning all sync data, clean all local SQLite. When cleaning the current wallet, reset others' wallet sync block number.
2. Fix network name display.