### PR TITLE
chore: enable prettier check in ci

### DIFF
--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -1,0 +1,38 @@
+name: Check Code Style
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  default:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          cache: "yarn"
+
+      - name: Restore
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: 2022-05-07-${{ runner.os }}-${{ hashFiles('**/yarn.lock')}}
+
+      - name: Bootstrap
+        run: |
+          yarn
+
+      - name: Changed Files
+        id: changed-files
+        uses: tj-actions/changed-files@v37
+
+      - name: Prettier Check
+        run: |
+          yarn prettier --check ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
Keeping the same code style will make the project more predictable, especially when finding some code in the whole project.

To keep the code in the same style, we can 

- A. add the `"prettier/prettier": "error"` in the eslint config, and run eslint in the CI
- B. run prettier when we commit, and run `prettier && git diff --exit-code` in the CI
- C. or something others

This PR using the option A as the solution, but this solution may not fit the habits of most Neuron contributors, so I need some feedback to continue this PR

## TODO

- [ ] https://github.com/nervosnetwork/neuron/pull/2683