### PR TITLE
build(ci): upgrade Electron to v30, ci Node to v20.11.1

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         node:
-          - 18.12.0
+          - 20.11.1
         os:
           - macos-latest
           - ubuntu-20.04

--- a/packages/neuron-ui/package.json
+++ b/packages/neuron-ui/package.json
@@ -91,7 +91,7 @@
     "@types/styled-components": "5.1.34",
     "@wojtekmaj/enzyme-adapter-react-17": "0.8.0",
     "babel-jest": "25.5.1",
-    "electron": "28.1.0",
+    "electron": "30.0.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.7",
     "eslint-config-airbnb": "19.0.4",

--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -93,7 +93,7 @@
     "@types/sqlite3": "3.1.11",
     "@types/uuid": "8.3.4",
     "devtron": "1.4.0",
-    "electron": "28.1.0",
+    "electron": "30.0.0",
     "electron-builder": "24.9.1",
     "electron-devtools-installer": "3.2.0",
     "jest-when": "3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5704,10 +5704,12 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^18.11.18":
-  version "18.16.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.18.tgz#85da09bafb66d4bc14f7c899185336d0c1736390"
-  integrity sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw==
+"@types/node@^20.9.0":
+  version "20.12.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.7.tgz#04080362fa3dd6c5822061aa3124f5c152cff384"
+  integrity sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -9639,13 +9641,13 @@ electron-window-state@5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@28.1.0:
-  version "28.1.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-28.1.0.tgz#9de1ecdaafcb0ec5753827f14dfb199e6c84545e"
-  integrity sha512-82Y7o4PSWPn1o/aVwYPsgmBw6Gyf2lVHpaBu3Ef8LrLWXxytg7ZRZr/RtDqEMOzQp3+mcuy3huH84MyjdmP50Q==
+electron@30.0.0:
+  version "30.0.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-30.0.0.tgz#6b72a27dcc46759fac5f12e147ef64554e596391"
+  integrity sha512-GRwKphq/TUhSlb44OwSckXKl50f5OR/pm9MvF3rBLyqcxwfu7L11xejrZ0hDea1eKyCkzGd4B+cIqaQiDguPEA==
   dependencies:
     "@electron/get" "^2.0.0"
-    "@types/node" "^18.11.18"
+    "@types/node" "^20.9.0"
     extract-zip "^2.0.1"
 
 elliptic@6.5.4, elliptic@^6.5.4:


### PR DESCRIPTION
Electron 30: Chromium 124.0.6367.49, Node 20.11.1, V8 12.4

Update CI Node to v20.11.1 to match with Electron v30's Node version.

We are not using features mentioned in Breaking Changes.
https://releases.electronjs.org/release/v30.0.0

This upgrade fixes the `Intl.NumberFormat.prototype.format()` issue metioned in [#3219](https://github.com/nervosnetwork/neuron/pull/3129)