### PR TITLE
fix: Fix light client sync slow when fetch much transactions.

### DIFF
--- a/packages/neuron-wallet/src/block-sync-renderer/sync/light-connector.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/light-connector.ts
@@ -248,14 +248,14 @@ export default class LightConnector extends Connector<CKBComponents.Hash> {
       .createBatchRequest<'getTransaction', string[], TransactionWithStatus[]>(txHashes.map(v => ['getTransaction', v]))
       .exec()
     const previousTxHashes = new Set<string>()
-    transactions.forEach(tx => {
-      tx.transaction.inputs.forEach(input => {
+    transactions
+      .flatMap(tx => tx.transaction.inputs)
+      .forEach(input => {
         const previousTxHash = input.previousOutput!.txHash
         if (previousTxHash !== `0x${'0'.repeat(64)}`) {
           previousTxHashes.add(previousTxHash)
         }
       })
-    })
     await this.lightRpc.createBatchRequest([...previousTxHashes].map(v => ['fetchTransaction' as keyof Base, v])).exec()
   }
 

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/light-connector.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/light-connector.ts
@@ -1,7 +1,7 @@
 import { BI } from '@ckb-lumos/bi'
 import { Subject } from 'rxjs'
 import { queue, QueueObject } from 'async'
-import { HexString, QueryOptions } from '@ckb-lumos/base'
+import type { HexString, QueryOptions, TransactionWithStatus } from '@ckb-lumos/base'
 import { Indexer as CkbIndexer, CellCollector } from '@ckb-lumos/ckb-indexer'
 import logger from '../../utils/logger'
 import { Address } from '../../models/address'
@@ -18,6 +18,7 @@ import AssetAccountInfo from '../../models/asset-account-info'
 import { DepType } from '../../models/chain/cell-dep'
 import { molecule } from '@ckb-lumos/codec'
 import { blockchain } from '@ckb-lumos/base'
+import type { Base } from '@ckb-lumos/rpc/lib/Base'
 
 interface SyncQueueParam {
   script: CKBComponents.Script
@@ -232,12 +233,30 @@ export default class LightConnector extends Connector<CKBComponents.Hash> {
       })
       return
     }
-    this.transactionsSubject.next({ txHashes: result.txs.map(v => v.txHash), params: syncProgress.hash })
+    const txHashes = result.txs.map(v => v.txHash)
+    await this.fetchPreviousOutputs(txHashes)
+    this.transactionsSubject.next({ txHashes, params: syncProgress.hash })
     this.syncInQueue.set(syncProgress.hash, {
       blockStartNumber: result.lastCursor === '0x' ? parseInt(blockRange[1]) : parseInt(blockRange[0]),
       blockEndNumber: parseInt(blockRange[1]),
       cursor: result.lastCursor === '0x' ? undefined : result.lastCursor,
     })
+  }
+
+  private async fetchPreviousOutputs(txHashes: string[]) {
+    const transactions = await this.lightRpc
+      .createBatchRequest<'getTransaction', string[], TransactionWithStatus[]>(txHashes.map(v => ['getTransaction', v]))
+      .exec()
+    const previousTxHashes = new Set<string>()
+    transactions.forEach(tx => {
+      tx.transaction.inputs.forEach(input => {
+        const previousTxHash = input.previousOutput!.txHash
+        if (previousTxHash !== `0x${'0'.repeat(64)}`) {
+          previousTxHashes.add(previousTxHash)
+        }
+      })
+    })
+    await this.lightRpc.createBatchRequest([...previousTxHashes].map(v => ['fetchTransaction' as keyof Base, v])).exec()
   }
 
   private async collectLiveCellsByScript(query: LumosCellQuery) {

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/light-connector.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/light-connector.ts
@@ -252,6 +252,7 @@ export default class LightConnector extends Connector<CKBComponents.Hash> {
       .flatMap(tx => tx.transaction.inputs)
       .forEach(input => {
         const previousTxHash = input.previousOutput!.txHash
+        // exclude the cell base transaction in a block
         if (previousTxHash !== `0x${'0'.repeat(64)}`) {
           previousTxHashes.add(previousTxHash)
         }

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
@@ -171,7 +171,10 @@ export default class Queue {
     }, 1)
 
     const drainFetchTxQueue = new Promise((resolve, reject) => {
-      fetchTxQueue.error(reject)
+      fetchTxQueue.error(err => {
+        fetchTxQueue.kill()
+        reject(err)
+      })
       fetchTxQueue.drain(() => resolve(0))
     })
 

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
@@ -90,6 +90,7 @@ export default class Queue {
       while (true) {
         try {
           await this.#checkAndSave(txHashes)
+          process.send?.({ channel: 'tx-db-changed' })
           break
         } catch (error) {
           logger.error('retry saving transactions in 2 seconds due to error:', error)


### PR DESCRIPTION
Refer to https://github.com/Magickbase/neuron-public-issues/issues/322

[wallet.json](https://github.com/nervosnetwork/neuron/files/13388483/issue-322-xpubkey.json) Here is a watched wallet to test this issue. The wallet has a transaction that receives over 3000 cells' inputs. https://pudge.explorer.nervos.org/transaction/0x1731a226064e9b8b51b7238420452191872dfaf65a91ba1d4ccaec2cf3ed3b2e

We can compare the difference between the release and the current PR package.

