### PR TITLE
fix: Fix migrate settings and network.

### DIFF
--- a/packages/neuron-wallet/src/services/networks.ts
+++ b/packages/neuron-wallet/src/services/networks.ts
@@ -66,7 +66,8 @@ enum NetworksKey {
 }
 
 const oldDefaultNames = ['Default', 'default node', presetNetworks.networks[0].name]
-// Before 0.106.0 version the default remote's value is http://localhost:8114.
+// Before 0.106.0 version the default remote's value is http://localhost:8114
+// "localhost" was deprecated because of https://github.com/Magickbase/neuron-public-issues/issues/122
 const oldDefaultRemotes = ['http://localhost:8114', BUNDLED_CKB_URL]
 
 export default class NetworksService extends Store {

--- a/packages/neuron-wallet/src/services/networks.ts
+++ b/packages/neuron-wallet/src/services/networks.ts
@@ -66,6 +66,7 @@ enum NetworksKey {
 }
 
 const oldDefaultNames = ['Default', 'default node', presetNetworks.networks[0].name]
+// Before 0.106.0 version the default remote's value is http://localhost:8114.
 const oldDefaultRemotes = ['http://localhost:8114', BUNDLED_CKB_URL]
 
 export default class NetworksService extends Store {

--- a/packages/neuron-wallet/src/services/networks.ts
+++ b/packages/neuron-wallet/src/services/networks.ts
@@ -66,6 +66,7 @@ enum NetworksKey {
 }
 
 const oldDefaultNames = ['Default', 'default node', presetNetworks.networks[0].name]
+const oldDefaultRemotes = ['http://localhost:8114', BUNDLED_CKB_URL]
 
 export default class NetworksService extends Store {
   private static instance: NetworksService
@@ -263,7 +264,7 @@ export default class NetworksService extends Store {
         if (
           // make sure that user has not change the network name
           oldDefaultNames.includes(oldMainnetNetwork.name) &&
-          oldMainnetNetwork.remote === defaultMainnetNetwork.remote &&
+          oldDefaultRemotes.includes(oldMainnetNetwork.remote) &&
           oldMainnetNetwork.type === defaultMainnetNetwork.type
         ) {
           this.updateAll([

--- a/packages/neuron-wallet/src/services/settings.ts
+++ b/packages/neuron-wallet/src/services/settings.ts
@@ -80,7 +80,7 @@ export default class SettingsService extends Store {
         ckbDataPath: path.resolve(app.getPath('userData'), 'chains/mainnet'),
       })
     )
-    if (!this.getNodeDataPath(LIGHT_CLIENT_MAINNET)) {
+    if (!this.getNodeDataPath(LIGHT_CLIENT_MAINNET) || !this.getNodeDataPath('ckb')) {
       this.migrateDataPath()
     }
   }

--- a/packages/neuron-wallet/src/services/settings.ts
+++ b/packages/neuron-wallet/src/services/settings.ts
@@ -93,8 +93,8 @@ export default class SettingsService extends Store {
   migrateDataPath() {
     const networkChain = NetworksService.getInstance().getCurrent()?.chain
     const currentCkbDataPath = this.readSync(settingKeys.ckbDataPath)
-    this.writeSync(`${settingKeys.nodeDataPath}_${networkChain}`, currentCkbDataPath)
     const defaultMainNetworkDir = path.resolve(app.getPath('userData'), 'chains/mainnet')
+    this.writeSync(`${settingKeys.nodeDataPath}_${networkChain}`, currentCkbDataPath || defaultMainNetworkDir)
     if (networkChain !== 'ckb') {
       // if user has changed the ckb data path and running with testnet
       this.writeSync(`${settingKeys.nodeDataPath}_ckb`, defaultMainNetworkDir)


### PR DESCRIPTION
Refer to https://github.com/Magickbase/neuron-public-issues/issues/320.

#### How to reproduce this problem

Delete the settings and network file, download the 0.103.1 Neuron, and start. Then update to 0.110.1.

The settings file location:
Mac OS: /Users/${username}/Library/Application Support/Neuron/settings.json
Windows: C:/Users/${username}/AppData/Roaming/Neuron/settings.json

The network file location:
Mac OS: /Users/${username}/Library/Application Support/Neuron/networks/index.json
Windows: C:/Users/${username}/AppData/Roaming/Neuron/networks/index.json