### PR TITLE
fix: Remove walletId for `get-multisig-config` API

### DIFF
--- a/packages/neuron-ui/src/components/MultisigAddress/hooks.ts
+++ b/packages/neuron-ui/src/components/MultisigAddress/hooks.ts
@@ -73,12 +73,12 @@ export const useConfigManage = ({ walletId, isMainnet }: { walletId: string; isM
     [walletId, setEntities]
   )
   useEffect(() => {
-    getMultisigConfig(walletId).then(res => {
+    getMultisigConfig().then(res => {
       if (isSuccessResponse(res) && res.result) {
         setEntities(res.result)
       }
     })
-  }, [setEntities, walletId])
+  }, [setEntities])
   const updateConfig = useCallback(
     (id: number) => (e: React.SyntheticEvent<unknown>) => {
       const { value } = e.target as HTMLInputElement

--- a/packages/neuron-ui/src/components/MultisigAddress/index.tsx
+++ b/packages/neuron-ui/src/components/MultisigAddress/index.tsx
@@ -28,10 +28,12 @@ import { ReactComponent as Edit } from 'widgets/Icons/Edit.svg'
 import { Download, Search } from 'widgets/Icons/icon'
 import { HIDE_BALANCE, NetworkType } from 'utils/const'
 import { onEnter } from 'utils/inputDevice'
+import getMultisigSignStatus from 'utils/getMultisigSignStatus'
 import { useSearch, useConfigManage, useExportConfig, useActions, useSubscription } from './hooks'
 
 import styles from './multisigAddress.module.scss'
 
+const ApproveKey = 'approve'
 const tableActions = [
   {
     key: 'info',
@@ -46,7 +48,7 @@ const tableActions = [
     icon: <Transfer />,
   },
   {
-    key: 'approve',
+    key: ApproveKey,
     icon: <Confirm />,
   },
 ]
@@ -56,7 +58,7 @@ const MultisigAddress = () => {
   useOnLocaleChange(i18n)
   useExitOnWalletChange()
   const {
-    wallet: { id: walletId },
+    wallet: { id: walletId, addresses },
     chain: { networkID },
     settings: { networks = [] },
   } = useGlobalState()
@@ -281,6 +283,7 @@ const MultisigAddress = () => {
                   dataIndex: 'action',
                   align: 'left',
                   render(_, __, item) {
+                    const { canSign } = getMultisigSignStatus({ multisigConfig: item, addresses })
                     return (
                       <div className={styles.action}>
                         <Tooltip
@@ -296,7 +299,7 @@ const MultisigAddress = () => {
                                   key={key}
                                   data-key={key}
                                   onClick={onClickItem(item)}
-                                  disabled={disabled}
+                                  disabled={key === ApproveKey ? !canSign || disabled : disabled}
                                 >
                                   {icon}
                                   <span>{t(label)}</span>

--- a/packages/neuron-ui/src/services/remote/multisig.ts
+++ b/packages/neuron-ui/src/services/remote/multisig.ts
@@ -29,7 +29,7 @@ export type MultisigConfig = MultisigEntity & {
 }
 
 export const saveMultisigConfig = remoteApi<PartialSome<MultisigEntity, 'id'>, MultisigEntity>('save-multisig-config')
-export const getMultisigConfig = remoteApi<string, MultisigEntity[]>('get-multisig-config')
+export const getMultisigConfig = remoteApi<void, MultisigEntity[]>('get-multisig-config')
 export const importMultisigConfig = remoteApi<string, MultisigConfig[]>('import-multisig-config')
 export const exportMultisigConfig = remoteApi<MultisigConfig[]>('export-multisig-config')
 export const updateMultisigConfig = remoteApi<RequiredSome<Partial<MultisigEntity>, 'id'>, MultisigEntity>(

--- a/packages/neuron-wallet/src/controllers/api.ts
+++ b/packages/neuron-wallet/src/controllers/api.ts
@@ -796,8 +796,8 @@ export default class ApiController {
       return this.#multisigController.deleteConfig(params)
     })
 
-    handle('get-multisig-config', async (_, walletId: string) => {
-      return this.#multisigController.getConfig(walletId)
+    handle('get-multisig-config', async () => {
+      return this.#multisigController.getConfig()
     })
 
     handle('import-multisig-config', async (_, walletId: string) => {

--- a/packages/neuron-wallet/src/controllers/multisig.ts
+++ b/packages/neuron-wallet/src/controllers/multisig.ts
@@ -79,8 +79,8 @@ export default class MultisigController {
     }
   }
 
-  async getConfig(walletId: string) {
-    const result = await this.#multisigService.getMultisigConfig(walletId)
+  async getConfig() {
+    const result = await this.#multisigService.getMultisigConfig()
     return {
       status: ResponseCode.Success,
       result,

--- a/packages/neuron-wallet/src/services/multisig.ts
+++ b/packages/neuron-wallet/src/services/multisig.ts
@@ -11,7 +11,6 @@ import NetworksService from './networks'
 import Multisig from '../models/multisig'
 import SyncProgress, { SyncAddressType } from '../database/chain/entities/sync-progress'
 import { NetworkType } from '../models/network'
-import WalletService from './wallets'
 import logger from '../utils/logger'
 
 const max64Int = '0x' + 'f'.repeat(16)
@@ -21,7 +20,6 @@ export default class MultisigService {
       .getRepository(MultisigConfig)
       .createQueryBuilder()
       .where({
-        walletId: multisigConfig.walletId,
         r: multisigConfig.r,
         m: multisigConfig.m,
         n: multisigConfig.n,
@@ -69,13 +67,10 @@ export default class MultisigService {
     return { ...result, ...params }
   }
 
-  async getMultisigConfig(walletId: string) {
+  async getMultisigConfig() {
     const result = await getConnection()
       .getRepository(MultisigConfig)
       .createQueryBuilder()
-      .where({
-        walletId,
-      })
       .orderBy('id', 'DESC')
       .getMany()
     return result
@@ -340,14 +335,7 @@ export default class MultisigService {
   }
 
   static async getMultisigConfigForLight() {
-    const currentWallet = WalletService.getInstance().getCurrent()
-    const multisigConfigs = await getConnection()
-      .getRepository(MultisigConfig)
-      .createQueryBuilder()
-      .where({
-        walletId: currentWallet?.id,
-      })
-      .getMany()
+    const multisigConfigs = await getConnection().getRepository(MultisigConfig).createQueryBuilder().getMany()
     return multisigConfigs.map(v => ({
       walletId: v.walletId,
       script: Multisig.getMultisigScript(v.blake160s, v.r, v.m, v.n),

--- a/packages/neuron-wallet/src/services/sync-progress.ts
+++ b/packages/neuron-wallet/src/services/sync-progress.ts
@@ -27,13 +27,13 @@ export default class SyncProgressService {
       .createQueryBuilder()
       .update(SyncProgress)
       .set({ delete: true })
-      .where({ walletId: Not(In(existWalletIds)) })
+      .where({ walletId: Not(In(existWalletIds)), addressType: SyncAddressType.Default })
       .execute()
     await getConnection()
       .createQueryBuilder()
       .update(SyncProgress)
       .set({ delete: false })
-      .where({ walletId: In(existWalletIds) })
+      .where({ walletId: In(existWalletIds), addressType: SyncAddressType.Default })
       .execute()
   }
 

--- a/packages/neuron-wallet/tests/controllers/multisig.test.ts
+++ b/packages/neuron-wallet/tests/controllers/multisig.test.ts
@@ -160,8 +160,8 @@ describe('test for multisig controller', () => {
   })
 
   it('get config', async () => {
-    await multisigController.getConfig('abcd')
-    expect(MultiSigServiceMock.prototype.getMultisigConfig).toHaveBeenCalledWith('abcd')
+    await multisigController.getConfig()
+    expect(MultiSigServiceMock.prototype.getMultisigConfig).toHaveBeenCalledWith()
   })
 
   describe('import config', () => {

--- a/packages/neuron-wallet/tests/services/multisig.test.ts
+++ b/packages/neuron-wallet/tests/services/multisig.test.ts
@@ -87,8 +87,10 @@ describe('multisig service', () => {
       await expect(multisigService.saveMultisigConfig(defaultMultisigConfig)).rejects.toThrow()
     })
     it('save success', async () => {
-      defaultMultisigConfig.walletId = 'walletId1'
-      const res = await multisigService.saveMultisigConfig(defaultMultisigConfig)
+      const anotherConfig = MultisigConfig.fromModel(multisigConfigModel)
+      anotherConfig.lastestBlockNumber = '0x0'
+      anotherConfig.r = 2
+      const res = await multisigService.saveMultisigConfig(anotherConfig)
       const count = await getConnection()
         .getRepository(MultisigConfig)
         .createQueryBuilder()
@@ -97,7 +99,6 @@ describe('multisig service', () => {
         })
         .getCount()
       expect(count).toBe(1)
-      defaultMultisigConfig.walletId = 'walletId'
     })
   })
 
@@ -127,12 +128,8 @@ describe('multisig service', () => {
   })
 
   describe('test get config', () => {
-    it('no config', async () => {
-      const configs = await multisigService.getMultisigConfig('noconfigwallet')
-      expect(configs).toHaveLength(0)
-    })
     it('has config wallet', async () => {
-      const configs = await multisigService.getMultisigConfig(multisigConfigModel.walletId)
+      const configs = await multisigService.getMultisigConfig()
       expect(configs).toHaveLength(1)
     })
   })


### PR DESCRIPTION
Refer to https://github.com/Magickbase/neuron-public-issues/issues/348
1. Remove `walletId` for `get-multisig-config` API
2. Disabled `Approve` button when the current wallet can not sign for the multisig config.

https://github.com/nervosnetwork/neuron/assets/12881040/32906371-9c4e-4421-951f-2edfe9fd372f

