### PR TITLE
Automatically pad decimal places when the deposit dialog automatically provides a maximum value with decimals

### DIFF
--- a/packages/neuron-ui/src/components/NervosDAO/hooks.ts
+++ b/packages/neuron-ui/src/components/NervosDAO/hooks.ts
@@ -12,6 +12,7 @@ import {
   shannonToCKBFormatter,
   isSuccessResponse,
   validateAmount,
+  padFractionDigitsIfDecimal,
 } from 'utils'
 
 import {
@@ -447,7 +448,7 @@ export const useOnSlide = ({
         maxDepositAmount - BigInt(CKBToShannonFormatter(`${value}`)) < BigInt(SHANNON_CKB_RATIO * MIN_AMOUNT)
           ? shannonToCKBFormatter(`${maxDepositAmount}`, false, '')
           : `${value}`
-      updateDepositValue(amount)
+      updateDepositValue(padFractionDigitsIfDecimal(amount, 8))
     },
     [updateDepositValue, maxDepositAmount]
   )

--- a/packages/neuron-ui/src/components/NervosDAO/index.tsx
+++ b/packages/neuron-ui/src/components/NervosDAO/index.tsx
@@ -15,6 +15,7 @@ import {
   getSyncStatus,
   CKBToShannonFormatter,
   clsx,
+  padFractionDigitsIfDecimal,
 } from 'utils'
 
 import { openExternal } from 'services/remote'
@@ -263,7 +264,8 @@ const NervosDAO = () => {
   useEffect(() => {
     try {
       if (BigInt(CKBToShannonFormatter(depositValue)) > maxDepositAmount) {
-        setDepositValue(shannonToCKBFormatter(`${maxDepositAmount}`, false, ''))
+        const amount = shannonToCKBFormatter(`${maxDepositAmount}`, false, '')
+        setDepositValue(padFractionDigitsIfDecimal(amount, 8))
       }
     } catch (error) {
       // ignore error

--- a/packages/neuron-ui/src/tests/formatters/padFractionDigitsIfDecimal/index.test.ts
+++ b/packages/neuron-ui/src/tests/formatters/padFractionDigitsIfDecimal/index.test.ts
@@ -1,0 +1,35 @@
+import { padFractionDigitsIfDecimal } from 'utils/formatters'
+
+describe('padFractionDigitsIfDecimal', () => {
+  it('should pad fraction digits if decimal', () => {
+    expect(padFractionDigitsIfDecimal(1.2, 5)).toBe('1.20000')
+    expect(padFractionDigitsIfDecimal(1.23456789, 3)).toBe('1.23456789')
+  })
+
+  it('should not pad fraction digits if not decimal', () => {
+    expect(padFractionDigitsIfDecimal(1, 5)).toBe('1')
+    expect(padFractionDigitsIfDecimal(123456789, 3)).toBe('123456789')
+  })
+
+  it('should handle string input', () => {
+    expect(padFractionDigitsIfDecimal('1.2', 5)).toBe('1.20000')
+    expect(padFractionDigitsIfDecimal('1.23456789', 3)).toBe('1.23456789')
+    expect(padFractionDigitsIfDecimal('1', 2)).toBe('1')
+  })
+
+  it('should handle negative numbers', () => {
+    expect(padFractionDigitsIfDecimal(-1.2, 5)).toBe('-1.20000')
+    expect(padFractionDigitsIfDecimal(-1.23456789, 3)).toBe('-1.23456789')
+    expect(padFractionDigitsIfDecimal(-1, 2)).toBe('-1')
+  })
+
+  it('should handle zero padding', () => {
+    expect(padFractionDigitsIfDecimal(1.2, 0)).toBe('1.2')
+    expect(padFractionDigitsIfDecimal(1.23456789, 0)).toBe('1.23456789')
+    expect(padFractionDigitsIfDecimal(1, 0)).toBe('1')
+  })
+
+  it('should handle non-numeric input', () => {
+    expect(padFractionDigitsIfDecimal('hello', 5)).toBe('hello')
+  })
+})

--- a/packages/neuron-ui/src/utils/formatters.ts
+++ b/packages/neuron-ui/src/utils/formatters.ts
@@ -304,3 +304,9 @@ export const errorFormatter = (error: string | FailureFromController['message'],
 
   return error.content || unknownError
 }
+
+export const padFractionDigitsIfDecimal = (num: string | number, minimumFractionDigits: number): string => {
+  const numText = num.toString()
+  const isDecimal = numText.includes('.')
+  return isDecimal ? numText.padEnd(numText.indexOf('.') + 1 + minimumFractionDigits, '0') : numText
+}


### PR DESCRIPTION
Automatically pad decimal places when the deposit dialog automatically provides a maximum value with decimals

Ref: https://github.com/Magickbase/neuron-public-issues/issues/172


https://github.com/nervosnetwork/neuron/assets/9160743/564ada69-e6b4-4245-afa6-1c5706973d3c

