### PR TITLE
fix: Remove duplicate config when get cells.

### DIFF
--- a/packages/neuron-wallet/src/services/multisig.ts
+++ b/packages/neuron-wallet/src/services/multisig.ts
@@ -91,15 +91,27 @@ export default class MultisigService {
     await getConnection().manager.remove(config)
   }
 
+  private static removeDulpicateConfig(multisigConfigs: MultisigConfig[]) {
+    const existMultisigLockHash: Set<string> = new Set()
+    return multisigConfigs.filter(v => {
+      const multisigLockHash = Multisig.getMultisigScript(v.blake160s, v.r, v.m, v.n).computeHash()
+      if (existMultisigLockHash.has(multisigLockHash)) {
+        return false
+      }
+      existMultisigLockHash.add(multisigLockHash)
+      return true
+    })
+  }
+
   static async getLiveCells(multisigConfigs: MultisigConfig[]) {
     const liveCells: MultisigOutput[] = []
     const addressCursorMap: Map<string, string> = new Map()
-    let currentMultisigConfigs = multisigConfigs
+    let currentMultisigConfigs = MultisigService.removeDulpicateConfig(multisigConfigs)
     const network = NetworksService.getInstance().getCurrent()
     while (currentMultisigConfigs.length) {
       const res = await rpcBatchRequest(
         network.remote,
-        currentMultisigConfigs.map((v) => {
+        currentMultisigConfigs.map(v => {
           const script = Multisig.getMultisigScript(v.blake160s, v.r, v.m, v.n)
           return {
             method: 'get_cells',
@@ -158,7 +170,7 @@ export default class MultisigService {
     while (currentMultisigConfigs.length) {
       const res = await rpcBatchRequest(
         network.remote,
-        currentMultisigConfigs.map((v) => {
+        currentMultisigConfigs.map(v => {
           const script = Multisig.getMultisigScript(v.blake160s, v.r, v.m, v.n)
           return {
             method: 'get_transactions',
@@ -204,13 +216,13 @@ export default class MultisigService {
       const network = await NetworksService.getInstance().getCurrent()
       const txList = await rpcBatchRequest(
         network.remote,
-        [...multisigOutputTxHashList].map((v) => ({
+        [...multisigOutputTxHashList].map(v => ({
           method: 'get_transaction',
           params: [v],
         }))
       )
       const removeOutputTxHashList: string[] = []
-      txList.forEach((v) => {
+      txList.forEach(v => {
         if (!v.error && v?.result?.transaction?.inputs?.length) {
           v?.result?.transaction?.inputs?.forEach((input: any) => {
             removeOutputTxHashList.push(input.previous_output.tx_hash + input.previous_output.index)
@@ -231,7 +243,7 @@ export default class MultisigService {
 
   static async deleteRemovedMultisigOutput() {
     const multisigConfigs = await getConnection().getRepository(MultisigConfig).createQueryBuilder().getMany()
-    const multisigLockHashList = multisigConfigs.map((v) =>
+    const multisigLockHashList = multisigConfigs.map(v =>
       scriptToHash(Multisig.getMultisigScript(v.blake160s, v.r, v.m, v.n))
     )
     await getConnection()
@@ -248,7 +260,7 @@ export default class MultisigService {
   static async saveMultisigSyncBlockNumber(multisigConfigs: MultisigConfig[], lastestBlockNumber: string) {
     const network = await NetworksService.getInstance().getCurrent()
     if (network.type === NetworkType.Light) {
-      const multisigScriptHashList = multisigConfigs.map((v) =>
+      const multisigScriptHashList = multisigConfigs.map(v =>
         scriptToHash(Multisig.getMultisigScript(v.blake160s, v.r, v.m, v.n))
       )
       const syncBlockNumbers = await getConnection()
@@ -263,7 +275,7 @@ export default class MultisigService {
       await getConnection()
         .getRepository(MultisigConfig)
         .save(
-          multisigConfigs.map((v) => {
+          multisigConfigs.map(v => {
             const blockNumber =
               syncBlockNumbersMap[scriptToHash(Multisig.getMultisigScript(v.blake160s, v.r, v.m, v.n))]
             v.lastestBlockNumber = `0x${BigInt(blockNumber).toString(16)}`
@@ -274,7 +286,7 @@ export default class MultisigService {
       await getConnection()
         .getRepository(MultisigConfig)
         .save(
-          multisigConfigs.map((v) => ({
+          multisigConfigs.map(v => ({
             ...v,
             lastestBlockNumber,
           }))
@@ -296,7 +308,7 @@ export default class MultisigService {
 
   static async saveSentMultisigOutput(transaction: Transaction) {
     const inputsOutpointList = transaction.inputs.map(
-      (input) => `${input.previousOutput?.txHash}0x${(+input.previousOutput!.index)?.toString(16)}`
+      input => `${input.previousOutput?.txHash}0x${(+input.previousOutput!.index)?.toString(16)}`
     )
     const multisigOutputs = transaction.outputs.map((output, idx) => {
       const entity = new MultisigOutput()
@@ -331,14 +343,14 @@ export default class MultisigService {
       .getRepository(MultisigConfig)
       .createQueryBuilder()
       .where({
-        walletId: currentWallet?.id
+        walletId: currentWallet?.id,
       })
       .getMany()
-    return multisigConfigs.map((v) => ({
+    return multisigConfigs.map(v => ({
       walletId: v.walletId,
       script: Multisig.getMultisigScript(v.blake160s, v.r, v.m, v.n),
       addressType: SyncAddressType.Multisig,
-      scriptType: 'lock' as CKBRPC.ScriptType
+      scriptType: 'lock' as CKBRPC.ScriptType,
     }))
   }
 }

--- a/packages/neuron-wallet/tests/services/multisig.test.ts
+++ b/packages/neuron-wallet/tests/services/multisig.test.ts
@@ -186,6 +186,46 @@ describe('multisig service', () => {
     })
   })
 
+  describe('removeDulpicateConfig', () => {
+    it('exist duplicate config', () => {
+      const multisigConfigModel = new MultisigConfigModel(
+        'walletId',
+        1,
+        2,
+        3,
+        [alice.publicKeyInBlake160, bob.publicKeyInBlake160, charlie.publicKeyInBlake160],
+      )
+      const multisigConfigs = [
+        MultisigConfig.fromModel(multisigConfigModel),
+        MultisigConfig.fromModel(multisigConfigModel),
+      ]
+      //@ts-ignore private-method
+      const res = MultisigService.removeDulpicateConfig(multisigConfigs)
+      expect(res.length).toBe(1)
+    })
+    it('non-exist duplicate config', () => {
+      const multisigConfigs = [
+        MultisigConfig.fromModel(new MultisigConfigModel(
+          'walletId',
+          1,
+          2,
+          3,
+          [alice.publicKeyInBlake160, bob.publicKeyInBlake160, charlie.publicKeyInBlake160],
+        )),
+        MultisigConfig.fromModel(new MultisigConfigModel(
+          'walletId',
+          2,
+          2,
+          3,
+          [alice.publicKeyInBlake160, bob.publicKeyInBlake160, charlie.publicKeyInBlake160],
+        )),
+      ]
+      //@ts-ignore private-method
+      const res = MultisigService.removeDulpicateConfig(multisigConfigs)
+      expect(res.length).toBe(2)
+    })
+  })
+
   describe('saveLiveMultisigOutput', () => {
     it('no live cell save', async () => {
       await MultisigService.saveLiveMultisigOutput()


### PR DESCRIPTION
The same `multisig` configs will create [MultisigOutput](https://github.com/nervosnetwork/neuron/blob/develop/packages/neuron-wallet/src/database/chain/entities/multisig-output.ts) entity. So we should remove duplicate config before calling `get_cells`.