### PR TITLE
fix: The first sync only stuck full ckb node start.

### DIFF
--- a/packages/neuron-wallet/src/services/node.ts
+++ b/packages/neuron-wallet/src/services/node.ts
@@ -136,7 +136,8 @@ class NodeService {
     await stopMonitor('ckb')
     const isDefaultCKBNeedStart = await this.isDefaultCKBNeedRestart()
     if (isDefaultCKBNeedStart) {
-      if (SettingsService.getInstance().isFirstSync) {
+      const currentNetwork = NetworksService.getInstance().getCurrent()
+      if (SettingsService.getInstance().isFirstSync && currentNetwork.type === NetworkType.Default) {
         logger.info("CKB:\tThis is the first sync, please wait for the user's confirmation")
         return
       }

--- a/packages/neuron-wallet/tests/services/node.test.ts
+++ b/packages/neuron-wallet/tests/services/node.test.ts
@@ -571,7 +571,7 @@ describe('NodeService', () => {
   describe('test start default node', () => {
     beforeEach(() => {
       const NodeService = require('../../src/services/node').default
-      stubbedNetworsServiceGet.mockReturnValue({ remote: BUNDLED_CKB_URL, readonly: true })
+      stubbedNetworsServiceGet.mockReturnValue({ remote: BUNDLED_CKB_URL, readonly: true, type: 0 })
       getLocalNodeInfoMock.mockRejectedValue('not start')
       nodeService = new NodeService()
     })


### PR DESCRIPTION
Because the first sync dialog only shows when the network is the default full ckb node, the sync will stuck and wait for the user to confirm when the first sync and the select network is the default mainnet