### PR TITLE
fix: Add react-refresh@0.14.0 to resolutions in root package.json (#3108)

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
   "dependencies": {},
   "resolutions": {
     "@types/react": "18.2.45",
-    "react-i18next": ">=11.16.4"
+    "react-i18next": ">=11.16.4",
+    "react-refresh": "0.14.0"
   },
   "volta": {
     "node": "20.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17127,12 +17127,7 @@ react-is@^17.0.0, react-is@^17.0.1, react-is@^17.0.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-refresh@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
-  integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
-
-react-refresh@^0.14.0:
+react-refresh@0.14.0, react-refresh@^0.11.0, react-refresh@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
   integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==


### PR DESCRIPTION
Fix https://github.com/nervosnetwork/neuron/issues/3108 by adding `"react-refresh": "0.14.0"` in `resolutions` in root `package.json`