### PR TITLE
refactor: rewrite shannonToCKB with lumos formatUnit

### DIFF
--- a/packages/neuron-wallet/src/utils/shannonToCKB.ts
+++ b/packages/neuron-wallet/src/utils/shannonToCKB.ts
@@ -1,18 +1,12 @@
-const DECIMAL = 8
+import { formatUnit, ckbDecimals } from '@ckb-lumos/bi'
 
 const shannonToCKB = (shannon: bigint) => {
-  if (shannon === BigInt(0)) {
-    return `+0.${'0'.repeat(DECIMAL)}`
-  }
-
-  const isNegative = shannon < 0
-  const absStr = isNegative ? `${shannon}`.slice(1) : `${shannon}`
-  if (absStr.length <= DECIMAL) {
-    return `${isNegative ? '-' : '+'}0.${absStr.padStart(DECIMAL, '0')}`
-  }
-  const int = absStr.slice(0, -1 * DECIMAL)
-  const dec = absStr.slice(-1 * DECIMAL)
-  return `${isNegative ? '-' : '+'}${int}.${dec}`
+  return new Intl.NumberFormat('en-US', {
+    useGrouping: false,
+    signDisplay: 'always',
+    minimumFractionDigits: ckbDecimals,
+    maximumFractionDigits: ckbDecimals,
+  }).format(formatUnit(shannon, 'ckb') as any)
 }
 
 export default shannonToCKB

--- a/packages/neuron-wallet/src/utils/to-csv-row.ts
+++ b/packages/neuron-wallet/src/utils/to-csv-row.ts
@@ -41,7 +41,7 @@ const toCSVRow = (
       txType = +tx.sudtInfo.amount <= 0 ? `UDT ${SEND_TYPE}` : `UDT ${RECEIVE_TYPE}`
     }
   } else {
-    amount = shannonToCKB(BigInt(tx.value ?? ''))
+    amount = shannonToCKB(BigInt(tx.value ?? '0'))
     if (tx.nervosDao) {
       txType = `Nervos DAO`
     } else if (['create', 'destroy'].includes(tx.type || '')) {


### PR DESCRIPTION
After the discussion in https://github.com/nervosnetwork/neuron/pull/3111, I realized that we just need to rewrite `shannonToCKB` with `formatUnit`.