### PR TITLE
ci: specify environments in some workflows

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,6 +20,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    environment: Release
+
     name: ${{ matrix.os }}(Node.js ${{ matrix.node }})
 
     steps:

--- a/.github/workflows/update_ckb_client_versions.yml
+++ b/.github/workflows/update_ckb_client_versions.yml
@@ -8,6 +8,7 @@ jobs:
   default:
     name: Update CKB client versions
     runs-on: ubuntu-latest
+    environment: neuron-bot
     permissions:
       pull-requests: write # open PR
       contents: write # update version files

--- a/.github/workflows/update_neuron_compatible.yml
+++ b/.github/workflows/update_neuron_compatible.yml
@@ -11,6 +11,7 @@ jobs:
   update-neuron-compatible:
     name: Update Neuron compatibility table
     runs-on: ubuntu-latest
+    environment: neuron-bot
     permissions:
       pull-requests: write # open PR
       contents: write # update version files


### PR DESCRIPTION
Secrets are defined in specific environment to be protected by
rules, so the environment should be specified in workflow to
load secrets correspondingly.

Ref: https://github.com/Magickbase/neuron-public-issues/issues/364