### PR TITLE
ci: remove 'files' option in typos action

### DIFF
--- a/.github/workflows/check-spell.yml
+++ b/.github/workflows/check-spell.yml
@@ -9,10 +9,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - id: changed-files
-        uses: tj-actions/changed-files@v36
-
       - uses: crate-ci/typos@master
-        with:
-          files: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
The 'files' option is prior to the configuration so the 'extend-exclude' list doesn't work in action.

This commit removes the 'files' option in action to adopt the scope defined in _typos.toml

Ref:
  - action run failed: https://github.com/Magickbase/nervos-official-website/actions/runs/5820152771
  - action run for debug: https://github.com/Magickbase/nervos-official-website/actions/runs/5820219884/job/15780159247