### PR TITLE
fix: the .prettierignore file did not take effect during precommit

### DIFF
--- a/packages/neuron-ui/package.json
+++ b/packages/neuron-ui/package.json
@@ -29,12 +29,12 @@
   },
   "lint-staged": {
     "src/**/*.{js,cjs,mjs,jsx,ts,tsx}": [
-      "prettier --write",
+      "prettier --ignore-path ../../.prettierignore --write",
       "eslint --fix",
       "git add"
     ],
     "src/**/*.{css,scss}": [
-      "prettier --write",
+      "prettier --ignore-path ../../.prettierignore --write",
       "git add"
     ]
   },

--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -31,7 +31,7 @@
   },
   "lint-staged": {
     "src/**/*.{js,cjs,mjs,jsx,ts,tsx}": [
-      "prettier --write",
+      "prettier --ignore-path ../../.prettierignore --write",
       "eslint --fix",
       "git add"
     ]


### PR DESCRIPTION
When Lerna executes package scripts, it uses the package directory as the execution directory.
However, Prettier only reads the `.prettierignore` file in the execution directory, so the root-level `.prettierignore` file is not effective when running `npx lerna run --no-bail --stream precommit`.

Since VSCode only reads the `.prettierignore` file in the opened folder, the file must exist in the root directory. Therefore, the current solution is adapted from https://github.com/prettier/prettier/issues/4081#issuecomment-1157180927.