### PR TITLE
refactor: rewrite sudtValueToAmount with formatUnit in neuron-wallet

### DIFF
--- a/packages/neuron-wallet/src/utils/sudt-value-to-amount.ts
+++ b/packages/neuron-wallet/src/utils/sudt-value-to-amount.ts
@@ -1,32 +1,11 @@
-const sudtValueToAmount = (value: string | null | undefined = '0', decimal: string | null | undefined = '') => {
-  if (value === null || value === '0') {
-    return '+0'
-  }
+import { formatUnit } from '@ckb-lumos/bi'
 
-  if (decimal === null || decimal === undefined || Number.isNaN(+value)) {
-    return '--'
-  }
-
-  let sign = '+'
-  if (value.startsWith('-')) {
-    sign = '-'
-  }
-
-  const unsignedValue = value.replace(/^-?0*/, '')
-
-  const dec = +decimal
-  if (dec === 0) {
-    return +unsignedValue ? `${sign}${unsignedValue}` : '+0'
-  }
-  let unsignedSUDTValue = ''
-  if (unsignedValue.length <= dec) {
-    unsignedSUDTValue = `0.${unsignedValue.padStart(dec, '0')}`.replace(/\.?0+$/, '')
-  } else {
-    const decimalFraction = `.${unsignedValue.slice(-dec)}`.replace(/\.?0+$/, '')
-    const int = unsignedValue.slice(0, -dec).replace(/\^0+/, '')
-    unsignedSUDTValue = `${int}${decimalFraction}`
-  }
-  return `${sign}${unsignedSUDTValue}`
+const sudtValueToAmount = (value: string | null = '0', decimal: string | null = '') => {
+  return value === null || value === '0'
+    ? '+0'
+    : decimal === null || Number.isNaN(+value) || Number.isNaN(+decimal)
+    ? '--'
+    : `${+value >= 0 ? '+' : ''}${formatUnit(BigInt(value), +decimal)}`
 }
 
 export default sudtValueToAmount

--- a/packages/neuron-wallet/tests/utils/sudt-value-to-amount/fixtures.json
+++ b/packages/neuron-wallet/tests/utils/sudt-value-to-amount/fixtures.json
@@ -14,9 +14,19 @@
     "decimal": "12",
     "expected": "+0"
   },
+  "null value and null decimal": {
+    "value": null,
+    "decimal": null,
+    "expected": "+0"
+  },
   "zero value": {
     "value": "0",
     "decimal": "1",
+    "expected": "+0"
+  },
+  "zero value and null decimal": {
+    "value": "0",
+    "decimal": null,
     "expected": "+0"
   },
   "negative value": {


### PR DESCRIPTION
Refactor and add two test cases. Verified.
<img width="1239" alt="image" src="https://github.com/nervosnetwork/neuron/assets/7459812/5168d571-00d5-4459-9e62-b0cc20946f79">
