### PR TITLE
fix: use electron-log format styles. The function can not transform object correctly.

### DIFF
--- a/packages/neuron-wallet/src/utils/logger.ts
+++ b/packages/neuron-wallet/src/utils/logger.ts
@@ -4,12 +4,10 @@ import env from '../env'
 if (!env.isDevMode) {
   logger.transports.file.level = 'info'
 }
-logger.transports.file.format = ({ date, level, data }) => {
-  return `[${date.toISOString()}] [${level}] ${data}`
-}
-logger.transports.console.format = ({ date, level, data }) => {
-  return `[${date.toISOString()}] [${level}] ${data}`
-}
+logger.transports.file.format = '[{iso}] [{level}] {text}'
+
+logger.transports.console.format = '[{iso}] [{level}] {text}'
+
 // logger.catchErrors({ showDialog: false })
 
 export default logger


### PR DESCRIPTION
1. Before

```
[2023-10-19T06:44:40.522Z] [info] Network:      switched to:,[object Object]
```

2. After

```
[2023-10-19T06:39:15.782Z] [info]  Network:     switched to: {
  id: '4a04d0de-cbf4-46c9-b383-5c73372387d6',
  name: 'devdd',
  remote: 'http://127.0.0.1:8114',
  genesisHash: '0x10639e0895502b5688a6be8cf69460d76541bfa4821629d86d62ba0aae3f9606',
  type: 1,
  chain: 'ckb_testnet',
  readonly: false
}
```