### PR TITLE
fix: no translation of language options

### DIFF
--- a/packages/neuron-ui/src/locales/es.json
+++ b/packages/neuron-ui/src/locales/es.json
@@ -422,11 +422,11 @@
         "switch-network-type": "Cambiar a {{type}}"
       },
       "locale": {
-        "en": "Inglés",
-        "en-US": "Inglés(Estados Unidos)",
+        "en": "English",
+        "en-US": "English(United States)",
         "zh": "中文(简体)",
         "zh-TW": "中文(繁體)",
-        "fr": "Francés",
+        "fr": "Français",
         "es": "Español"
       },
       "data": {

--- a/packages/neuron-ui/src/locales/fr.json
+++ b/packages/neuron-ui/src/locales/fr.json
@@ -429,8 +429,8 @@
         "switch-network-type": "Basculer vers {{type}}"
       },
       "locale": {
-        "en": "Anglais",
-        "en-US": "Anglais (États-Unis)",
+        "en": "English",
+        "en-US": "English(United States)",
         "zh": "中文(简体)",
         "zh-TW": "中文(繁體)",
         "fr": "Français",


### PR DESCRIPTION
So target language option can be recognized by the target language label