### PR TITLE
fix: Avoid unexpected dialog shown.

### DIFF
--- a/packages/neuron-ui/src/components/NervosDAO/index.tsx
+++ b/packages/neuron-ui/src/components/NervosDAO/index.tsx
@@ -113,6 +113,7 @@ const NervosDAO = () => {
     cacheTipBlockNumber,
     currentTimestamp: Date.now(),
     url: getCurrentUrl(networkID, networks),
+    networkID,
   })
 
   const MemoizedRecords = useMemo(() => {

--- a/packages/neuron-ui/src/states/stateProvider/reducer.ts
+++ b/packages/neuron-ui/src/states/stateProvider/reducer.ts
@@ -209,6 +209,7 @@ export const reducer = produce((state: Draft<State.AppWithNeuronWallet>, action:
           cacheTipBlockNumber: action.payload.cacheTipBlockNumber,
           currentTimestamp: Date.now(),
           url: getCurrentUrl(state.chain.networkID, state.settings.networks),
+          networkID: state.chain.networkID,
         }),
       }
       break

--- a/packages/neuron-ui/src/utils/getSyncStatus.ts
+++ b/packages/neuron-ui/src/utils/getSyncStatus.ts
@@ -5,6 +5,7 @@ const TEN_MINS = 10 * 60 * 1000
 let blockNumber10MinAgo: number = -1
 let timestamp10MinAgo: number | undefined
 let prevUrl: string | undefined
+let prevNetworkID: string | undefined
 
 export const getSyncStatus = ({
   bestKnownBlockNumber,
@@ -12,17 +13,23 @@ export const getSyncStatus = ({
   cacheTipBlockNumber,
   currentTimestamp,
   url,
+  networkID,
 }: {
   bestKnownBlockNumber: number
   bestKnownBlockTimestamp: number
   cacheTipBlockNumber: number
   currentTimestamp: number
   url: string | undefined
+  networkID: string
 }) => {
-  if ((!timestamp10MinAgo && bestKnownBlockNumber >= 0) || (prevUrl && url !== prevUrl && bestKnownBlockNumber >= 0)) {
+  if (
+    (!timestamp10MinAgo && bestKnownBlockNumber >= 0) ||
+    (((prevUrl && url !== prevUrl) || (prevNetworkID && prevNetworkID !== networkID)) && bestKnownBlockNumber >= 0)
+  ) {
     timestamp10MinAgo = currentTimestamp
     blockNumber10MinAgo = bestKnownBlockNumber
     prevUrl = url
+    prevNetworkID = networkID
   }
 
   const now = Math.floor(currentTimestamp / 1000) * 1000

--- a/packages/neuron-ui/src/utils/getSyncStatus.ts
+++ b/packages/neuron-ui/src/utils/getSyncStatus.ts
@@ -23,7 +23,10 @@ export const getSyncStatus = ({
   networkID: string
 }) => {
   if (
+    // !timestamp10MinAgo means start sync for the first time
     (!timestamp10MinAgo && bestKnownBlockNumber >= 0) ||
+    // prevUrl for change the network remote(change network or eidt the network)
+    // prevNetworkID for change the network, sometime change network the remote is same. light client mainnet -> testnet
     (((prevUrl && url !== prevUrl) || (prevNetworkID && prevNetworkID !== networkID)) && bestKnownBlockNumber >= 0)
   ) {
     timestamp10MinAgo = currentTimestamp

--- a/packages/neuron-wallet/src/controllers/export-debug.ts
+++ b/packages/neuron-wallet/src/controllers/export-debug.ts
@@ -12,6 +12,7 @@ import redistCheck from '../utils/redist-check'
 import SettingsService from '../services/settings'
 import { generateRPC } from '../utils/ckb-rpc'
 import { CKBLightRunner } from '../services/light-runner'
+import { LIGHT_CLIENT_MAINNET, LIGHT_CLIENT_TESTNET } from '../utils/const'
 
 export default class ExportDebugController {
   #I18N_PATH = 'export-debug-info'
@@ -162,10 +163,13 @@ export default class ExportDebugController {
   }
 
   private addBundledCKBLightClientLog() {
-    const logPath = CKBLightRunner.getInstance().logPath
-    if (!fs.existsSync(logPath)) {
-      return
+    const mainnetLogPath = CKBLightRunner.getInstance().getLogPath(LIGHT_CLIENT_MAINNET)
+    const testnetLogPath = CKBLightRunner.getInstance().getLogPath(LIGHT_CLIENT_TESTNET)
+    if (fs.existsSync(mainnetLogPath)) {
+      this.archive.file(mainnetLogPath, { name: 'bundled-ckb-lignt-client-mainnet.log' })
     }
-    this.archive.file(logPath, { name: 'bundled-ckb-lignt-client.log' })
+    if (fs.existsSync(testnetLogPath)) {
+      this.archive.file(testnetLogPath, { name: 'bundled-ckb-lignt-client-testnet.log' })
+    }
   }
 }

--- a/packages/neuron-wallet/src/services/ckb-runner.ts
+++ b/packages/neuron-wallet/src/services/ckb-runner.ts
@@ -119,16 +119,16 @@ export const startCkbNode = async () => {
     stdio[1] = 'pipe'
   }
   logger.info(`CKB:\tckb full node will with rpc port ${rpcPort}, listen port ${listenPort}, with options`, options)
-  ckb = spawn(ckbBinary(), options, { stdio })
+  const currentProcess = spawn(ckbBinary(), options, { stdio })
 
-  ckb.stderr?.on('data', data => {
+  currentProcess.stderr?.on('data', data => {
     const dataString: string = data.toString()
     logger.error('CKB:\trun fail:', dataString)
     if (dataString.includes('CKB wants to migrate the data into new format')) {
       MigrateSubject.next({ type: 'need-migrate' })
     }
   })
-  ckb.stdout?.on('data', data => {
+  currentProcess.stdout?.on('data', data => {
     const dataString: string = data.toString()
     if (
       dataString.includes(
@@ -142,17 +142,23 @@ export const startCkbNode = async () => {
     }
   })
 
-  ckb.on('error', error => {
+  currentProcess.on('error', error => {
     logger.error('CKB:\trun fail:', error)
     isLookingValidTarget = false
-    ckb = null
+    if (ckb?.pid === currentProcess.pid) {
+      ckb = null
+    }
   })
 
-  ckb.on('close', () => {
+  currentProcess.on('close', () => {
     logger.info('CKB:\tprocess closed')
     isLookingValidTarget = false
-    ckb = null
+    if (ckb?.pid === currentProcess.pid) {
+      ckb = null
+    }
   })
+
+  ckb = currentProcess
 
   removeOldIndexerIfRunSuccess()
 }

--- a/packages/neuron-wallet/src/services/ckb-runner.ts
+++ b/packages/neuron-wallet/src/services/ckb-runner.ts
@@ -145,7 +145,7 @@ export const startCkbNode = async () => {
   currentProcess.on('error', error => {
     logger.error('CKB:\trun fail:', error)
     isLookingValidTarget = false
-    if (ckb?.pid === currentProcess.pid) {
+    if (Object.is(ckb, currentProcess)) {
       ckb = null
     }
   })
@@ -153,7 +153,7 @@ export const startCkbNode = async () => {
   currentProcess.on('close', () => {
     logger.info('CKB:\tprocess closed')
     isLookingValidTarget = false
-    if (ckb?.pid === currentProcess.pid) {
+    if (Object.is(ckb, currentProcess)) {
       ckb = null
     }
   })

--- a/packages/neuron-wallet/src/services/light-runner.ts
+++ b/packages/neuron-wallet/src/services/light-runner.ts
@@ -162,14 +162,14 @@ export class CKBLightRunner extends NodeRunner {
       })
     runnerProcess.once('error', error => {
       logger.error('CKB Light Runner:\trun fail:', error)
-      if (this.runnerProcess?.pid === runnerProcess.pid) {
+      if (Object.is(this.runnerProcess, runnerProcess)) {
         this.runnerProcess = undefined
       }
     })
 
     runnerProcess.once('close', () => {
       logger.info('CKB Light Runner:\tprocess closed')
-      if (this.runnerProcess?.pid === runnerProcess.pid) {
+      if (Object.is(this.runnerProcess, runnerProcess)) {
         this.runnerProcess = undefined
       }
     })

--- a/packages/neuron-wallet/tests/controllers/export-debug.test.ts
+++ b/packages/neuron-wallet/tests/controllers/export-debug.test.ts
@@ -78,7 +78,9 @@ jest.mock('../../src/services/light-runner', () => {
     CKBLightRunner: {
       getInstance() {
         return {
-          logPath: '',
+          getLogPath() {
+            return ''
+          },
         }
       },
     },

--- a/packages/neuron-wallet/tests/services/node.test.ts
+++ b/packages/neuron-wallet/tests/services/node.test.ts
@@ -1,6 +1,7 @@
 import { distinctUntilChanged, sampleTime, flatMap, delay, retry } from 'rxjs/operators'
 import { BUNDLED_CKB_URL, START_WITHOUT_INDEXER } from '../../src/utils/const'
 import { NetworkType } from '../../src/models/network'
+import { scheduler } from 'timers/promises'
 
 describe('NodeService', () => {
   let nodeService: any
@@ -9,7 +10,6 @@ describe('NodeService', () => {
   const stubbedStartLightNode = jest.fn()
   const stubbedStopLightNode = jest.fn()
   const stubbedConnectionStatusSubjectNext = jest.fn()
-  const stubbedCKBSetNode = jest.fn()
   const stubbedGetTipBlockNumber = jest.fn()
   const stubbedRxjsDebounceTime = jest.fn()
   const stubbedCurrentNetworkIDSubjectSubscribe = jest.fn()
@@ -37,7 +37,6 @@ describe('NodeService', () => {
     stubbedStartCKBNode.mockReset()
     stubbedStopCkbNode.mockReset()
     stubbedConnectionStatusSubjectNext.mockReset()
-    stubbedCKBSetNode.mockReset()
     stubbedGetTipBlockNumber.mockReset()
     stubbedCurrentNetworkIDSubjectSubscribe.mockReset()
     stubbedNetworsServiceGet.mockReset()
@@ -351,19 +350,16 @@ describe('NodeService', () => {
     describe('targets to bundled node', () => {
       const bundledNodeUrl = 'http://127.0.0.1:8114'
       beforeEach(async () => {
-        stubbedCKBSetNode.mockImplementation(() => {
-          nodeService.ckb.node.url = bundledNodeUrl
-        })
         stubbedStartCKBNode.mockResolvedValue(true)
         redistCheckMock.mockResolvedValue(true)
         stubbedNetworsServiceGet.mockReturnValue({ remote: bundledNodeUrl, readonly: true })
         getLocalNodeInfoMock.mockRejectedValue('not start')
         await nodeService.tryStartNodeOnDefaultURI()
-
+        await scheduler.wait(1500)
         jest.advanceTimersByTime(10000)
       })
       it('sets startedBundledNode to true in ConnectionStatusSubject', () => {
-        expect(stubbedConnectionStatusSubjectNext).toHaveBeenCalledWith({
+        expect(stubbedConnectionStatusSubjectNext).toHaveBeenLastCalledWith({
           url: bundledNodeUrl,
           connected: false,
           isBundledNode: true,


### PR DESCRIPTION
To avoid unexpected dialog that notifies the user of an external node shown.
1. Set the process to null when the started pid equals the current process pid.
2. Stop the get tip number when switching the network and start after starting the node.
3. Add debounce time to start node, that is avoid the user switching the internal network faster.