### PR TITLE
chore(CI): Checkout pr branch when event is issue_comment

### DIFF
--- a/.github/workflows/package_for_test.yml
+++ b/.github/workflows/package_for_test.yml
@@ -49,17 +49,23 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
 
+      - name: Checkout for push
+        uses: actions/checkout@v3
+        if: ${{ github.event_name == 'push' }}
+
       - name: Get PR Branch
         if: github.event_name == 'issue_comment'
         id: comment-branch
-        uses: xt0rted/pull-request-comment-branch@v1
+        uses: yanguoyu/pull-request-comment-branch@v2.1.0-beta
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Checkout
+      - name: Checkout for PR
         uses: actions/checkout@v3
+        if: ${{ github.event_name == 'issue_comment' }}
         with:
-          ref: ${{ steps.comment-branch.outputs.ref }}
+          repository: ${{ steps.comment-branch.outputs.head_owner }}/${{ steps.comment-branch.outputs.head_repo }}
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
Because the `outputs.ref` is the fork repo's branch name. So we should add the repo parameter for `checkout` action when the event is `issue_comment`.

Examples:
Trigger by push: https://github.com/yanguoyu/neuron/actions/runs/5419801750
Trigger by issue_comment with current repo: [pr](https://github.com/yanguoyu/neuron/pull/52), action: https://github.com/yanguoyu/neuron/actions/runs/5441117221
Trigger by issue_comment with fork repo: [pr](https://github.com/yanguoyu/neuron/pull/51), action: https://github.com/yanguoyu/neuron/actions/runs/5441115012
