### PR TITLE
feat: Add package for pull request and comment

### DIFF
--- a/.github/workflows/comment_for_pr_package.yml
+++ b/.github/workflows/comment_for_pr_package.yml
@@ -1,0 +1,43 @@
+name: Comment on the pull request
+
+on:
+  workflow_run:
+    workflows: ["Package Neuron for Test"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    name: Append links to the Pull Request
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - id: download_artifact
+        uses: dawidd6/action-download-artifact@v2
+        continue-on-error: true
+        with:
+          name: package_info
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: if non exist, skip comment
+        if: ${{ steps.download_artifact.outcome == 'failure' }}
+        run: exit 0
+
+      - id: pr_number
+        run: |
+          export PR_NUM=$(cat ./pr_number)
+          echo "pr_num=$PR_NUM" >> $GITHUB_OUTPUT
+      - id: run_id
+        run: |
+          export RUN_ID=$(cat ./run_id)
+          echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+      - id: sha
+        run: |
+          export SHA=$(cat ./sha)
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
+      - uses: thollander/actions-comment-pull-request@v2
+        if: ${{ steps.pr_number.outputs.pr_num != '' && steps.run_id.outputs.run_id != '' }}
+        with:
+          message: |
+            Packaging for test is done in [${{ steps.run_id.outputs.run_id }}](https://github.com/${{github.repository}}/actions/runs/${{steps.run_id.outputs.run_id}}) for commit https://github.com/${{github.repository}}/pull/${{steps.pr_number.outputs.pr_num}}/commits/${{steps.sha.outputs.sha}} .
+          pr_number: ${{ steps.pr_number.outputs.pr_num }}

--- a/.github/workflows/package_for_test.yml
+++ b/.github/workflows/package_for_test.yml
@@ -1,6 +1,8 @@
 name: Package Neuron for Test
 
-on: [push]
+on: 
+  pull_request:
+  push:
 
 jobs:
   packaging:
@@ -16,6 +18,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     name: ${{ matrix.os }}(Node.js ${{ matrix.node }})
+    env:
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      WIN_CERTIFICATE_BASE64: ${{ secrets.WIN_CERTIFICATE_BASE64 }}
 
     steps:
       - name: Set git to use LF
@@ -62,8 +67,9 @@ jobs:
           CI: false
 
       - name: Package for MacOS
-        if: matrix.os == 'macos-latest'
+        if: ${{ matrix.os == 'macos-latest' && env.APPLE_ID != '' }}
         run: |
+          export CSC_FOR_PULL_REQUEST=true
           ./scripts/download-ckb.sh mac
           yarn package:test mac
         env:
@@ -73,8 +79,19 @@ jobs:
           CSC_LINK: ${{ secrets.MAC_CERTIFICATE_BASE64 }}
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTIFICATE_PASSWORD }}
 
+      - name: Package for MacOS for skip code sign
+        if: ${{ matrix.os == 'macos-latest' && env.APPLE_ID == '' }}
+        run: |
+          export CSC_IDENTITY_AUTO_DISCOVERY=false
+          unset APPLE_ID
+          ./scripts/download-ckb.sh mac
+          yarn package:test mac
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SKIP_NOTARIZE: true
+
       - name: Package for Windows
-        if: matrix.os == 'windows-2019'
+        if: ${{ matrix.os == 'windows-2019' && env.WIN_CERTIFICATE_BASE64 != '' }}
         run: |
           bash ./scripts/download-ckb.sh win
           yarn build
@@ -84,6 +101,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.WIN_CERTIFICATE_BASE64 }}
           CSC_KEY_PASSWORD: ${{ secrets.WIN_CERTIFICATE_PASSWORD }}
+
+      - name: Package for Windows for skip code sign
+        if: ${{ matrix.os == 'windows-2019' && env.WIN_CERTIFICATE_BASE64 == '' }}
+        run: |
+          bash ./scripts/download-ckb.sh win
+          yarn build
+          bash ./scripts/copy-ui-files.sh
+          bash ./scripts/package-for-test.sh win
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package for Linux
         if: matrix.os == 'ubuntu-20.04'
@@ -135,8 +162,31 @@ jobs:
           name: Neuron-Linux
           path: release/Neuron-*.AppImage
 
+  cache-package-info:
+    needs: [packaging]
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number and run id
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          RUN_ID: ${{ github.run_id }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mkdir -p ./package_info
+          echo $PR_NUMBER > ./package_info/pr_number
+          echo $RUN_ID > ./package_info/run_id
+          echo $SHA > ./package_info/sha
+      - uses: actions/upload-artifact@v3
+        with:
+          name: package_info
+          path: package_info/
+          retention-days: 3
   comment:
     needs: [packaging]
+    # During a pull_request event triggered by a forked repository, actions have no write access to GitHub resources and will fail on any attempt.
+    # ref https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#restrictions-on-repository-forks
+    if: ${{ github.event_name == 'push' }}
     name: Append links to the Pull Request
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/package_for_test.yml
+++ b/.github/workflows/package_for_test.yml
@@ -69,7 +69,6 @@ jobs:
       - name: Package for MacOS
         if: ${{ matrix.os == 'macos-latest' && env.APPLE_ID != '' }}
         run: |
-          export CSC_FOR_PULL_REQUEST=true
           ./scripts/download-ckb.sh mac
           yarn package:test mac
         env:

--- a/packages/neuron-wallet/scripts/notarize.js
+++ b/packages/neuron-wallet/scripts/notarize.js
@@ -6,6 +6,11 @@ exports.default = async function notarizing(context) {
     return
   }
 
+  if (process.env.SKIP_NOTARIZE === 'true') {
+    console.warn('Skip notarizing when package on pull_request')
+    return Promise.resolve('skip')
+  }
+
   const appleId = process.env.APPLE_ID;
   const appleIdPassword = process.env.APPLE_ID_PASSWORD;
 

--- a/packages/neuron-wallet/scripts/notarize.js
+++ b/packages/neuron-wallet/scripts/notarize.js
@@ -7,7 +7,7 @@ exports.default = async function notarizing(context) {
   }
 
   if (process.env.SKIP_NOTARIZE === 'true') {
-    console.warn('Skip notarizing when package on pull_request')
+    console.warn('Skip notarizing when apple id is empty')
     return Promise.resolve('skip')
   }
 


### PR DESCRIPTION
Because the trigger on `workflow_run` needs the action's yml file to exist on the default branch.
https://github.com/yanguoyu/neuron/pull/38#issuecomment-1569914593 is an example of a comment package for committing to PR.

1. Add pull_request trigger for the `Package Neuron for Test` action
2. Skip the code sign if there not exist certificate
3. Because for pull_request action, there is no access to write comments. Add a workflow to add comments on the PR. https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#restrictions-on-repository-forks. Then when the trigger on push event, add a comment on the commit, else add a comment on the PR.