### PR TITLE
fix: fixed locktime cell,multisig sync blocknumber, table head style

### DIFF
--- a/packages/neuron-ui/src/components/PageContainer/index.tsx
+++ b/packages/neuron-ui/src/components/PageContainer/index.tsx
@@ -151,6 +151,7 @@ const PageContainer: React.FC<ComponentProps> = props => {
         show={isSetStartBlockShown}
         onCancel={closeDialog}
         onConfirm={onConfirm}
+        disabled={!startBlockNumber}
       >
         <p className={styles.startBlockTip}>{t('set-start-block-number.tip')}</p>
         <TextField

--- a/packages/neuron-ui/src/components/SUDTSend/index.tsx
+++ b/packages/neuron-ui/src/components/SUDTSend/index.tsx
@@ -353,11 +353,13 @@ const SUDTSend = () => {
           <div className={styles.left}>
             <div className={styles.info}>
               <SUDTAvatar type="logo" />
-              <div>
+              <div className={styles.infoDetails}>
                 <div className={styles.accountName}>{accountInfo?.accountName}</div>
                 <div className={styles.tokenName}>{displayTokenName}</div>
                 <div className={styles.balance}>
-                  {showBalance ? balance : HIDE_BALANCE} {displaySymbol}
+                  <span>
+                    {showBalance ? balance : HIDE_BALANCE} {displaySymbol}
+                  </span>
                   <Button className={styles.btn} type="text" onClick={() => setShowBalance(prev => !prev)}>
                     {showBalance ? <EyesOpen /> : <EyesClose />}
                   </Button>

--- a/packages/neuron-ui/src/components/SUDTSend/sUDTSend.module.scss
+++ b/packages/neuron-ui/src/components/SUDTSend/sUDTSend.module.scss
@@ -20,12 +20,15 @@ $bottomHeight: 186px;
   }
 }
 
+$right-min-width: 476px;
+
 .layout {
   display: flex;
 
   .left {
     flex: 1;
     position: relative;
+    max-width: calc(100% - $right-min-width);
 
     .info {
       padding: 20px 16px 16px;
@@ -33,6 +36,9 @@ $bottomHeight: 186px;
       display: flex;
       gap: 16px;
       color: var(--main-text-color);
+      .infoDetails {
+        max-width: calc(100% - 48px);
+      }
       .accountName {
         font-weight: 500;
         font-size: 14px;
@@ -42,10 +48,9 @@ $bottomHeight: 186px;
         margin-top: 4px;
         font-size: 12px;
         line-height: 17px;
-        overflow: initial !important;
         position: relative;
         color: var(--input-second-color);
-        display: inline-flex;
+        @include text-overflow-ellipsis;
       }
       .balance {
         margin-top: 8px;
@@ -54,10 +59,14 @@ $bottomHeight: 186px;
         line-height: 22px;
         display: flex;
         align-items: center;
+        & > span {
+          @include text-overflow-ellipsis;
+        }
         .btn {
           height: 16px;
           min-width: 16px;
           padding: 0 8px;
+          flex-shrink: 0;
           svg {
             g,
             path {
@@ -106,6 +115,10 @@ $bottomHeight: 186px;
       }
       .amount {
         margin-top: 20px;
+
+        & > label {
+          @include text-overflow-ellipsis;
+        }
       }
       .max {
         border-left: var(--divide-line-color) solid 1px;
@@ -162,6 +175,7 @@ $bottomHeight: 186px;
   .right {
     margin-left: 16px;
     flex: 1;
+    min-width: $right-min-width;
     @include card;
 
     .rightContent {

--- a/packages/neuron-ui/src/components/SignAndVerify/index.tsx
+++ b/packages/neuron-ui/src/components/SignAndVerify/index.tsx
@@ -316,7 +316,6 @@ const SignAndVerify = () => {
             field="signature"
             value={signature}
             onChange={handleInputChange}
-            disabled={!signature}
             width="100%"
           />
 

--- a/packages/neuron-ui/src/widgets/Dialog/dialog.module.scss
+++ b/packages/neuron-ui/src/widgets/Dialog/dialog.module.scss
@@ -48,12 +48,8 @@
 .content {
   padding: 20px 16px;
   position: relative;
-  max-height: calc(90vh);
+  max-height: calc(100vh - 260px);
   overflow-y: scroll;
-  scrollbar-width: none;
-  &::-webkit-scrollbar {
-    display: none;
-  }
 }
 
 .footerWrap {

--- a/packages/neuron-ui/src/widgets/Table/table.module.scss
+++ b/packages/neuron-ui/src/widgets/Table/table.module.scss
@@ -34,7 +34,7 @@ $head-height: 52px;
       border-top: 1px solid var(--table-head-border-color);
       border-bottom: 1px solid var(--table-head-border-color);
 
-      & > .headWithBalance {
+      .headWithBalance {
         display: flex;
         align-items: center;
       }

--- a/packages/neuron-wallet/src/services/multisig.ts
+++ b/packages/neuron-wallet/src/services/multisig.ts
@@ -279,7 +279,7 @@ export default class MultisigService {
           multisigConfigs.map(v => {
             const blockNumber =
               syncBlockNumbersMap[scriptToHash(Multisig.getMultisigScript(v.blake160s, v.r, v.m, v.n))]
-            v.lastestBlockNumber = `0x${BigInt(blockNumber).toString(16)}`
+            v.lastestBlockNumber = `0x${BigInt(blockNumber ?? v.lastestBlockNumber).toString(16)}`
             return v
           })
         )

--- a/packages/neuron-wallet/src/services/tx/transaction-persistor.ts
+++ b/packages/neuron-wallet/src/services/tx/transaction-persistor.ts
@@ -400,12 +400,13 @@ export class TransactionPersistor {
 
   private static shouldSaveDetail(cell: InputEntity | OutputEntity, lockArgsSetNeedsDetail: Set<string>) {
     return (
-      cell.lockArgs &&
-      (lockArgsSetNeedsDetail.has(cell.lockArgs) ||
-        (cell.lockArgs.length === CHEQUE_ARGS_LENGTH &&
-          [cell.lockArgs.slice(0, DEFAULT_ARGS_LENGTH), `0x${cell.lockArgs.slice(DEFAULT_ARGS_LENGTH)}`].some(v =>
-            lockArgsSetNeedsDetail.has(v)
-          )))
+      (cell.multiSignBlake160 && lockArgsSetNeedsDetail.has(cell.multiSignBlake160)) ||
+      (cell.lockArgs &&
+        (lockArgsSetNeedsDetail.has(cell.lockArgs) ||
+          (cell.lockArgs.length === CHEQUE_ARGS_LENGTH &&
+            [cell.lockArgs.slice(0, DEFAULT_ARGS_LENGTH), `0x${cell.lockArgs.slice(DEFAULT_ARGS_LENGTH)}`].some(v =>
+              lockArgsSetNeedsDetail.has(v)
+            ))))
     )
   }
 


### PR DESCRIPTION
1. Lock time cells should be saved into the local database.
2. For the light client skip update the multisig sync block number if the address is not the current wallet. Because of light client only subscribe current wallet multisig address
3. Fixed able head style.

<img width="1231" alt="image" src="https://github.com/nervosnetwork/neuron/assets/12881040/66f2ae95-a815-46bd-9110-43ff66fce11c">

4. Fix styles when the asset name is too long
<img width="1007" alt="image" src="https://github.com/nervosnetwork/neuron/assets/12881040/0b468d16-46c2-4135-9af2-f71debd4774d">

5. Fix some elements that are hidden when Neuron height is the smallest

<img width="819" alt="image" src="https://github.com/nervosnetwork/neuron/assets/12881040/3a620862-e111-4041-8615-e82d689f3849">
 
