### PR TITLE
fix: When address is not enough, stop update localSavedBlockNumber

### DIFF
--- a/packages/neuron-wallet/src/block-sync-renderer/index.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/index.ts
@@ -64,7 +64,7 @@ export const resetSyncTask = async (startTask = true) => {
 
   if (startTask) {
     await WalletService.getInstance().maintainAddressesIfNecessary()
-    await TransactionPersistor.checkTxLock()
+    await CommonUtils.retry(3, 5000, TransactionPersistor.checkTxLock)
     await CommonUtils.sleep(3000)
     await createBlockSyncTask()
   }

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/light-synchronizer.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/light-synchronizer.ts
@@ -267,6 +267,10 @@ export default class LightSynchronizer extends Synchronizer {
   }
 
   private async updateBlockStartNumber(blockNumber: number) {
+    if (this._needGenerateAddress || !this.pollingIndexer) {
+      logger.info('LightConnector:\twait for generating address')
+      return
+    }
     const scripts = await this.lightRpc.getScripts()
     await SyncProgressService.updateBlockNumber(
       scripts.map(v => v.script.args),

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/queue.ts
@@ -22,6 +22,7 @@ import LightSynchronizer from './light-synchronizer'
 import { generateRPC } from '../../utils/ckb-rpc'
 import { BUNDLED_LIGHT_CKB_URL } from '../../utils/const'
 import { NetworkType } from '../../models/network'
+import WalletService from '../../services/wallets'
 
 export default class Queue {
   #lockHashes: string[]
@@ -254,6 +255,9 @@ export default class Queue {
         .map(addr => addr.walletId)
     )
     if (process.send) {
+      this.#indexerConnector!.needGenerateAddress = await WalletService.getInstance().checkNeedGenerateAddress([
+        ...walletIds,
+      ])
       process.send({ channel: 'check-and-save-wallet-address', message: [...walletIds] })
     } else {
       throw new ShouldInChildProcess()

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/synchronizer.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/synchronizer.ts
@@ -58,6 +58,7 @@ export abstract class Synchronizer {
   protected addressesByWalletId: Map<string, AddressMeta[]> = new Map()
   protected pollingIndexer: boolean = false
   private indexerQueryQueue: QueueObject<LumosCellQuery> | undefined
+  protected _needGenerateAddress: boolean = false
 
   abstract connect(): Promise<void>
   abstract processTxsInNextBlockNumber(): Promise<void>
@@ -94,6 +95,10 @@ export abstract class Synchronizer {
 
   public stop(): void {
     this.pollingIndexer = false
+  }
+
+  public set needGenerateAddress(v: boolean) {
+    this._needGenerateAddress = v
   }
 
   protected async processNextBlockNumber() {

--- a/packages/neuron-wallet/tests/block-sync-renderer/index/resetSyncTask.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-renderer/index/resetSyncTask.test.ts
@@ -5,7 +5,11 @@ describe(`Reset sync task`, () => {
   jest.doMock('services/wallets', () => ({
     getInstance: () => ({ maintainAddressesIfNecessary: stubbedmaintainAddressesIfNecessary }),
   }))
-  jest.doMock('utils/common', () => ({ sleep: stubbedSleep, timeout: stubbedTimeout }))
+  jest.doMock('utils/common', () => ({
+    sleep: stubbedSleep,
+    timeout: stubbedTimeout,
+    retry: (_: number, __: number, fn: () => void) => fn(),
+  }))
   jest.doMock('services/tx', () => ({ TransactionPersistor: { checkTxLock: jest.fn() } }))
 
   const blockSyncRenderer = require('block-sync-renderer')

--- a/packages/neuron-wallet/tests/block-sync-renderer/queue.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-renderer/queue.test.ts
@@ -183,6 +183,15 @@ describe('queue', () => {
         },
       }
     })
+    jest.doMock('../../src/services/wallets', () => {
+      return {
+        getInstance() {
+          return {
+            checkNeedGenerateAddress: jest.fn(),
+          }
+        },
+      }
+    })
     const Queue = require('../../src/block-sync-renderer/sync/queue').default
     queue = new Queue(fakeNodeUrl, addresses)
   })


### PR DESCRIPTION
This is an issue from [`discord`](https://discord.com/channels/956765352514183188/1084671124211769364/1212615721897689088)

The reason is the generated address and sync process are not synchronized. So when there is not enough address, the sync process will stop saving `localSavedBlockNumber`. Then after the new address is derived, it will start syncing from the right block number.