### PR TITLE
chore: check only the supported types

### DIFF
--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -32,7 +32,10 @@ jobs:
       - name: Changed Files
         id: changed-files
         uses: tj-actions/changed-files@v37
+        with:
+          files: "**/*.{js,cjs,mjs,jsx,ts,tsx,css,scss}"
 
       - name: Prettier Check
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           yarn prettier --check ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
This PR picks the supported files of prettier when running the code style checking. 

The below example shows it skip the `*.lock` and pick the `*.ts`

- commit: https://github.com/homura/neuron/commit/6a3afbc0f09ac2941e62512a375d1897daa3ec2c
- workflow result: https://github.com/homura/neuron/actions/runs/5412266831/jobs/9836139129#step:7:2