### PR TITLE
fix: If all of the previous Tx hashes are cell base, skip fetch tx.

### DIFF
--- a/packages/neuron-wallet/src/block-sync-renderer/sync/light-synchronizer.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/light-synchronizer.ts
@@ -262,6 +262,7 @@ export default class LightSynchronizer extends Synchronizer {
           previousTxHashes.add(previousTxHash)
         }
       })
+    if (!previousTxHashes.size) return
     await this.lightRpc.createBatchRequest([...previousTxHashes].map(v => ['fetchTransaction' as keyof Base, v])).exec()
   }
 


### PR DESCRIPTION
If calling `createBatchRequest` with an empty array, will throw the error `Rpc(JsonRpcError(Error { code: MethodNotFound, message: "Method not found", data: None }))`