### PR TITLE
refactor: refactor sign method to allow unidentified lock scripts

### DIFF
--- a/packages/neuron-wallet/src/controllers/anyone-can-pay.ts
+++ b/packages/neuron-wallet/src/controllers/anyone-can-pay.ts
@@ -21,7 +21,7 @@ export interface SendAnyoneCanPayTxParams {
   walletID: string
   tx: Transaction
   password: string
-  skipLastInputs?: boolean
+  skipLastInput?: boolean
 }
 
 export default class AnyoneCanPayController {
@@ -64,7 +64,7 @@ export default class AnyoneCanPayController {
       params.walletID,
       txModel,
       params.password,
-      params?.skipLastInputs ?? true,
+      params?.skipLastInput ?? true,
       skipSign
     )
 

--- a/packages/neuron-wallet/src/services/hardware/hardware.ts
+++ b/packages/neuron-wallet/src/services/hardware/hardware.ts
@@ -25,12 +25,12 @@ export abstract class Hardware {
     walletID: string,
     tx: Transaction,
     txHash: string,
-    skipLastInputs: boolean = true,
+    skipLastInput: boolean = true,
     context?: RPC.RawTransaction[]
   ) {
     const wallet = WalletService.getInstance().get(walletID)
     const addressInfos = await AddressService.getAddressesByWalletId(walletID)
-    const witnessSigningEntries = tx.inputs.slice(0, skipLastInputs ? -1 : tx.inputs.length).map((input, index) => {
+    const witnessSigningEntries = tx.inputs.slice(0, skipLastInput ? -1 : tx.inputs.length).map((input, index) => {
       const lockArgs: string = input.lock!.args!
       const wit: WitnessArgs | string = tx.witnesses[index]
       const witnessArgs: WitnessArgs = wit instanceof WitnessArgs ? wit : WitnessArgs.generateEmpty()

--- a/packages/neuron-wallet/src/services/transaction-sender.ts
+++ b/packages/neuron-wallet/src/services/transaction-sender.ts
@@ -67,12 +67,12 @@ export default class TransactionSender {
     walletID: string = '',
     transaction: Transaction,
     password: string = '',
-    skipLastInputs: boolean = true,
+    skipLastInput: boolean = true,
     skipSign = false
   ) {
     const tx = skipSign
       ? Transaction.fromObject(transaction)
-      : await this.sign(walletID, transaction, password, skipLastInputs)
+      : await this.sign(walletID, transaction, password, skipLastInput)
 
     return this.broadcastTx(walletID, tx)
   }
@@ -109,7 +109,7 @@ export default class TransactionSender {
     walletID: string = '',
     transaction: Transaction,
     password: string = '',
-    skipLastInputs: boolean = true,
+    skipLastInput: boolean = true,
     context?: RPC.RawTransaction[]
   ) {
     const wallet = this.walletService.get(walletID)
@@ -124,7 +124,7 @@ export default class TransactionSender {
         await device.connect()
       }
       try {
-        return await device.signTx(walletID, tx, txHash, skipLastInputs, context)
+        return await device.signTx(walletID, tx, txHash, skipLastInput, context)
       } catch (err) {
         if (err instanceof TypeError) {
           throw err
@@ -167,7 +167,7 @@ export default class TransactionSender {
     }
 
     const witnessSigningEntries: SignInfo[] = tx.inputs
-      .slice(0, skipLastInputs ? -1 : tx.inputs.length)
+      .slice(0, skipLastInput ? -1 : tx.inputs.length)
       .map((input: Input, index: number) => {
         const lockArgs: string = input.lock!.args!
         const wit: WitnessArgs | string = tx.witnesses[index]

--- a/packages/neuron-wallet/tests/controllers/anyone-can-pay.test.ts
+++ b/packages/neuron-wallet/tests/controllers/anyone-can-pay.test.ts
@@ -96,7 +96,7 @@ describe('anyone-can-pay-controller', () => {
       walletID: 'string',
       tx: new Transaction('', [], [], [], [], []),
       password: 'string',
-      skipLastInputs: false,
+      skipLastInput: false,
     }
     it('throw exception', async () => {
       sendTxMock.mockResolvedValueOnce(undefined)

--- a/packages/neuron-wallet/tests/controllers/offline-sign.test.ts
+++ b/packages/neuron-wallet/tests/controllers/offline-sign.test.ts
@@ -115,6 +115,8 @@ describe('OfflineSignController', () => {
     },
   }
 
+  const mockTransactionMetadata = { locks: { skipped: new Set() } }
+
   const mockTxInstance = {
     toSDKRawTransaction() {
       return mockTransaction
@@ -347,7 +349,9 @@ describe('OfflineSignController', () => {
           filePath: 'filePath.json',
         })
 
-        stubbedTransactionSenderSign.mockReturnValue(mockTransaction)
+        stubbedTransactionSenderSign.mockReturnValue(
+          Promise.resolve({ tx: mockTransaction, metadata: mockTransactionMetadata })
+        )
       })
 
       it('sign status should change to `signed`', async () => {
@@ -413,7 +417,9 @@ describe('OfflineSignController', () => {
           filePath: 'filePath.json',
         })
 
-        stubbedTransactionSenderSign.mockReturnValue(mockTransaction)
+        stubbedTransactionSenderSign.mockReturnValue(
+          Promise.resolve({ tx: mockTransaction, metadata: mockTransactionMetadata })
+        )
       })
 
       it('should signed', async () => {
@@ -486,7 +492,7 @@ describe('OfflineSignController', () => {
   describe('signAndBroadcastTransaction', () => {
     beforeEach(() => {
       resetMocks()
-      signMultisigMock.mockReturnValue(mockTransaction)
+      signMultisigMock.mockReturnValue({ tx: mockTransaction, metadata: mockTransactionMetadata })
     })
     it('throw exception', async () => {
       getMultisigStatusMock.mockReturnValueOnce(SignStatus.PartiallySigned)


### PR DESCRIPTION
The sign method is refactored to allow unidentified lock scripts
while skipped lock scripts are prevented outside the sign method

Notice that skipped lock scripts validation is not adopted when
a multisig transaction because it's explictly thrown
when no private key is found. It may be intended.