### PR TITLE
feat: Add check ckb node update or compatibility

### DIFF
--- a/compatible.csv
+++ b/compatible.csv
@@ -1,5 +1,5 @@
 CKB,0.110,0.109,0.108,0.107,0.106,0.105,0.104,0.103
-Neuron
+Neuron,,,,,,,,
 0.110,yes,yes,no,no,no,no,no,no
 0.106,no,no,yes,yes,yes,yes,no,no
 0.103,no,no,no,no,no,no,yes,yes

--- a/compatible.csv
+++ b/compatible.csv
@@ -1,0 +1,5 @@
+CKB,0.110,0.109,0.108,0.107,0.106,0.105,0.104,0.103
+Neuron
+0.110,yes,yes,no,no,no,no,no,no
+0.106,no,no,yes,yes,yes,yes,no,no
+0.103,no,no,no,no,no,no,yes,yes

--- a/packages/neuron-ui/src/containers/Main/index.tsx
+++ b/packages/neuron-ui/src/containers/Main/index.tsx
@@ -57,6 +57,7 @@ const MainContent = () => {
         show={!!globalAlertDialog}
         title={globalAlertDialog?.title}
         message={globalAlertDialog?.message}
+        action={globalAlertDialog?.action}
         type={globalAlertDialog?.type ?? 'success'}
         onCancel={onCancelGlobalDialog}
       />

--- a/packages/neuron-ui/src/locales/en.json
+++ b/packages/neuron-ui/src/locales/en.json
@@ -22,7 +22,10 @@
       "sync-not-start": "Sync not started yet",
       "connecting": "Connecting",
       "experimental-functions": "Experimental",
-      "s-udt": "Asset Accounts"
+      "s-udt": "Asset Accounts",
+      "update-neuron-with-ckb": "The version of the CKB node does not match Neuron (v{{ version }}), which may cause compatibility issues. Please update to the latest version of Neuron.",
+      "ckb-node-compatible": "CKB node is not compatible with Neuron (v{{ version }}), please check before further operation.",
+      "ckb-without-indexer": "Please add '--indexer' option to start local node"
     },
     "network-status": {
       "tooltip": {

--- a/packages/neuron-ui/src/locales/zh-tw.json
+++ b/packages/neuron-ui/src/locales/zh-tw.json
@@ -22,7 +22,10 @@
       "sync-not-start": "同步尚未開始",
       "connecting": "正在連接節點",
       "experimental-functions": "實驗性功能",
-      "s-udt": "資產賬戶"
+      "s-udt": "資產賬戶",
+      "update-neuron-with-ckb": "CKB 節點版本與 Neuron (v{{ version }}) 不匹配，可能導致兼容性問題。請更新到最新版 Neuron。",
+      "ckb-node-compatible": "CKB 節點版本與 Neuron (v{{ version }}) 不兼容，請謹慎使用。",
+      "ckb-without-indexer": "請添加 '--indexer' 參數來啟動本地節點"
     },
     "network-status": {
       "tooltip": {

--- a/packages/neuron-ui/src/locales/zh.json
+++ b/packages/neuron-ui/src/locales/zh.json
@@ -22,7 +22,10 @@
       "sync-not-start": "同步尚未开始",
       "connecting": "正在连接节点",
       "experimental-functions": "实验性功能",
-      "s-udt": "资产账户"
+      "s-udt": "资产账户",
+      "update-neuron-with-ckb": "CKB 节点版本与 Neuron (v{{ version }}) 不匹配，可能导致兼容性问题。请更新到最新版 Neuron。",
+      "ckb-node-compatible": "CKB 节点版本与 Neuron (v{{ version }}) 不兼容，请谨慎使用。",
+      "ckb-without-indexer": "请添加 '--indexer' 参数来启动本地节点"
     },
     "network-status": {
       "tooltip": {

--- a/packages/neuron-ui/src/services/remote/app.ts
+++ b/packages/neuron-ui/src/services/remote/app.ts
@@ -24,6 +24,22 @@ export const stopProcessMonitor = remoteApi<'ckb'>('stop-process-monitor')
 export const startProcessMonitor = remoteApi<'ckb'>('start-process-monitor')
 export const getIsCkbRunExternal = remoteApi<void, boolean>('is-ckb-run-external')
 
+export enum VerifyCkbVersionResult {
+  Same,
+  Compatible,
+  ShouldUpdate,
+  Incompatible,
+}
+
+export type VerifyExternalCkbNodeRes =
+  | {
+      ckb: VerifyCkbVersionResult
+      withIndexer: boolean
+    }
+  | undefined
+
+export const verifyExternalCkbNode = remoteApi<void, VerifyExternalCkbNodeRes>('verify-external-ckb-node')
+
 export const clearCellCache = remoteApi<Controller.ClearCache.Params>('clear-cache')
 
 export const invokeShowErrorMessage = remoteApi<{ title: string; content: string }>('show-error-message')

--- a/packages/neuron-ui/src/services/remote/app.ts
+++ b/packages/neuron-ui/src/services/remote/app.ts
@@ -24,20 +24,13 @@ export const stopProcessMonitor = remoteApi<'ckb'>('stop-process-monitor')
 export const startProcessMonitor = remoteApi<'ckb'>('start-process-monitor')
 export const getIsCkbRunExternal = remoteApi<void, boolean>('is-ckb-run-external')
 
-export enum VerifyCkbVersionResult {
-  Same,
-  Compatible,
-  ShouldUpdate,
-  Incompatible,
-}
-
 export type VerifyExternalCkbNodeRes =
   | {
-      ckb: VerifyCkbVersionResult
+      ckbIsCompatible: boolean | undefined
       withIndexer: boolean
+      shouldUpdate: boolean
     }
   | undefined
-
 export const verifyExternalCkbNode = remoteApi<void, VerifyExternalCkbNodeRes>('verify-external-ckb-node')
 
 export const clearCellCache = remoteApi<Controller.ClearCache.Params>('clear-cache')

--- a/packages/neuron-ui/src/services/remote/remoteApiWrapper.ts
+++ b/packages/neuron-ui/src/services/remote/remoteApiWrapper.ts
@@ -49,6 +49,7 @@ type Action =
   | 'is-dark'
   | 'set-theme'
   | 'is-ckb-run-external'
+  | 'verify-external-ckb-node'
   // Wallets
   | 'get-all-wallets'
   | 'get-current-wallet'

--- a/packages/neuron-ui/src/types/App/index.d.ts
+++ b/packages/neuron-ui/src/types/App/index.d.ts
@@ -139,6 +139,7 @@ declare namespace State {
     title?: string
     message?: string
     type: 'success' | 'failed' | 'warning'
+    action?: 'ok' | 'cancel' | 'all'
     onClose?: () => void
     onOk?: () => void
     onCancel?: () => void

--- a/packages/neuron-ui/src/types/Subject/index.d.ts
+++ b/packages/neuron-ui/src/types/Subject/index.d.ts
@@ -67,5 +67,6 @@ declare namespace Subject {
     title?: string
     message?: string
     type: 'success' | 'failed' | 'warning'
+    action?: 'ok' | 'cancel'
   }
 }

--- a/packages/neuron-ui/src/widgets/AlertDialog/index.tsx
+++ b/packages/neuron-ui/src/widgets/AlertDialog/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDialog } from 'utils'
 import Button from 'widgets/Button'
@@ -8,6 +8,7 @@ import Tips from 'widgets/Icons/Tips.png'
 import styles from './alertDialog.module.scss'
 
 type AlertType = 'success' | 'failed' | 'warning'
+type Action = 'ok' | 'cancel' | 'all'
 
 const AlertDialog = ({
   show,
@@ -17,6 +18,7 @@ const AlertDialog = ({
   onClose,
   onOk,
   onCancel,
+  action,
 }: {
   show?: boolean
   title?: string
@@ -25,10 +27,17 @@ const AlertDialog = ({
   onClose?: () => void
   onOk?: () => void
   onCancel?: () => void
+  action?: Action
 }) => {
   const [t] = useTranslation()
   const dialogRef = useRef<HTMLDialogElement | null>(null)
   useDialog({ show, dialogRef, onClose: onClose || (() => {}) })
+  const actions = useMemo<('cancel' | 'ok')[]>(() => {
+    if (action) {
+      return action === 'all' ? ['cancel', 'ok'] : [action]
+    }
+    return type === 'warning' ? ['cancel', 'ok'] : ['ok']
+  }, [action, type])
 
   return (
     <dialog ref={dialogRef} className={styles.alertDialog}>
@@ -38,13 +47,12 @@ const AlertDialog = ({
       <h2 className={styles.title}>{title}</h2>
       <p className={styles.message}>{message}</p>
       <div className={styles.actions}>
-        {type === 'failed' && <Button type="confirm" onClick={onCancel} label={t('common.confirm')} />}
-        {type === 'success' && <Button type="confirm" onClick={onCancel || onOk} label={t('common.confirm')} />}
-        {type === 'warning' && (
-          <>
+        {actions.map(v =>
+          v === 'cancel' ? (
             <Button type="cancel" onClick={onCancel} label={t('common.cancel')} />
-            <Button type="confirm" onClick={onOk} label={t('common.confirm')} />
-          </>
+          ) : (
+            <Button type="confirm" onClick={onCancel || onOk} label={t('common.confirm')} />
+          )
         )}
       </div>
     </dialog>

--- a/packages/neuron-wallet/electron-builder.yml
+++ b/packages/neuron-wallet/electron-builder.yml
@@ -13,7 +13,7 @@ afterSign: scripts/notarize.js
 files:
   - from: "../.."
     to: "."
-    filter: ["!**/*", ".ckb-version", ".ckb-light-version", "ormconfig.json"]
+    filter: ["!**/*", ".ckb-version", ".ckb-light-version", "ormconfig.json", "compatible.csv"]
   - package.json
   - dist
   - ".env"

--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -34,6 +34,11 @@
       "prettier --ignore-path ../../.prettierignore --write",
       "eslint --fix",
       "git add"
+    ],
+    "test/**/*.{js,cjs,mjs,jsx,ts,tsx}": [
+      "prettier --ignore-path ../../.prettierignore --write",
+      "eslint --fix",
+      "git add"
     ]
   },
   "dependencies": {

--- a/packages/neuron-wallet/src/controllers/api.ts
+++ b/packages/neuron-wallet/src/controllers/api.ts
@@ -296,6 +296,13 @@ export default class ApiController {
       }
     })
 
+    handle('verify-external-ckb-node', async () => {
+      return {
+        status: ResponseCode.Success,
+        result: await NodeService.getInstance().verifyExternalCkbNode(),
+      }
+    })
+
     // Wallets
 
     handle('get-all-wallets', async () => {

--- a/packages/neuron-wallet/src/locales/en.ts
+++ b/packages/neuron-wallet/src/locales/en.ts
@@ -218,12 +218,6 @@ export default {
           cancel: 'Cancel',
         },
       },
-      'node-version-different': {
-        message: 'The node version is inconsistent with Neuron(v {{ version }}), please use after confirmation',
-      },
-      'ckb-without-indexer': {
-        message: "Please add '--indexer' option to start local node",
-      },
     },
     prompt: {
       password: {

--- a/packages/neuron-wallet/src/locales/zh-tw.ts
+++ b/packages/neuron-wallet/src/locales/zh-tw.ts
@@ -205,12 +205,6 @@ export default {
           cancel: '取消',
         },
       },
-      'node-version-different': {
-        message: '節點版本與 Neuron(v {{ version }}) 不壹致，請確認後使用',
-      },
-      'ckb-without-indexer': {
-        message: "請添加 '--indexer' 參數來啟動本地節點",
-      },
     },
     prompt: {
       password: {

--- a/packages/neuron-wallet/src/locales/zh.ts
+++ b/packages/neuron-wallet/src/locales/zh.ts
@@ -206,12 +206,6 @@ export default {
           cancel: '取消',
         },
       },
-      'node-version-different': {
-        message: '节点版本与 Neuron(v {{ version }}) 不一致，请确认后使用',
-      },
-      'ckb-without-indexer': {
-        message: "请添加 '--indexer' 参数来启动本地节点",
-      },
     },
     prompt: {
       password: {

--- a/packages/neuron-wallet/src/models/subjects/show-global-dialog.ts
+++ b/packages/neuron-wallet/src/models/subjects/show-global-dialog.ts
@@ -4,6 +4,7 @@ const ShowGlobalDialogSubject = new Subject<{
   title?: string
   message?: string
   type: 'success' | 'failed' | 'warning'
+  action?: 'ok' | 'cancel'
 }>()
 
 export default ShowGlobalDialogSubject


### PR DESCRIPTION
All of the scenes should start ckb external.
1. When Neuron has an updated version, and the running external ckb version is bigger than Neuron's internal ckb version
This scene can test with https://github.com/nervosnetwork/neuron/pull/2807, the external ckb version should be bigger than v0.109.0
<img width="588" alt="image" src="https://github.com/nervosnetwork/neuron/assets/12881040/0f9d123b-2f63-4989-ab7f-3bd321e35dfe">

2. When the running external ckb version is not compatible with Neuron.
This scene can be tested with the current pr package, and the external ckb version should not be 0.109 ~ 0.110
<img width="573" alt="image" src="https://github.com/nervosnetwork/neuron/assets/12881040/7b7f8d89-6fcb-4368-b350-b6edfea448ba">

