### PR TITLE
ci: use key locker to sign neuron for windows

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -51,6 +51,39 @@ jobs:
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
 
+      - name: Setup Certificate
+        if: matrix.os == 'windows-2019'
+        run: |
+          echo "${{ secrets.SM_CLIENT_CERT_FILE_BASE64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
+        shell: bash
+
+      - name: Set variables
+        if: matrix.os == 'windows-2019'
+        run: |
+          echo "SM_KEYPAIR_NAME=${{ secrets.SM_KEYPAIR_ALIAS }}" >> "$GITHUB_ENV"
+          echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV"
+          echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV"
+          echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> "$GITHUB_ENV"
+          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
+          echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
+          echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
+          echo "C:\Program Files\DigiCert\DigiCert One Signing Manager Tools" >> $GITHUB_PATH
+        shell: bash
+
+      - name: Setting up the client tools
+        if: matrix.os == 'windows-2019'
+        run: |
+          curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
+          msiexec /i smtools-windows-x64.msi /quiet /qn
+          C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
+        shell: cmd
+
+      - name: Certificates Sync
+        if: matrix.os == 'windows-2019'
+        run: |
+          smctl windows certsync
+        shell: cmd
+
       - name: Install libudev
         if: matrix.os == 'ubuntu-20.04'
         run: |
@@ -88,8 +121,6 @@ jobs:
           bash ./scripts/release.sh win
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_LINK: ${{ secrets.WIN_CERTIFICATE_BASE64 }}
-          CSC_KEY_PASSWORD: ${{ secrets.WIN_CERTIFICATE_PASSWORD }}
 
       - name: Package for Linux
         if: matrix.os == 'ubuntu-20.04'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -71,7 +71,7 @@ jobs:
         shell: bash
 
       - name: Setting up the client tools
-        if: matrix.os == 'windows-2019'
+        if: ${{ matrix.os == 'windows-2019' && env.SM_API_KEY != '' }}
         run: |
           curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
           msiexec /i smtools-windows-x64.msi /quiet /qn
@@ -79,7 +79,7 @@ jobs:
         shell: cmd
 
       - name: Certificates Sync
-        if: matrix.os == 'windows-2019'
+        if: ${{ matrix.os == 'windows-2019' && env.SM_API_KEY != '' }}
         run: |
           smctl windows certsync
         shell: cmd

--- a/.github/workflows/package_for_test.yml
+++ b/.github/workflows/package_for_test.yml
@@ -82,7 +82,7 @@ jobs:
         shell: bash
 
       - name: Setting up the client tools
-        if: matrix.os == 'windows-2019'
+        if: ${{ matrix.os == 'windows-2019' && env.SM_API_KEY != '' }}
         run: |
           curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
           msiexec /i smtools-windows-x64.msi /quiet /qn
@@ -90,7 +90,7 @@ jobs:
         shell: cmd
 
       - name: Certificates Sync
-        if: matrix.os == 'windows-2019'
+        if: ${{ matrix.os == 'windows-2019' && env.SM_API_KEY != '' }}
         run: |
           smctl windows certsync
         shell: cmd

--- a/.github/workflows/package_for_test.yml
+++ b/.github/workflows/package_for_test.yml
@@ -62,6 +62,39 @@ jobs:
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
 
+      - name: Setup Certificate
+        if: matrix.os == 'windows-2019'
+        run: |
+          echo "${{ secrets.SM_CLIENT_CERT_FILE_BASE64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
+        shell: bash
+
+      - name: Set variables
+        if: matrix.os == 'windows-2019'
+        run: |
+          echo "SM_KEYPAIR_NAME=${{ secrets.SM_KEYPAIR_ALIAS }}" >> "$GITHUB_ENV"
+          echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV"
+          echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV"
+          echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> "$GITHUB_ENV"
+          echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
+          echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
+          echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
+          echo "C:\Program Files\DigiCert\DigiCert One Signing Manager Tools" >> $GITHUB_PATH
+        shell: bash
+
+      - name: Setting up the client tools
+        if: matrix.os == 'windows-2019'
+        run: |
+          curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
+          msiexec /i smtools-windows-x64.msi /quiet /qn
+          C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
+        shell: cmd
+
+      - name: Certificates Sync
+        if: matrix.os == 'windows-2019'
+        run: |
+          smctl windows certsync
+        shell: cmd
+
       - name: Install libudev
         if: matrix.os == 'ubuntu-20.04'
         run: |
@@ -101,19 +134,7 @@ jobs:
           SKIP_NOTARIZE: true
 
       - name: Package for Windows
-        if: ${{ matrix.os == 'windows-2019' && env.WIN_CERTIFICATE_BASE64 != '' }}
-        run: |
-          bash ./scripts/download-ckb.sh win
-          yarn build
-          bash ./scripts/copy-ui-files.sh
-          bash ./scripts/package-for-test.sh win
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_LINK: ${{ secrets.WIN_CERTIFICATE_BASE64 }}
-          CSC_KEY_PASSWORD: ${{ secrets.WIN_CERTIFICATE_PASSWORD }}
-
-      - name: Package for Windows for skip code sign
-        if: ${{ matrix.os == 'windows-2019' && env.WIN_CERTIFICATE_BASE64 == '' }}
+        if: matrix.os == 'windows-2019'
         run: |
           bash ./scripts/download-ckb.sh win
           yarn build

--- a/packages/neuron-wallet/electron-builder.yml
+++ b/packages/neuron-wallet/electron-builder.yml
@@ -49,6 +49,9 @@ win:
     - target: nsis
       arch:
         - x64
+  sign: scripts/customSign.js
+  signingHashAlgorithms:
+    - sha256
 
 mac:
   artifactName: "${productName}-v${version}-${os}-${arch}.${ext}"

--- a/packages/neuron-wallet/scripts/customSign.js
+++ b/packages/neuron-wallet/scripts/customSign.js
@@ -1,0 +1,11 @@
+const { execSync } = require('node:child_process')
+
+exports.default = async configuration => {
+  if (!configuration.path) {
+    throw new Error(`Configuration is required`)
+  }
+
+  execSync(`smctl sign --keypair-alias="${process.env.SM_KEYPAIR_NAME}" --input "${String(configuration.path)}"`, {
+    stdio: 'inherit',
+  })
+}

--- a/packages/neuron-wallet/scripts/customSign.js
+++ b/packages/neuron-wallet/scripts/customSign.js
@@ -1,6 +1,11 @@
 const { execSync } = require('node:child_process')
 
 exports.default = async configuration => {
+  if (!process.env.SM_API_KEY) {
+    console.info(`Skip signing because SM_API_KEY and  not configured`)
+    return
+  }
+
   if (!configuration.path) {
     throw new Error(`Path of application is not found`)
   }

--- a/packages/neuron-wallet/scripts/customSign.js
+++ b/packages/neuron-wallet/scripts/customSign.js
@@ -2,7 +2,7 @@ const { execSync } = require('node:child_process')
 
 exports.default = async configuration => {
   if (!configuration.path) {
-    throw new Error(`Configuration is required`)
+    throw new Error(`Path of application is not found`)
   }
 
   execSync(`smctl sign --keypair-alias="${process.env.SM_KEYPAIR_NAME}" --input "${String(configuration.path)}"`, {


### PR DESCRIPTION
ref: 
- why use key locker: https://knowledge.digicert.com/solution/digicert-keylocker.html
- how to use key locker in github action: https://docs.digicert.com/en/digicert-keylocker/ci-cd-integrations/script-integrations/github-integration-ksp.html
- Update certificate of Neuron for windows: https://github.com/Magickbase/neuron-public-issues/issues/188

---
Package Neuron for test: https://github.com/nervosnetwork/neuron/actions/runs/6658266030/job/18094724690#step:17:124
<img width="426" alt="image" src="https://github.com/nervosnetwork/neuron/assets/7271329/f4a4a8fd-7388-4968-896d-7714c4204937">

Package Neuron for Release Draft: https://github.com/nervosnetwork/neuron/actions/runs/6658347469/job/18094990967#step:15:120
<img width="427" alt="image" src="https://github.com/nervosnetwork/neuron/assets/7271329/3fed7250-606d-4e15-a6b4-163100543a23">
