### PR TITLE
fix: Format date when output log. Catch exception when export public key info.

### DIFF
--- a/packages/neuron-wallet/src/controllers/export-debug.ts
+++ b/packages/neuron-wallet/src/controllers/export-debug.ts
@@ -137,14 +137,18 @@ export default class ExportDebugController {
   }
 
   private async addHdPublicKeyInfoCsv() {
-    const addressMetas = await AddressService.getAddressesByAllWallets()
-    let csv = 'walletId,addressType,addressIndex,publicKeyInBlake160\n'
-    for (const addressMeta of addressMetas) {
-      const row = `${addressMeta.walletId},${addressMeta.addressType},${addressMeta.addressIndex},${addressMeta.blake160}\n`
-      csv += row
+    try {
+      const addressMetas = await AddressService.getAddressesByAllWallets()
+      let csv = 'walletId,addressType,addressIndex,publicKeyInBlake160\n'
+      for (const addressMeta of addressMetas) {
+        const row = `${addressMeta.walletId},${addressMeta.addressType},${addressMeta.addressIndex},${addressMeta.blake160}\n`
+        csv += row
+      }
+      const csvFileName = 'hd_public_key_info.csv'
+      this.archive.append(csv, { name: csvFileName })
+    } catch (error) {
+      logger.error(`Export Debug:\t export public key info error: ${error}`)
     }
-    const csvFileName = 'hd_public_key_info.csv'
-    this.archive.append(csv, { name: csvFileName })
   }
 
   private addLogFiles = (files = ['main.log', 'renderer.log']) => {

--- a/packages/neuron-wallet/src/utils/logger.ts
+++ b/packages/neuron-wallet/src/utils/logger.ts
@@ -4,7 +4,12 @@ import env from '../env'
 if (!env.isDevMode) {
   logger.transports.file.level = 'info'
 }
-
+logger.transports.file.format = ({ date, level, data }) => {
+  return `[${date.toISOString()}] [${level}] ${data}`
+}
+logger.transports.console.format = ({ date, level, data }) => {
+  return `[${date.toISOString()}] [${level}] ${data}`
+}
 // logger.catchErrors({ showDialog: false })
 
 export default logger


### PR DESCRIPTION
1. Format date for electron-log, define for `file` and `console` to output unified date.
2. Sometimes user's DB connection is not opened with an unknown exception, so catch the exception when exporting public key info. 