### PR TITLE
feat: Optimize the setting of sync start block in light client mode.

### DIFF
--- a/packages/neuron-ui/src/components/PageContainer/hooks.ts
+++ b/packages/neuron-ui/src/components/PageContainer/hooks.ts
@@ -1,8 +1,36 @@
-import { useCallback, useEffect, useState } from 'react'
+import { TFunction } from 'i18next'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { importedWalletDialogShown } from 'services/localCache'
-import { isDark, openExternal, updateWallet, setTheme as setThemeAPI } from 'services/remote'
+import { isDark, openExternal, setTheme as setThemeAPI, updateWalletStartBlockNumber } from 'services/remote'
 import { Migrate } from 'services/subjects'
 import { getExplorerUrl, isSuccessResponse } from 'utils'
+
+const waitConfirmTime = 5
+
+const useCountDown = (second: number) => {
+  const [countdown, setCountdown] = useState(0)
+  const countDecreaseIntervalRef = useRef<ReturnType<typeof setInterval>>()
+  const resetCountDown = useCallback(() => {
+    clearInterval(countDecreaseIntervalRef.current)
+    setCountdown(second)
+    const decrement = () => {
+      countDecreaseIntervalRef.current = setInterval(() => {
+        setCountdown(v => {
+          if (v > 0) {
+            return v - 1
+          }
+          clearInterval(countDecreaseIntervalRef.current)
+          return v
+        })
+      }, 1_000)
+    }
+    decrement()
+  }, [setCountdown, countDecreaseIntervalRef])
+  return {
+    countdown,
+    resetCountDown,
+  }
+}
 
 export const useSetBlockNumber = ({
   firstAddress,
@@ -10,25 +38,40 @@ export const useSetBlockNumber = ({
   isMainnet,
   isLightClient,
   isHomePage,
+  initStartBlockNumber,
+  headerTipNumber,
+  t,
 }: {
   firstAddress: string
   walletID: string
   isMainnet: boolean
   isLightClient: boolean
   isHomePage?: boolean
+  initStartBlockNumber?: number
+  headerTipNumber: number
+  t: TFunction
 }) => {
   const [isSetStartBlockShown, setIsSetStartBlockShown] = useState(false)
   const [startBlockNumber, setStartBlockNumber] = useState('')
   const [blockNumberErr, setBlockNumberErr] = useState('')
-  const onChangeStartBlockNumber = useCallback((e: React.SyntheticEvent<HTMLInputElement>) => {
-    const { value } = e.currentTarget
-    const blockNumber = value.replace(/,/g, '')
-    if (Number.isNaN(+blockNumber) || /[^\d]/.test(blockNumber)) {
-      return
-    }
-    setStartBlockNumber(blockNumber)
-    setBlockNumberErr('')
-  }, [])
+  const isSetLessThanBefore = useMemo(
+    () => !!(startBlockNumber && initStartBlockNumber && +startBlockNumber < initStartBlockNumber),
+    [initStartBlockNumber, startBlockNumber]
+  )
+  const { countdown, resetCountDown } = useCountDown(waitConfirmTime)
+  const onChangeStartBlockNumber = useCallback(
+    (e: React.SyntheticEvent<HTMLInputElement>) => {
+      const { value } = e.currentTarget
+      const blockNumber = value.replaceAll(',', '')
+      if (Number.isNaN(+blockNumber)) {
+        return
+      }
+      setStartBlockNumber(+blockNumber > headerTipNumber ? headerTipNumber.toString() : blockNumber)
+      setBlockNumberErr(+blockNumber > headerTipNumber ? t('set-start-block-number.reset-to-header-tip-number') : '')
+      resetCountDown()
+    },
+    [resetCountDown, initStartBlockNumber, headerTipNumber, t]
+  )
   const onOpenAddressInExplorer = useCallback(() => {
     const explorerUrl = getExplorerUrl(isMainnet)
     openExternal(`${explorerUrl}/address/${firstAddress}`)
@@ -38,7 +81,10 @@ export const useSetBlockNumber = ({
     openExternal(`${explorerUrl}/block/${startBlockNumber}`)
   }, [startBlockNumber, isMainnet])
   const onConfirm = useCallback(() => {
-    updateWallet({ id: walletID, startBlockNumber: `0x${BigInt(startBlockNumber).toString(16)}` }).then(res => {
+    updateWalletStartBlockNumber({
+      id: walletID,
+      startBlockNumber: `0x${BigInt(startBlockNumber).toString(16)}`,
+    }).then(res => {
       if (isSuccessResponse(res)) {
         setIsSetStartBlockShown(false)
       } else {
@@ -48,9 +94,9 @@ export const useSetBlockNumber = ({
   }, [startBlockNumber, walletID])
   const openDialog = useCallback(() => {
     setIsSetStartBlockShown(true)
-    setStartBlockNumber('')
+    setStartBlockNumber(initStartBlockNumber?.toString() ?? '')
     setBlockNumberErr('')
-  }, [])
+  }, [initStartBlockNumber])
   useEffect(() => {
     if (isHomePage) {
       const needShow = importedWalletDialogShown.getStatus(walletID)
@@ -70,6 +116,8 @@ export const useSetBlockNumber = ({
     onViewBlock,
     onConfirm,
     blockNumberErr,
+    countdown,
+    isSetLessThanBefore,
   }
 }
 

--- a/packages/neuron-ui/src/components/PageContainer/pageContainer.module.scss
+++ b/packages/neuron-ui/src/components/PageContainer/pageContainer.module.scss
@@ -144,9 +144,32 @@
   }
 }
 
-.startBlockTip {
-  font-weight: 400;
-  color: var(--secondary-text-color);
+.setBlockContent {
+  padding: 0 0 20px 0;
+  overflow-y: auto;
+
+  .content {
+    padding: 0 16px 0 16px;
+  }
+  .startBlockTip {
+    font-weight: 400;
+    color: var(--secondary-text-color);
+  }
+
+  .setBlockWarn {
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--warn-background-color);
+    color: var(--warn-text-color);
+    font-size: 12px;
+    font-weight: 500;
+
+    & > svg {
+      margin-right: 4px;
+    }
+  }
 }
 
 .viewAction {

--- a/packages/neuron-ui/src/components/SyncStatus/index.tsx
+++ b/packages/neuron-ui/src/components/SyncStatus/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { SyncStatus as SyncStatusEnum, ConnectionStatus } from 'utils'
+import { SyncStatus as SyncStatusEnum, ConnectionStatus, clsx, localNumberFormatter } from 'utils'
 import { Confirming, NewTab } from 'widgets/Icons/icon'
 import { ReactComponent as UnexpandStatus } from 'widgets/Icons/UnexpandStatus.svg'
 import { ReactComponent as StartBlock } from 'widgets/Icons/StartBlock.svg'
@@ -13,12 +13,14 @@ const SyncDetail = ({
   onOpenValidTarget,
   isLightClient,
   onOpenSetStartBlock,
+  startBlockNumber,
 }: {
   syncBlockNumbers: string
   isLookingValidTarget: boolean
   onOpenValidTarget: (e: React.SyntheticEvent) => void
   isLightClient: boolean
   onOpenSetStartBlock: () => void
+  startBlockNumber?: string
 }) => {
   const [t] = useTranslation()
   return (
@@ -42,10 +44,16 @@ const SyncDetail = ({
           </div>
         </div>
       )}
+      {isLightClient && startBlockNumber ? (
+        <div className={styles.startBlockNumber}>
+          <div className={styles.title}>{t('network-status.tooltip.start-block-number')}:</div>
+          <div className={styles.number}>{localNumberFormatter(startBlockNumber)}</div>
+        </div>
+      ) : null}
       {isLightClient && (
         <div
           role="link"
-          className={styles.action}
+          className={clsx(styles.action, styles.setStartBlockNumber)}
           onClick={onOpenSetStartBlock}
           onKeyPress={onOpenSetStartBlock}
           tabIndex={-1}
@@ -70,6 +78,7 @@ const SyncStatus = ({
   isMigrate,
   isLightClient,
   onOpenSetStartBlock,
+  startBlockNumber,
 }: React.PropsWithoutRef<{
   syncStatus: SyncStatusEnum
   connectionStatus: State.ConnectionStatus
@@ -80,6 +89,7 @@ const SyncStatus = ({
   isMigrate: boolean
   isLightClient: boolean
   onOpenSetStartBlock: () => void
+  startBlockNumber?: string
 }>) => {
   const [t] = useTranslation()
   const [isOpen, setIsOpen] = useState(false)
@@ -116,6 +126,7 @@ const SyncStatus = ({
           onOpenValidTarget={onOpenValidTarget}
           isLightClient={isLightClient}
           onOpenSetStartBlock={onOpenSetStartBlock}
+          startBlockNumber={startBlockNumber}
         />
       }
       trigger="click"

--- a/packages/neuron-ui/src/components/SyncStatus/syncStatus.module.scss
+++ b/packages/neuron-ui/src/components/SyncStatus/syncStatus.module.scss
@@ -63,7 +63,7 @@
     font-size: 12px;
     font-weight: 400;
 
-    &:nth-child(2) {
+    &.setStartBlockNumber {
       &::before {
         content: '';
         display: block;
@@ -72,10 +72,6 @@
         background-color: var(--divide-line-color);
         margin: 12px 0;
       }
-    }
-
-    &:nth-child(3) {
-      margin-top: 12px;
     }
 
     & > div {
@@ -93,6 +89,19 @@
           fill: var(--primary-color);
         }
       }
+    }
+  }
+
+  .startBlockNumber {
+    margin-top: 8px;
+    .title {
+      font-size: 12px;
+      font-weight: 400;
+    }
+    .number {
+      color: var(--third-text-color);
+      font-family: D-DIN-PRO;
+      font-weight: 700;
     }
   }
 }

--- a/packages/neuron-ui/src/locales/en.json
+++ b/packages/neuron-ui/src/locales/en.json
@@ -31,6 +31,7 @@
       "tooltip": {
         "block-synced": "Block Synced",
         "looking-valid-target": "Looking for assumed valid target",
+        "start-block-number": "Start block number",
         "set-start-block-number": "Set start block number"
       },
       "migrating": "migrating..."
@@ -1124,10 +1125,13 @@
     },
     "set-start-block-number": {
       "title": "Set the start block number",
+      "warn": "Warning: Transactions before the start block of synchronization will not be synchronized",
       "tip": "The start sync block number is configuration when use light client ckb node, then you can set it and quick the sync",
       "input-place-holder": "Please enter the start sync block number, eg: 10,100,101",
       "locate-first-tx": "Locate the first transaction",
-      "view-block": "View the block"
+      "view-block": "View the block",
+      "set-less-than-before": "The block number you set is smaller than the previous set, the synchronization will restart, please proceed with caution.",
+      "reset-to-header-tip-number": "Unable to set a block number greater than the header tip block number, reset to the header tip block number."
     },
     "main": {
       "external-node-detected-dialog": {

--- a/packages/neuron-ui/src/locales/fr.json
+++ b/packages/neuron-ui/src/locales/fr.json
@@ -31,6 +31,7 @@
       "tooltip": {
         "block-synced": "Bloc synchronisé",
         "looking-valid-target": "Recherche de la cible valide présumée",
+        "start-block-number": "bloc de départ",
         "set-start-block-number": "Définir le numéro de bloc de départ"
       },
       "migrating": "migration en cours..."
@@ -1124,10 +1125,13 @@
     },
     "set-start-block-number": {
       "title": "Définir le numéro de bloc de départ",
+      "warn": "Veuillez noter que les transactions antérieures à la synchronisation du bloc initial ne seront pas synchronisées !",
       "tip": "Le numéro de bloc de départ est une configuration lorsque vous utilisez le noeud CKB en mode client léger. Vous pouvez le définir et accélérer la synchronisation.",
       "input-place-holder": "Veuillez entrer le numéro de bloc de départ pour la synchronisation, par exemple : 10, 100, 101",
       "locate-first-tx": "Localiser la première transaction",
-      "view-block": "Voir le bloc"
+      "view-block": "Voir le bloc",
+      "set-less-than-before": "Le numéro de bloc que vous avez défini est inférieur au bloc précédent. La synchronisation recommencera, veuillez procéder avec prudence.",
+      "reset-to-header-tip-number": "Impossible de définir un numéro de bloc supérieur au bloc le plus récent. Réinitialisation au numéro de bloc le plus récent."
     },
     "main": {
       "external-node-detected-dialog": {

--- a/packages/neuron-ui/src/locales/zh-tw.json
+++ b/packages/neuron-ui/src/locales/zh-tw.json
@@ -31,6 +31,7 @@
       "tooltip": {
         "block-synced": "已同步區塊",
         "looking-valid-target": "尋找預設可信區塊",
+        "start-block-number": "起始區塊",
         "set-start-block-number": "設置同步起始區塊"
       },
       "migrating": "正在數據遷移..."
@@ -1095,10 +1096,13 @@
     },
     "set-start-block-number": {
       "title": "設置同步起始區塊",
+      "warn": "請註意，同步起始區塊之前的交易不會被同步！",
       "tip": "輕客戶端模式下的訂閱起始點是可配置的，因此您可以設置同步起始區塊以加快同步速度。",
       "input-place-holder": "輸入同步起始區塊高度，例如：10,100,101",
       "locate-first-tx": "定位第一筆交易",
-      "view-block": "查看區塊"
+      "view-block": "查看區塊",
+      "set-less-than-before": "您設置的區塊號小於之前區塊，同步將重新開始，請謹慎操作。",
+      "reset-to-header-tip-number": "無法設置比最新區塊更大的區塊號，已重置為最新區塊號。"
     },
     "main": {
       "external-node-detected-dialog": {

--- a/packages/neuron-ui/src/locales/zh.json
+++ b/packages/neuron-ui/src/locales/zh.json
@@ -31,6 +31,7 @@
       "tooltip": {
         "block-synced": "已同步区块",
         "looking-valid-target": "寻找预设可信区块",
+        "start-block-number": "起始区块",
         "set-start-block-number": "设置同步起始区块"
       },
       "migrating": "正在数据迁移..."
@@ -1116,10 +1117,13 @@
     },
     "set-start-block-number": {
       "title": "设置同步起始区块",
+      "warn": "请注意，同步起始区块之前的交易不会被同步！",
       "tip": "轻客户端模式下的订阅起始点是可配置的，因此您可以设置同步起始区块以加快同步速度。",
       "input-place-holder": "输入同步起始区块高度，例如：10,100,101",
       "locate-first-tx": "定位第一笔交易",
-      "view-block": "查看区块"
+      "view-block": "查看区块",
+      "set-less-than-before": "您设置的区块号小于之前的设定，同步将重新开始，请谨慎操作。",
+      "reset-to-header-tip-number": "无法设置比最新区块更大的区块号，已重置为最新区块号。"
     },
     "main": {
       "external-node-detected-dialog": {

--- a/packages/neuron-ui/src/services/remote/remoteApiWrapper.ts
+++ b/packages/neuron-ui/src/services/remote/remoteApiWrapper.ts
@@ -60,6 +60,7 @@ type Action =
   | 'update-wallet'
   | 'delete-wallet'
   | 'backup-wallet'
+  | 'update-wallet-start-block-number'
   | 'get-all-addresses'
   | 'update-address-description'
   | 'request-password'

--- a/packages/neuron-ui/src/services/remote/wallets.ts
+++ b/packages/neuron-ui/src/services/remote/wallets.ts
@@ -9,6 +9,9 @@ export const createWallet = remoteApi<Controller.CreateWalletParams>('create-wal
 export const updateWallet = remoteApi<Controller.UpdateWalletParams>('update-wallet')
 export const deleteWallet = remoteApi<Controller.DeleteWalletParams>('delete-wallet')
 export const backupWallet = remoteApi<Controller.DeleteWalletParams>('backup-wallet')
+export const updateWalletStartBlockNumber = remoteApi<Controller.UpdateWalletStartBlockNumberParams>(
+  'update-wallet-start-block-number'
+)
 export const getAddressesByWalletID = remoteApi<Controller.GetAddressesByWalletIDParams>('get-all-addresses')
 export const updateAddressDescription =
   remoteApi<Controller.UpdateAddressDescriptionParams>('update-address-description')

--- a/packages/neuron-ui/src/types/App/index.d.ts
+++ b/packages/neuron-ui/src/types/App/index.d.ts
@@ -202,6 +202,7 @@ declare namespace State {
     device?: DeviceInfo
     isHD?: boolean
     isWatchOnly?: boolean
+    startBlockNumber?: string
   }
 
   interface DeviceInfo {

--- a/packages/neuron-ui/src/types/Controller/index.d.ts
+++ b/packages/neuron-ui/src/types/Controller/index.d.ts
@@ -35,7 +35,11 @@ declare namespace Controller {
     newPassword?: string
     name?: string
     device?: any
-    startBlockNumber?: string
+  }
+
+  interface UpdateWalletStartBlockNumberParams {
+    id: string
+    startBlockNumber: string
   }
 
   interface RequestPasswordParams {


### PR DESCRIPTION
Refer to https://github.com/Magickbase/neuron-public-issues/issues/304.
1. Show the last setted start block number
<img width="217" alt="image" src="https://github.com/nervosnetwork/neuron/assets/12881040/c1a54a58-7931-46c0-9ced-761779e32e34">

2. If the current set start block number is less than before

<img width="694" alt="image" src="https://github.com/nervosnetwork/neuron/assets/12881040/c4f3d4f9-34a9-4bc7-993b-7d7eb3c1f83d">

3. If the current set start block number is bigger than the header tip block number

<img width="699" alt="image" src="https://github.com/nervosnetwork/neuron/assets/12881040/be042cf7-764e-4283-8b97-420ece881898">
