### PR TITLE
fix: Fix miss saving some inputs and outputs with optimize input and output storage

### DIFF
--- a/packages/neuron-wallet/src/block-sync-renderer/index.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/index.ts
@@ -19,6 +19,7 @@ import MultisigConfigDbChangedSubject from '../models/subjects/multisig-config-d
 import Multisig from '../services/multisig'
 import { SyncAddressType } from '../database/chain/entities/sync-progress'
 import { debounceTime } from 'rxjs/operators'
+import { TransactionPersistor } from '../services/tx'
 
 let network: Network | null
 let child: ChildProcess | null = null
@@ -63,6 +64,7 @@ export const resetSyncTask = async (startTask = true) => {
 
   if (startTask) {
     await WalletService.getInstance().maintainAddressesIfNecessary()
+    await TransactionPersistor.checkTxLock()
     await CommonUtils.sleep(3000)
     await createBlockSyncTask()
   }

--- a/packages/neuron-wallet/src/database/chain/entities/indexer-tx-hash-cache.ts
+++ b/packages/neuron-wallet/src/database/chain/entities/indexer-tx-hash-cache.ts
@@ -66,4 +66,25 @@ export default class IndexerTxHashCache extends BaseEntity {
     onUpdate: 'CURRENT_TIMESTAMP',
   })
   updatedAt!: Date
+
+  static fromObject(obj: {
+    txHash: string
+    blockNumber: number
+    blockHash: string
+    blockTimestamp: string
+    lockHash: string
+    address: string
+    walletId: string
+  }) {
+    const result = new IndexerTxHashCache()
+    result.txHash = obj.txHash
+    result.blockNumber = obj.blockNumber
+    result.blockHash = obj.blockHash
+    result.blockTimestamp = obj.blockTimestamp
+    result.lockHash = obj.lockHash
+    result.address = obj.address
+    result.walletId = obj.walletId
+    result.isProcessed = false
+    return result
+  }
 }

--- a/packages/neuron-wallet/src/database/chain/entities/sync-info.ts
+++ b/packages/neuron-wallet/src/database/chain/entities/sync-info.ts
@@ -21,7 +21,7 @@ export default class SyncInfo {
     return res
   }
 
-  static getLastCachedKey(walletId: string) {
-    return `lastCachedBlockNumber_${walletId}`
+  static getLastCachedKey(blake160: string) {
+    return `lastCachedBlockNumber_${blake160}`
   }
 }

--- a/packages/neuron-wallet/src/database/chain/entities/tx-lock.ts
+++ b/packages/neuron-wallet/src/database/chain/entities/tx-lock.ts
@@ -1,4 +1,4 @@
-import { BaseEntity, Entity, PrimaryColumn } from 'typeorm'
+import { BaseEntity, Column, Entity, Index, PrimaryColumn } from 'typeorm'
 
 @Entity()
 export default class TxLock extends BaseEntity {
@@ -12,10 +12,18 @@ export default class TxLock extends BaseEntity {
   })
   lockHash!: string
 
-  static fromObject(obj: { txHash: string; lockHash: string }) {
+  @Column({
+    type: 'varchar',
+  })
+  @Index()
+  // check whether saving wallet blake160
+  lockArgs!: string
+
+  static fromObject(obj: { txHash: string; lockHash: string; lockArgs: string }) {
     const res = new TxLock()
     res.transactionHash = obj.txHash
     res.lockHash = obj.lockHash
+    res.lockArgs = obj.lockArgs
     return res
   }
 }

--- a/packages/neuron-wallet/src/database/chain/migrations/1694746034975-TxLockAddArgs.ts
+++ b/packages/neuron-wallet/src/database/chain/migrations/1694746034975-TxLockAddArgs.ts
@@ -1,0 +1,15 @@
+import {MigrationInterface, QueryRunner, TableIndex} from "typeorm";
+
+export class TxLockAddArgs1694746034975 implements MigrationInterface {
+    name = 'TxLockAddArgs1694746034975'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "tx_lock" ADD COLUMN "lockArgs" varchar;`);
+        await queryRunner.createIndex("tx_lock", new TableIndex({ columnNames: ["lockArgs"] }))
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "tx_lock" DROP COLUMN "lockArgs" varchar;`);
+    }
+
+}

--- a/packages/neuron-wallet/src/database/chain/ormconfig.ts
+++ b/packages/neuron-wallet/src/database/chain/ormconfig.ts
@@ -54,6 +54,7 @@ import { AddSyncProgress1676441837373 } from './migrations/1676441837373-AddSync
 import { AddTypeSyncProgress1681360188494 } from './migrations/1681360188494-AddTypeSyncProgress'
 import { TxLock1684488676083 } from './migrations/1684488676083-TxLock'
 import { ResetSyncProgressPrimaryKey1690361215400 } from './migrations/1690361215400-ResetSyncProgressPrimaryKey'
+import { TxLockAddArgs1694746034975 } from './migrations/1694746034975-TxLockAddArgs'
 
 export const CONNECTION_NOT_FOUND_NAME = 'ConnectionNotFoundError'
 
@@ -124,6 +125,7 @@ const connectOptions = async (genesisBlockHash: string): Promise<SqliteConnectio
       AddTypeSyncProgress1681360188494,
       TxLock1684488676083,
       ResetSyncProgressPrimaryKey1690361215400,
+      TxLockAddArgs1694746034975,
     ],
     logger: 'simple-console',
     logging,

--- a/packages/neuron-wallet/src/services/addresses.ts
+++ b/packages/neuron-wallet/src/services/addresses.ts
@@ -27,9 +27,9 @@ export interface AddressMetaInfo {
 export default class AddressService {
   private static minUnusedAddressCount: number = 3
 
-  private static createQueue = queueWrapper(AddressService.create)
-
   public static generateAndSaveForPublicKeyQueue = queueWrapper(AddressService.generateAndSaveForPublicKey)
+
+  public static generateAndSaveForExtendedKeyQueue = queueWrapper(AddressService.generateAndSaveForExtendedKey)
 
   private static async create({ addresses }: { addresses: AddressInterface[] }) {
     const walletIds = new Set(addresses.map(v => v.walletId))
@@ -74,8 +74,7 @@ export default class AddressService {
     )
 
     const generatedAddresses: AddressInterface[] = [...addresses.receiving, ...addresses.change]
-    await AddressService.createQueue.asyncPush({ addresses: generatedAddresses })
-
+    await AddressService.create({ addresses: generatedAddresses })
     return generatedAddresses
   }
 
@@ -141,23 +140,29 @@ export default class AddressService {
     return allGeneratedAddresses
   }
 
-  public static async generateAndSaveForExtendedKey(
-    walletId: string,
-    extendedKey: AccountExtendedPublicKey,
-    isImporting: boolean | undefined,
-    receivingAddressCount: number = DefaultAddressNumber.Receiving,
-    changeAddressCount: number = DefaultAddressNumber.Change
-  ): Promise<AddressInterface[] | undefined> {
-    const generatedAddresses = await this.recursiveGenerateAndSave(
+  public static async generateAndSaveForExtendedKey({
+    walletId,
+    extendedKey,
+    isImporting,
+    receivingAddressCount,
+    changeAddressCount,
+  }: {
+    walletId: string
+    extendedKey: AccountExtendedPublicKey
+    isImporting?: boolean
+    receivingAddressCount?: number
+    changeAddressCount?: number
+  }) {
+    const generatedAddresses = await AddressService.recursiveGenerateAndSave(
       walletId,
       extendedKey,
       isImporting,
-      receivingAddressCount,
-      changeAddressCount
+      receivingAddressCount ?? DefaultAddressNumber.Receiving,
+      changeAddressCount ?? DefaultAddressNumber.Change
     )
 
     if (generatedAddresses) {
-      this.notifyAddressCreated(generatedAddresses, isImporting)
+      AddressService.notifyAddressCreated(generatedAddresses, isImporting)
     }
 
     return generatedAddresses
@@ -201,7 +206,7 @@ export default class AddressService {
     await getConnection().manager.save(publicKeyInfo)
 
     const addressMeta = AddressMeta.fromHdPublicKeyInfoModel(publicKeyInfo.toModel())
-    this.notifyAddressCreated([addressMeta], undefined)
+    AddressService.notifyAddressCreated([addressMeta], undefined)
   }
 
   // Generate both receiving and change addresses.

--- a/packages/neuron-wallet/src/services/tx/transaction-persistor.ts
+++ b/packages/neuron-wallet/src/services/tx/transaction-persistor.ts
@@ -1,4 +1,4 @@
-import { getConnection, QueryRunner } from 'typeorm'
+import { getConnection, In, QueryRunner } from 'typeorm'
 import InputEntity from '../../database/chain/entities/input'
 import OutputEntity from '../../database/chain/entities/output'
 import TransactionEntity from '../../database/chain/entities/transaction'
@@ -11,6 +11,7 @@ import Transaction, { TransactionStatus } from '../../models/chain/transaction'
 import Input from '../../models/chain/input'
 import TxLockEntity from '../../database/chain/entities/tx-lock'
 import { CHEQUE_ARGS_LENGTH, DEFAULT_ARGS_LENGTH } from '../../utils/const'
+import IndexerTxHashCache from '../../database/chain/entities/indexer-tx-hash-cache'
 
 export enum TxSaveType {
   Sent = 'sent',
@@ -269,6 +270,8 @@ export class TransactionPersistor {
     }
 
     const outputsData = transaction.outputsData!
+    const useTxInputs = await connection.getRepository(InputEntity).find({ outPointTxHash: tx.hash })
+    const useTxIndices = new Set(useTxInputs.map(v => v.outPointIndex))
     const outputs: OutputEntity[] = transaction.outputs.map((o, index) => {
       const output = new OutputEntity()
       output.outPointTxHash = transaction.hash || transaction.computeHash()
@@ -280,6 +283,9 @@ export class TransactionPersistor {
       output.lockHash = o.lockHash!
       output.transaction = tx
       output.status = outputStatus
+      if (useTxIndices.has(index.toString())) {
+        output.status = OutputStatus.Dead
+      }
       output.multiSignBlake160 = o.multiSignBlake160 || null
       if (o.type) {
         output.typeCodeHash = o.type.codeHash
@@ -309,12 +315,11 @@ export class TransactionPersistor {
     if (lockArgsSetNeedsDetail?.size) {
       willSaveDetailInputs = inputs.filter(v => this.shouldSaveDetail(v, lockArgsSetNeedsDetail))
       willSaveDetailOutputs = outputs.filter(v => this.shouldSaveDetail(v, lockArgsSetNeedsDetail))
-      txLocks = [
-        ...new Set([
-          ...inputs.filter(v => v.lockHash && !this.shouldSaveDetail(v, lockArgsSetNeedsDetail)).map(v => v.lockHash!),
-          ...outputs.filter(v => !this.shouldSaveDetail(v, lockArgsSetNeedsDetail)).map(v => v.lockHash),
-        ]),
-      ].map(v => TxLockEntity.fromObject({ txHash: tx.hash, lockHash: v }))
+      txLocks = await TransactionPersistor.findAndCreateTxLocks(
+        [...inputs, ...outputs],
+        lockArgsSetNeedsDetail,
+        tx.hash
+      )
     }
 
     const chunk = 100
@@ -402,6 +407,80 @@ export class TransactionPersistor {
             lockArgsSetNeedsDetail.has(v)
           )))
     )
+  }
+
+  public static async checkTxLock() {
+    const resetTxLocks = await getConnection()
+      .getRepository(TxLockEntity)
+      .createQueryBuilder()
+      .select('transactionHash')
+      .where('lockArgs IN (SELECT publicKeyInBlake160 from hd_public_key_info)')
+      .getRawMany<{ transactionHash: string }>()
+    if (!resetTxLocks?.length) {
+      return
+    }
+    const resetTxHashes = resetTxLocks.map(v => v.transactionHash)
+    const queryRunner = getConnection().createQueryRunner()
+    await TransactionPersistor.waitUntilTransactionFinished(queryRunner)
+    await queryRunner.startTransaction()
+    try {
+      await queryRunner.manager
+        .createQueryBuilder()
+        .update(IndexerTxHashCache)
+        .set({ isProcessed: false })
+        .where({ txHash: In(resetTxHashes) })
+        .execute()
+      await queryRunner.manager
+        .createQueryBuilder()
+        .delete()
+        .from(TransactionEntity)
+        .where({ hash: In(resetTxHashes) })
+        .execute()
+      await queryRunner.manager
+        .createQueryBuilder()
+        .delete()
+        .from(InputEntity)
+        .where({ transactionHash: In(resetTxHashes) })
+        .execute()
+      await queryRunner.manager
+        .createQueryBuilder()
+        .delete()
+        .from(OutputEntity)
+        .where({ outPointTxHash: In(resetTxHashes) })
+        .execute()
+      await queryRunner.manager
+        .createQueryBuilder()
+        .delete()
+        .from(TxLockEntity)
+        .where({ transactionHash: In(resetTxHashes) })
+        .execute()
+      await queryRunner.commitTransaction()
+    } catch (err) {
+      logger.error('Database:\tReset tx entity error:', err)
+      await queryRunner.rollbackTransaction()
+      throw err
+    } finally {
+      await queryRunner.release()
+    }
+  }
+
+  private static findAndCreateTxLocks(
+    cells: (InputEntity | OutputEntity)[],
+    lockArgsSetNeedsDetail: Set<string>,
+    txHash: string
+  ) {
+    const lockHashArgs: Record<string, string> = {}
+    const lockHashSet = new Set(
+      cells
+        .filter(v => v.lockHash && !this.shouldSaveDetail(v, lockArgsSetNeedsDetail))
+        .map(v => {
+          if (v.lockHash) {
+            lockHashArgs[v.lockHash] = v.lockArgs!
+          }
+          return v.lockHash!
+        })
+    )
+    return [...lockHashSet].map(v => TxLockEntity.fromObject({ txHash, lockHash: v, lockArgs: lockHashArgs[v] }))
   }
 }
 

--- a/packages/neuron-wallet/src/services/wallets.ts
+++ b/packages/neuron-wallet/src/services/wallets.ts
@@ -183,13 +183,13 @@ export class FileKeystoreWallet extends Wallet {
     receivingAddressCount: number = DefaultAddressNumber.Receiving,
     changeAddressCount: number = DefaultAddressNumber.Change
   ): Promise<AddressInterface[] | undefined> => {
-    return await AddressService.generateAndSaveForExtendedKey(
-      this.id,
-      this.accountExtendedPublicKey(),
+    return await AddressService.generateAndSaveForExtendedKeyQueue.asyncPush({
+      walletId: this.id,
+      extendedKey: this.accountExtendedPublicKey(),
       isImporting,
       receivingAddressCount,
-      changeAddressCount
-    )
+      changeAddressCount,
+    })
   }
 
   public getNextAddress = async (): Promise<AddressInterface | undefined> => {

--- a/packages/neuron-wallet/src/utils/queue.ts
+++ b/packages/neuron-wallet/src/utils/queue.ts
@@ -1,10 +1,10 @@
-import { AsyncQueue, AsyncResultIterator, queue } from 'async'
+import { QueueObject, AsyncResultIterator, queue } from 'async'
 
 export default function queueWrapper<T, R, E = Error>(
   fn: (item: T) => Promise<R>,
   concurrency?: number,
   ignoreSameItem?: boolean
-): AsyncQueue<T> & { asyncPush: (item: T) => Promise<R | undefined> } {
+): QueueObject<T> & { asyncPush: (item: T) => Promise<R | undefined> } {
   const itemList: T[] = []
   const promiseList: Promise<R | undefined>[] = []
   const queueFn: AsyncResultIterator<T, R, E> = (item: T, callback: (err?: E | null, res?: R) => void) => {
@@ -45,5 +45,5 @@ export default function queueWrapper<T, R, E = Error>(
       return promiseList[promiseList.length - 1]
     },
     writable: false,
-  }) as AsyncQueue<T> & { asyncPush: (item: T) => Promise<R | undefined> }
+  }) as QueueObject<T> & { asyncPush: (item: T) => Promise<R | undefined> }
 }

--- a/packages/neuron-wallet/tests/block-sync-renderer/index/resetSyncTask.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-renderer/index/resetSyncTask.test.ts
@@ -6,6 +6,7 @@ describe(`Reset sync task`, () => {
     getInstance: () => ({ maintainAddressesIfNecessary: stubbedmaintainAddressesIfNecessary }),
   }))
   jest.doMock('utils/common', () => ({ sleep: stubbedSleep, timeout: stubbedTimeout }))
+  jest.doMock('services/tx', () => ({ TransactionPersistor: { checkTxLock: jest.fn() } }))
 
   const blockSyncRenderer = require('block-sync-renderer')
   const spyCreateBlockSyncTask = jest

--- a/packages/neuron-wallet/tests/services/address.test.ts
+++ b/packages/neuron-wallet/tests/services/address.test.ts
@@ -142,13 +142,13 @@ describe('integration tests for AddressService', () => {
 
       describe('when the newly created public keys have not been used', () => {
         beforeEach(async () => {
-          await AddressService.generateAndSaveForExtendedKey(
+          await AddressService.generateAndSaveForExtendedKey({
             walletId,
             extendedKey,
             isImporting,
             receivingAddressCount,
-            changeAddressCount
-          )
+            changeAddressCount,
+          })
           generatedAddresses = await AddressService.getAddressesByWalletId(walletId)
         })
 
@@ -179,13 +179,13 @@ describe('integration tests for AddressService', () => {
             )
             await linkNewCell([receivingAddresses[0].blake160, changeAddresses[0].blake160])
 
-            await AddressService.generateAndSaveForExtendedKey(
+            await AddressService.generateAndSaveForExtendedKey({
               walletId,
               extendedKey,
               isImporting,
               receivingAddressCount,
-              changeAddressCount
-            )
+              changeAddressCount,
+            })
             generatedAddresses = await AddressService.getAddressesByWalletId(walletId)
           })
           it('generates new addresses for both receiving and change', () => {
@@ -202,13 +202,13 @@ describe('integration tests for AddressService', () => {
         })
         describe('when none of public keys are used', () => {
           beforeEach(async () => {
-            await AddressService.generateAndSaveForExtendedKey(
+            await AddressService.generateAndSaveForExtendedKey({
               walletId,
               extendedKey,
               isImporting,
               receivingAddressCount,
-              changeAddressCount
-            )
+              changeAddressCount,
+            })
             generatedAddresses = await AddressService.getAddressesByWalletId(walletId)
           })
           it('should not generate new addresses', () => {
@@ -223,13 +223,13 @@ describe('integration tests for AddressService', () => {
             )
             await linkNewCell([receivingAddresses[0].blake160])
 
-            await AddressService.generateAndSaveForExtendedKey(
+            await AddressService.generateAndSaveForExtendedKey({
               walletId,
               extendedKey,
               isImporting,
               receivingAddressCount,
-              changeAddressCount
-            )
+              changeAddressCount,
+            })
             generatedAddresses = await AddressService.getAddressesByWalletId(walletId)
           })
           it('generates addresses for receiving', () => {
@@ -253,13 +253,13 @@ describe('integration tests for AddressService', () => {
             )
             await linkNewCell([changeAddresses[0].blake160])
 
-            await AddressService.generateAndSaveForExtendedKey(
+            await AddressService.generateAndSaveForExtendedKey({
               walletId,
               extendedKey,
               isImporting,
               receivingAddressCount,
-              changeAddressCount
-            )
+              changeAddressCount,
+            })
             generatedAddresses = await AddressService.getAddressesByWalletId(walletId)
           })
           it('generates addresses for change', () => {
@@ -280,13 +280,13 @@ describe('integration tests for AddressService', () => {
         beforeEach(async () => {
           await linkNewCell(preloadedPublicKeys.filter((k: any) => k.addressIndex < 4).map((k: any) => k.publicKeyHash))
 
-          await AddressService.generateAndSaveForExtendedKey(
+          await AddressService.generateAndSaveForExtendedKey({
             walletId,
             extendedKey,
             isImporting,
             receivingAddressCount,
-            changeAddressCount
-          )
+            changeAddressCount,
+          })
           generatedAddresses = await AddressService.getAddressesByWalletId(walletId)
         })
         it('recursively generates both receiving and change addresses', () => {
@@ -357,20 +357,20 @@ describe('integration tests for AddressService', () => {
       const changeAddressCount = 4
       let allAddresses: Address[] = []
       beforeEach(async () => {
-        await AddressService.generateAndSaveForExtendedKey(
-          '1',
+        await AddressService.generateAndSaveForExtendedKey({
+          walletId: '1',
           extendedKey,
           isImporting,
           receivingAddressCount,
-          changeAddressCount
-        )
-        await AddressService.generateAndSaveForExtendedKey(
-          '2',
+          changeAddressCount,
+        })
+        await AddressService.generateAndSaveForExtendedKey({
+          walletId: '2',
           extendedKey,
           isImporting,
           receivingAddressCount,
-          changeAddressCount
-        )
+          changeAddressCount,
+        })
         allAddresses = await AddressService.getAddressesByAllWallets()
       })
       it('returns all addresses', () => {
@@ -387,13 +387,13 @@ describe('integration tests for AddressService', () => {
       let address: Address
       const walletId = '1'
       beforeEach(async () => {
-        await AddressService.generateAndSaveForExtendedKey(
+        await AddressService.generateAndSaveForExtendedKey({
           walletId,
           extendedKey,
           isImporting,
           receivingAddressCount,
-          changeAddressCount
-        )
+          changeAddressCount,
+        })
         address = await AddressService.getFirstAddressByWalletId(walletId)
       })
       it('returns the first addresses by by wallet id', () => {
@@ -410,16 +410,16 @@ describe('integration tests for AddressService', () => {
     describe('#nextUnusedAddress', () => {
       const receivingAddressCount = 2
       const changeAddressCount = 2
-      let publicKeysToUse = []
+      let publicKeysToUse: string[] = []
       describe('when there are unused receiving addresses', () => {
         beforeEach(async () => {
-          await AddressService.generateAndSaveForExtendedKey(
+          await AddressService.generateAndSaveForExtendedKey({
             walletId,
             extendedKey,
             isImporting,
             receivingAddressCount,
-            changeAddressCount
-          )
+            changeAddressCount,
+          })
           generatedAddresses = await AddressService.getAddressesByWalletId(walletId)
           publicKeysToUse = [generatedAddresses[0].blake160]
           await linkNewCell(publicKeysToUse)
@@ -432,13 +432,13 @@ describe('integration tests for AddressService', () => {
       })
       describe('when there are unused change addresses but no receiving addresses', () => {
         beforeEach(async () => {
-          await AddressService.generateAndSaveForExtendedKey(
+          await AddressService.generateAndSaveForExtendedKey({
             walletId,
             extendedKey,
             isImporting,
             receivingAddressCount,
-            changeAddressCount
-          )
+            changeAddressCount,
+          })
           generatedAddresses = await AddressService.getAddressesByWalletId(walletId)
           publicKeysToUse = generatedAddresses
             .filter((addr: Address) => addr.addressType === AddressType.Receiving)
@@ -454,13 +454,13 @@ describe('integration tests for AddressService', () => {
       })
       describe('when there is no receiving or change unused address', () => {
         beforeEach(async () => {
-          await AddressService.generateAndSaveForExtendedKey(
+          await AddressService.generateAndSaveForExtendedKey({
             walletId,
             extendedKey,
             isImporting,
             receivingAddressCount,
-            changeAddressCount
-          )
+            changeAddressCount,
+          })
           generatedAddresses = await AddressService.getAddressesByWalletId(walletId)
           publicKeysToUse = generatedAddresses.map((addr: Address) => addr.blake160)
 
@@ -474,18 +474,18 @@ describe('integration tests for AddressService', () => {
     })
 
     describe('#allUnusedReceivingAddresses', () => {
-      let publicKeysToUse = []
+      let publicKeysToUse: string[] = []
       const receivingAddressCount = 4
       const changeAddressCount = 4
       describe('when there are unused receiving addresses', () => {
         beforeEach(async () => {
-          await AddressService.generateAndSaveForExtendedKey(
+          await AddressService.generateAndSaveForExtendedKey({
             walletId,
             extendedKey,
             isImporting,
             receivingAddressCount,
-            changeAddressCount
-          )
+            changeAddressCount,
+          })
           generatedAddresses = await AddressService.getAddressesByWalletId(walletId)
           publicKeysToUse = [generatedAddresses[0].blake160]
           await linkNewCell(publicKeysToUse)
@@ -500,13 +500,13 @@ describe('integration tests for AddressService', () => {
       })
       describe('when there is no unused receiving address', () => {
         beforeEach(async () => {
-          await AddressService.generateAndSaveForExtendedKey(
+          await AddressService.generateAndSaveForExtendedKey({
             walletId,
             extendedKey,
             isImporting,
             receivingAddressCount,
-            changeAddressCount
-          )
+            changeAddressCount,
+          })
           generatedAddresses = await AddressService.getAddressesByWalletId(walletId)
           publicKeysToUse = generatedAddresses.map((addr: Address) => addr.blake160)
           await linkNewCell(publicKeysToUse)
@@ -519,17 +519,17 @@ describe('integration tests for AddressService', () => {
     })
 
     describe('#nextUnusedChangeAddress', () => {
-      let publicKeysToUse = []
+      let publicKeysToUse: string[] = []
       const receivingAddressCount = 4
       const changeAddressCount = 4
       beforeEach(async () => {
-        await AddressService.generateAndSaveForExtendedKey(
+        await AddressService.generateAndSaveForExtendedKey({
           walletId,
           extendedKey,
           isImporting,
           receivingAddressCount,
-          changeAddressCount
-        )
+          changeAddressCount,
+        })
       })
       describe('when there are unused change addresses', () => {
         beforeEach(async () => {
@@ -563,13 +563,13 @@ describe('integration tests for AddressService', () => {
       const receivingAddressCount = 1
       const changeAddressCount = 1
       beforeEach(async () => {
-        await AddressService.generateAndSaveForExtendedKey(
+        await AddressService.generateAndSaveForExtendedKey({
           walletId,
           extendedKey,
           isImporting,
           receivingAddressCount,
-          changeAddressCount
-        )
+          changeAddressCount,
+        })
         generatedAddresses = await AddressService.getAddressesByWalletId(walletId)
         publicKeysToUse = generatedAddresses.map((addr: Address) => addr.blake160)
 
@@ -607,20 +607,20 @@ describe('integration tests for AddressService', () => {
 
       describe('when saved description', () => {
         beforeEach(async () => {
-          await AddressService.generateAndSaveForExtendedKey(
-            walletId1,
+          await AddressService.generateAndSaveForExtendedKey({
+            walletId: walletId1,
             extendedKey,
             isImporting,
             receivingAddressCount,
-            changeAddressCount
-          )
-          await AddressService.generateAndSaveForExtendedKey(
-            walletId2,
+            changeAddressCount,
+          })
+          await AddressService.generateAndSaveForExtendedKey({
+            walletId: walletId2,
             extendedKey,
             isImporting,
             receivingAddressCount,
-            changeAddressCount
-          )
+            changeAddressCount,
+          })
 
           const generatedAddresses1 = await AddressService.getAddressesByWalletId(walletId1)
           addressToUpdate = generatedAddresses1[0]

--- a/packages/neuron-wallet/tests/services/tx/transaction-persistor.test.ts
+++ b/packages/neuron-wallet/tests/services/tx/transaction-persistor.test.ts
@@ -1,4 +1,4 @@
-import Transaction from '../../../src/models/chain/transaction'
+import Transaction, { TransactionStatus } from '../../../src/models/chain/transaction'
 import { TransactionPersistor, TxSaveType } from '../../../src/services/tx'
 import initConnection from '../../../src/database/chain/ormconfig'
 import TransactionEntity from '../../../src/database/chain/entities/transaction'
@@ -8,6 +8,10 @@ import AssetAccountInfo from '../../../src/models/asset-account-info'
 import SystemScriptInfo from '../../../src/models/system-script-info'
 import Multisig from '../../../src/models/multisig'
 import TxLockEntity from '../../../src/database/chain/entities/tx-lock'
+import { OutputStatus } from '../../../src/models/chain/output'
+import OutputEntity from '../../../src/database/chain/entities/output'
+import HdPublicKeyInfo from '../../../src/database/chain/entities/hd-public-key-info'
+import InputEntity from '../../../src/database/chain/entities/input'
 
 const [tx, tx2] = transactions
 
@@ -88,14 +92,14 @@ describe('TransactionPersistor', () => {
       expect(loadedTx?.inputs.length).toBe(0)
       expect(loadedTx?.outputs.length).toBe(1)
       expect(loadedTx?.outputs[0].lockArgs).toBe(tx.outputs[0].lock.args)
-      const txLocks = await getConnection()
-        .getRepository(TxLockEntity)
-        .find({ transactionHash: tx.hash })
+      const txLocks = await getConnection().getRepository(TxLockEntity).find({ transactionHash: tx.hash })
       expect(txLocks.length).toBe(1)
       expect(txLocks[0].lockHash).toBe(tx.inputs[0].lock?.computeHash())
     })
     it('all args is current', async () => {
-      const args = [...tx.inputs.map(v => v.lock?.args), ...tx.outputs.map(v => v.lock.args)].filter((v): v is string => !!v)
+      const args = [...tx.inputs.map(v => v.lock?.args), ...tx.outputs.map(v => v.lock.args)].filter(
+        (v): v is string => !!v
+      )
       await TransactionPersistor.convertTransactionAndSave(tx, TxSaveType.Fetch, new Set(args))
       const loadedTx = await getConnection()
         .getRepository(TransactionEntity)
@@ -106,22 +110,26 @@ describe('TransactionPersistor', () => {
         .getOne()
       expect(loadedTx?.inputs.length).toBe(1)
       expect(loadedTx?.outputs.length).toBe(2)
-      const txLocks = await getConnection()
-        .getRepository(TxLockEntity)
-        .find({ transactionHash: tx.hash })
+      const txLocks = await getConnection().getRepository(TxLockEntity).find({ transactionHash: tx.hash })
       expect(txLocks.length).toBe(0)
     })
     it('filter with receive cheque and send cheque', async () => {
       const assetAccountInfo = new AssetAccountInfo()
       const txWithCheque = Transaction.fromObject(tx)
-      const outputReceiveChequeLock = assetAccountInfo.generateChequeScript(txWithCheque.outputs[0].lockHash, `0x${'0'.repeat(42)}`)
-      const outputSendChequeLock = assetAccountInfo.generateChequeScript(`0x${'0'.repeat(42)}`, txWithCheque.outputs[0].lockHash)
+      const outputReceiveChequeLock = assetAccountInfo.generateChequeScript(
+        txWithCheque.outputs[0].lockHash,
+        `0x${'0'.repeat(42)}`
+      )
+      const outputSendChequeLock = assetAccountInfo.generateChequeScript(
+        `0x${'0'.repeat(42)}`,
+        txWithCheque.outputs[0].lockHash
+      )
       txWithCheque.outputs[0].setLock(outputReceiveChequeLock)
       txWithCheque.outputs[1].setLock(outputSendChequeLock)
-      const args = [...tx.inputs.map(v => v.lock?.args), ...tx.outputs.map(v => v.lock.args)].filter((v): v is string => !!v).map(v => [
-        v,
-        SystemScriptInfo.generateSecpScript(v).computeHash().slice(0, 42),
-      ]).flat()
+      const args = [...tx.inputs.map(v => v.lock?.args), ...tx.outputs.map(v => v.lock.args)]
+        .filter((v): v is string => !!v)
+        .map(v => [v, SystemScriptInfo.generateSecpScript(v).computeHash().slice(0, 42)])
+        .flat()
       await TransactionPersistor.convertTransactionAndSave(txWithCheque, TxSaveType.Fetch, new Set(args))
       const loadedTx = await getConnection()
         .getRepository(TransactionEntity)
@@ -132,19 +140,19 @@ describe('TransactionPersistor', () => {
         .getOne()
       expect(loadedTx?.inputs.length).toBe(1)
       expect(loadedTx?.outputs.length).toBe(2)
-      const txLocks = await getConnection()
-        .getRepository(TxLockEntity)
-        .find({ transactionHash: tx.hash })
+      const txLocks = await getConnection().getRepository(TxLockEntity).find({ transactionHash: tx.hash })
       expect(txLocks.length).toBe(0)
     })
     it('filter with multi lock time', async () => {
       const txWithCheque = Transaction.fromObject(tx)
-      const multisigLockTimeLock = SystemScriptInfo.generateMultiSignScript(Multisig.hash([txWithCheque.outputs[0].lock.args]))
+      const multisigLockTimeLock = SystemScriptInfo.generateMultiSignScript(
+        Multisig.hash([txWithCheque.outputs[0].lock.args])
+      )
       txWithCheque.outputs[0].setLock(multisigLockTimeLock)
-      const args = [...tx.inputs.map(v => v.lock?.args), ...tx.outputs.map(v => v.lock.args)].filter((v): v is string => !!v).map(v => [
-        v,
-        Multisig.hash([v]),
-      ]).flat()
+      const args = [...tx.inputs.map(v => v.lock?.args), ...tx.outputs.map(v => v.lock.args)]
+        .filter((v): v is string => !!v)
+        .map(v => [v, Multisig.hash([v])])
+        .flat()
       await TransactionPersistor.convertTransactionAndSave(txWithCheque, TxSaveType.Fetch, new Set(args))
       const loadedTx = await getConnection()
         .getRepository(TransactionEntity)
@@ -155,10 +163,175 @@ describe('TransactionPersistor', () => {
         .getOne()
       expect(loadedTx?.inputs.length).toBe(1)
       expect(loadedTx?.outputs.length).toBe(2)
-      const txLocks = await getConnection()
-        .getRepository(TxLockEntity)
-        .find({ transactionHash: tx.hash })
+      const txLocks = await getConnection().getRepository(TxLockEntity).find({ transactionHash: tx.hash })
       expect(txLocks.length).toBe(0)
+    })
+  })
+
+  describe('#saveWithSent', () => {
+    const createMock = jest.fn()
+    const originalCreate = TransactionPersistor.create
+    beforeAll(() => {
+      TransactionPersistor.create = createMock
+    })
+    afterAll(() => {
+      TransactionPersistor.create = originalCreate
+    })
+    afterEach(async () => {
+      await getConnection().synchronize(true)
+      createMock.mockReset()
+    })
+
+    it('there is no transaction', async () => {
+      //@ts-ignore private method
+      await TransactionPersistor.saveWithSent(tx)
+      expect(createMock).toBeCalledWith(tx, OutputStatus.Sent, OutputStatus.Pending)
+    })
+    it('there is a transaction but status is failed', async () => {
+      const entity = new TransactionEntity()
+      entity.hash = tx.hash || tx.computeHash()
+      entity.version = tx.version
+      entity.headerDeps = tx.headerDeps
+      entity.cellDeps = tx.cellDeps
+      entity.timestamp = tx.timestamp!
+      entity.blockHash = tx.blockHash!
+      entity.blockNumber = tx.blockNumber!
+      entity.witnesses = tx.witnessesAsString()
+      entity.description = '' // tx desc is saved in leveldb as wallet property
+      entity.status = TransactionStatus.Failed
+      entity.inputs = []
+      entity.outputs = []
+      await getConnection().manager.save(entity)
+      //@ts-ignore private method
+      await TransactionPersistor.saveWithSent(tx)
+      expect(createMock).toBeCalledWith(tx, OutputStatus.Sent, OutputStatus.Pending)
+    })
+    it('there is a transaction but status is not failed', async () => {
+      await originalCreate(tx, OutputStatus.Dead, OutputStatus.Dead)
+      //@ts-ignore private method
+      await TransactionPersistor.saveWithSent(tx)
+      expect(createMock).toBeCalledTimes(0)
+    })
+  })
+
+  describe('#saveWithFetch', () => {
+    const createMock = jest.fn()
+    const originalCreate = TransactionPersistor.create
+    beforeAll(() => {
+      TransactionPersistor.create = createMock
+    })
+    afterAll(() => {
+      TransactionPersistor.create = originalCreate
+    })
+    afterEach(async () => {
+      await getConnection().synchronize(true)
+      createMock.mockReset()
+    })
+
+    it('there is no transaction', async () => {
+      //@ts-ignore private method
+      await TransactionPersistor.saveWithFetch(tx)
+      expect(createMock).toBeCalledWith(tx, OutputStatus.Live, OutputStatus.Dead, undefined)
+    })
+    it('update sent output to live', async () => {
+      const entity = await originalCreate(tx, OutputStatus.Sent, OutputStatus.Pending)
+      expect(entity.outputs[0]?.status).toBe(OutputStatus.Sent)
+      //@ts-ignore private method
+      await TransactionPersistor.saveWithFetch(tx)
+      expect(createMock).toBeCalledTimes(0)
+      const output = await getConnection().getRepository(OutputEntity).findOne({ outPointTxHash: entity.hash })
+      expect(output?.status).toBe(OutputStatus.Live)
+    })
+    it('update live output to dead because refer to input', async () => {
+      const entity = await originalCreate(tx, OutputStatus.Live, OutputStatus.Dead)
+      expect(entity.outputs[0]?.status).toBe(OutputStatus.Live)
+      await originalCreate(tx2, OutputStatus.Sent, OutputStatus.Pending)
+      //@ts-ignore private method
+      await TransactionPersistor.saveWithFetch(tx2)
+      const output = await getConnection().getRepository(OutputEntity).findOne({
+        outPointTxHash: tx2.inputs[0].previousOutput?.txHash,
+        outPointIndex: tx2.inputs[0].previousOutput?.index,
+      })
+      expect(output?.status).toBe(OutputStatus.Dead)
+    })
+  })
+
+  describe('#create', () => {
+    afterEach(async () => {
+      await getConnection().synchronize(true)
+    })
+    it('set output to dead if it is in input', async () => {
+      await TransactionPersistor.convertTransactionAndSave(tx2, TxSaveType.Sent)
+      await TransactionPersistor.convertTransactionAndSave(tx, TxSaveType.Sent)
+      const output = await getConnection().getRepository(OutputEntity).findOne({
+        outPointTxHash: tx2.inputs[0].previousOutput?.txHash,
+        outPointIndex: tx2.inputs[0].previousOutput?.index,
+      })
+      expect(output?.status).toBe(OutputStatus.Dead)
+    })
+  })
+
+  describe('#checkTxLock', () => {
+    afterEach(async () => {
+      await getConnection().synchronize(true)
+    })
+
+    it('no tx lock saving wrong', async () => {
+      const mock = jest.fn()
+      jest.doMock('typeorm', () => ({
+        getConnection() {
+          return { createQueryRunner: mock }
+        },
+      }))
+      await TransactionPersistor.checkTxLock()
+      expect(mock).toBeCalledTimes(0)
+    })
+
+    it('some tx lock saving wrong', async () => {
+      const txLocks = TxLockEntity.fromObject({
+        txHash: tx.hash!,
+        lockHash: tx.inputs[0].lockHash!,
+        lockArgs: tx.inputs[0].lock!.args!,
+      })
+      const hdPublicKeyInfo = HdPublicKeyInfo.fromObject({
+        walletId: 'w1',
+        addressType: 0,
+        addressIndex: 0,
+        publicKeyInBlake160: tx.inputs[0].lock!.args!,
+      })
+      await getConnection().manager.save([txLocks, hdPublicKeyInfo])
+      await TransactionPersistor.convertTransactionAndSave(tx, TxSaveType.Sent)
+      let output = await getConnection().getRepository(OutputEntity).findOne({ outPointTxHash: tx.hash })
+      let input = await getConnection().getRepository(InputEntity).findOne({ transactionHash: tx.hash })
+      expect(output).toBeDefined()
+      expect(input).toBeDefined()
+      await TransactionPersistor.checkTxLock()
+      output = await getConnection().getRepository(OutputEntity).findOne({ outPointTxHash: tx.hash })
+      input = await getConnection().getRepository(InputEntity).findOne({ transactionHash: tx.hash })
+      expect(output).toBeUndefined()
+      expect(input).toBeUndefined()
+    })
+  })
+
+  describe('#findAndCreateTxLocks', () => {
+    let inputEntities: InputEntity[] = []
+    let outputEntities: OutputEntity[] = []
+    beforeAll(async () => {
+      await TransactionPersistor.convertTransactionAndSave(tx, TxSaveType.Sent)
+      inputEntities = await getConnection().getRepository(InputEntity).find({ transactionHash: tx.hash })
+      outputEntities = await getConnection().getRepository(OutputEntity).find({ outPointTxHash: tx.hash })
+    })
+    it('no filter', () => {
+      const cells = [...inputEntities, ...outputEntities]
+      //@ts-ignore private method
+      const result = TransactionPersistor.findAndCreateTxLocks(cells, new Set(), tx.hash!)
+      expect(result).toHaveLength(new Set(cells.map(v => v.lockHash!)).size)
+    })
+    it('filter with lock args', () => {
+      const cells = [...inputEntities, ...outputEntities]
+      //@ts-ignore private method
+      const result = TransactionPersistor.findAndCreateTxLocks(cells, new Set([tx.inputs[0].lock?.args]), tx.hash!)
+      expect(result).toHaveLength(1)
     })
   })
 })


### PR DESCRIPTION
Fixed https://github.com/Magickbase/neuron-public-issues/issues/282.

1. Save entity into `indexer_tx_hash_cache` order by the block number
2. Create a queue to check generate address
3. When starting the sync process, check whether there exist some lock args belonging to the Neuron wallet