### PR TITLE
Fix light sync

### DIFF
--- a/packages/neuron-wallet/src/block-sync-renderer/sync/light-synchronizer.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/light-synchronizer.ts
@@ -175,9 +175,11 @@ export default class LightSynchronizer extends Synchronizer {
     if (!this.addressMetas.length && !appendScripts.length) {
       return
     }
+    const existSyncArgses = await SyncProgressService.getExistingSyncArgses()
     const syncScripts = await this.lightRpc.getScripts()
+    const retainedSyncScripts = syncScripts.filter(v => existSyncArgses.has(v.script.args))
     const existSyncscripts: Record<string, LightScriptFilter> = {}
-    syncScripts.forEach(v => {
+    retainedSyncScripts.forEach(v => {
       existSyncscripts[scriptToHash(v.script)] = v
     })
     const currentWalletId = WalletService.getInstance().getCurrent()?.id
@@ -228,7 +230,7 @@ export default class LightSynchronizer extends Synchronizer {
       ...allScripts.map(v => scriptToHash(v.script)),
       ...appendScripts.map(v => scriptToHash(v.script)),
     ])
-    const deleteScript = syncScripts.filter(v => !allScriptHashes.has(scriptToHash(v.script)))
+    const deleteScript = retainedSyncScripts.filter(v => !allScriptHashes.has(scriptToHash(v.script)))
     await this.lightRpc.setScripts(deleteScript, 'delete')
     const walletIds = [...new Set(this.addressMetas.map(v => v.walletId))]
     await SyncProgressService.initSyncProgress(addScripts)

--- a/packages/neuron-wallet/src/block-sync-renderer/sync/light-synchronizer.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/light-synchronizer.ts
@@ -207,7 +207,11 @@ export default class LightSynchronizer extends Synchronizer {
     const otherTypeSyncBlockNumber = await SyncProgressService.getOtherTypeSyncBlockNumber()
     const addScripts = [
       ...allScripts
-        .filter(v => !existSyncscripts[scriptToHash(v.script)])
+        .filter(
+          v =>
+            !existSyncscripts[scriptToHash(v.script)] ||
+            +existSyncscripts[scriptToHash(v.script)].blockNumber < +(walletStartBlockMap[v.walletId] ?? 0)
+        )
         .map(v => {
           const blockNumber = Math.max(
             parseInt(walletStartBlockMap[v.walletId] ?? '0x0'),

--- a/packages/neuron-wallet/src/services/sync-progress.ts
+++ b/packages/neuron-wallet/src/services/sync-progress.ts
@@ -68,6 +68,11 @@ export default class SyncProgressService {
     return res
   }
 
+  static async getExistingSyncArgses() {
+    const syncProgresses = await getConnection().getRepository(SyncProgress).createQueryBuilder().getMany()
+    return new Set(syncProgresses.map(v => v.args))
+  }
+
   static async getAllSyncStatusToMap() {
     const result: Map<CKBComponents.Hash, SyncProgress> = new Map()
     const syncProgresses = await getConnection()
@@ -131,5 +136,12 @@ export default class SyncProgressService {
       .update(SyncProgress)
       .set({ localSavedBlockNumber: 0, syncedBlockNumber: 0 })
       .execute()
+  }
+
+  static async deleteWalletSyncProgress(walletId: string) {
+    await getConnection().getRepository(SyncProgress).delete({
+      walletId,
+      addressType: SyncAddressType.Default,
+    })
   }
 }

--- a/packages/neuron-wallet/src/services/wallets.ts
+++ b/packages/neuron-wallet/src/services/wallets.ts
@@ -16,6 +16,7 @@ import { getConnection } from '../database/chain/connection'
 import NetworksService from './networks'
 import { NetworkType } from '../models/network'
 import { resetSyncTaskQueue } from '../block-sync-renderer'
+import SyncProgressService from './sync-progress'
 
 const fileService = FileService.getInstance()
 
@@ -435,6 +436,7 @@ export default class WalletService {
     this.setCurrent(newWallet.id)
 
     await AddressService.deleteByWalletId(existingWalletId)
+    await SyncProgressService.deleteWalletSyncProgress(existingWalletId)
 
     const newWallets = wallets.filter(w => w.id !== existingWalletId)
     this.listStore.writeSync(this.walletsKey, [...newWallets, newWallet])
@@ -489,6 +491,7 @@ export default class WalletService {
     }
 
     await AddressService.deleteByWalletId(id)
+    await SyncProgressService.deleteWalletSyncProgress(id)
 
     this.listStore.writeSync(this.walletsKey, newWallets)
 

--- a/packages/neuron-wallet/tests/block-sync-renderer/light-synchronizer.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-renderer/light-synchronizer.test.ts
@@ -326,6 +326,47 @@ describe('test light synchronizer', () => {
       )
       expect(setScriptsMock).toHaveBeenLastCalledWith([], 'delete')
     })
+    it('when set the wallet start block number is bigger than current synced block number', async () => {
+      getScriptsMock.mockResolvedValue([{ script, blockNumber: '0xaa' }])
+      const addressMeta = AddressMeta.fromObject({
+        walletId: 'walletId',
+        address,
+        path: '',
+        addressIndex: 10,
+        addressType: 0,
+        blake160: script.args,
+      })
+      getWalletMinLocalSavedBlockNumberMock.mockResolvedValue({})
+      walletGetAllMock.mockReturnValue([{ id: 'walletId', startBlockNumber: '0xffff' }])
+      const connect = new LightSynchronizer([addressMeta], '')
+      //@ts-ignore
+      await connect.initSyncProgress()
+      expect(setScriptsMock).toHaveBeenNthCalledWith(
+        1,
+        [
+          {
+            script: addressMeta.generateDefaultLockScript().toSDK(),
+            scriptType: 'lock',
+            walletId: 'walletId',
+            blockNumber: '0xffff',
+          },
+          {
+            script: addressMeta.generateACPLockScript().toSDK(),
+            scriptType: 'lock',
+            walletId: 'walletId',
+            blockNumber: '0xffff',
+          },
+          {
+            script: addressMeta.generateLegacyACPLockScript().toSDK(),
+            scriptType: 'lock',
+            walletId: 'walletId',
+            blockNumber: '0xffff',
+          },
+        ],
+        'partial'
+      )
+      expect(setScriptsMock).toHaveBeenLastCalledWith([], 'delete')
+    })
   })
 
   describe('test initSync', () => {


### PR DESCRIPTION
1. When setting a bigger number than the current synced block number, reset the start block number
  Refer to https://github.com/Magickbase/neuron-public-issues/issues/387

3. Fix light client sync when importing an existed or existing wallet.
  Refer to https://github.com/Magickbase/neuron-public-issues/issues/388