### PR TITLE
fix: Pop up window can be rolled when error message is long

### DIFF
--- a/packages/neuron-ui/src/widgets/AlertDialog/alertDialog.module.scss
+++ b/packages/neuron-ui/src/widgets/AlertDialog/alertDialog.module.scss
@@ -23,7 +23,9 @@
     line-height: 28px;
     margin: 0;
     color: var(--dialog-secondary-text-color);
-    word-break: break-word;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
   }
 
   .actions {


### PR DESCRIPTION
fix issue: https://github.com/Magickbase/neuron-public-issues/issues/337

<img width="1428" alt="image" src="https://github.com/nervosnetwork/neuron/assets/11756869/3bd9155f-1aa9-4db9-bb13-90a7625c55f0">
