### PR TITLE
ci: fix api of github-scripts

### DIFF
--- a/.github/workflows/add-replied-label.yml
+++ b/.github/workflows/add-replied-label.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           script: |
             try{
-              const response = await github.repos.checkCollaborator({
+              const response = await github.rest.repos.checkCollaborator({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 username: context.payload.comment.user.login,
@@ -33,7 +33,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const response = await github.issues.get({
+            const response = await github.rest.issues.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
@@ -48,7 +48,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            await github.issues.addLabels({
+            await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,


### PR DESCRIPTION
A breaking change was introduced in github-scripts@v5 that all rest apis are moved from top-level to top-level.rest.

The breaking change in v5 was not noticed when the script was upgraded from v4 to v6

Ref: https://github.com/octokit/plugin-rest-endpoint-methods.js/releases/tag/v5.0.0

---

Before:
![image](https://github.com/nervosnetwork/neuron/assets/7271329/4fb4b0c7-c839-4bc8-87b7-7b372b3964c4)

After:
![image](https://github.com/nervosnetwork/neuron/assets/7271329/56be1695-b56d-4f6b-9cff-3c952fbc3dca)
