### PR TITLE
fix: If node is connecting, show '--' for confirmation

### DIFF
--- a/packages/neuron-ui/src/components/History/RowExtend.tsx
+++ b/packages/neuron-ui/src/components/History/RowExtend.tsx
@@ -61,8 +61,10 @@ const RowExtend = ({ column, columns, isMainnet, id, bestBlockNumber }: RowExten
   )
 
   const { blockNumber, hash, description, status } = column
-  const confirmations = blockNumber ? 1 + bestBlockNumber - +blockNumber : 0
-  const confirmationsLabel = confirmations > 1000 ? '1,000+' : localNumberFormatter(confirmations)
+  const confirmations = bestBlockNumber && blockNumber ? 1 + bestBlockNumber - +blockNumber : null
+  const confirmationsLabel =
+    // eslint-disable-next-line no-nested-ternary
+    confirmations === null ? '--' : confirmations > 1000 ? '1,000+' : localNumberFormatter(confirmations)
   const onCopy = useCallback(() => {
     window.navigator.clipboard.writeText(hash)
     showPageNotice('common.copied')(dispatch)


### PR DESCRIPTION
Before network connect
<img width="978" alt="image" src="https://github.com/nervosnetwork/neuron/assets/12881040/c9eae051-befe-412a-8b0b-1c7361ff1485">

After network connect
<img width="1013" alt="image" src="https://github.com/nervosnetwork/neuron/assets/12881040/a23f43f2-8e49-48bf-9307-4d82192fde62">
