### PR TITLE
fix: download x64 portable and fix running neuron locally

### DIFF
--- a/packages/neuron-wallet/src/services/ckb-runner.ts
+++ b/packages/neuron-wallet/src/services/ckb-runner.ts
@@ -30,7 +30,14 @@ const ckbPath = (): string => {
 
 const ckbBinary = (): string => {
   const binary = app.isPackaged ? path.resolve(ckbPath(), './ckb') : path.resolve(ckbPath(), `./${platform()}`, './ckb')
-  return platform() === 'win' ? binary + '.exe' : binary
+  switch (platform()) {
+    case 'win':
+      return binary + '.exe'
+    case 'mac':
+      return `${binary}-${process.arch === 'arm64' ? 'arm64' : 'x64'}`
+    default:
+      return binary
+  }
 }
 
 const initCkb = async () => {

--- a/scripts/download-ckb.sh
+++ b/scripts/download-ckb.sh
@@ -11,7 +11,7 @@ function download_macos() {
 
 function download_macos_x86_64() {
   # for macOS x64
-  CKB_FILENAME="ckb_${CKB_VERSION}_x86_64-apple-darwin"
+  CKB_FILENAME="ckb_${CKB_VERSION}_x86_64-apple-darwin-portable"
   cd $ROOT_DIR/packages/neuron-wallet/bin/mac
 
   curl -O -L "${GITHUB_RELEASE_URL}/${CKB_VERSION}/${CKB_FILENAME}.zip"

--- a/scripts/download-ckb.sh
+++ b/scripts/download-ckb.sh
@@ -23,7 +23,7 @@ function download_macos_x86_64() {
 
 function download_macos_aarch64() {
   # for macOS arm64
-  CKB_FILENAME="ckb_${CKB_VERSION}_aarch64-apple-darwin"
+  CKB_FILENAME="ckb_${CKB_VERSION}_aarch64-apple-darwin-portable"
   cd $ROOT_DIR/packages/neuron-wallet/bin/mac
 
   curl -O -L "${GITHUB_RELEASE_URL}/${CKB_VERSION}/${CKB_FILENAME}.zip"


### PR DESCRIPTION
1. Some arm64 can not run not portable x64 ckb
2. When starting neuron to develop, the ckb file should add arch.