### PR TITLE
refactor: replace ckbCore with lumos CKBRPC

### DIFF
--- a/packages/neuron-ui/package.json
+++ b/packages/neuron-ui/package.json
@@ -51,11 +51,11 @@
   ],
   "dependencies": {
     "@ckb-lumos/bi": "0.21.1",
+    "@ckb-lumos/rpc": "0.21.1",
     "@ckb-lumos/base": "0.21.1",
     "@ckb-lumos/codec": "0.21.1",
     "@ckb-lumos/helpers": "0.21.1",
     "@ckb-lumos/config-manager": "0.21.1",
-    "@nervosnetwork/ckb-sdk-core": "0.109.0",
     "@nervosnetwork/ckb-sdk-utils": "0.109.0",
     "canvg": "2.0.0",
     "i18next": "23.7.11",

--- a/packages/neuron-ui/src/components/WithdrawDialog/index.tsx
+++ b/packages/neuron-ui/src/components/WithdrawDialog/index.tsx
@@ -50,7 +50,7 @@ const WithdrawDialog = ({
           getHeader(tx.txStatus.blockHash).then(header => {
             setWithdrawValue(
               calculateMaximumWithdraw(
-                tx.transaction.outputs[+record.outPoint.index],
+                tx.transaction.outputs[+record.outPoint.index] as CKBComponents.CellOutput,
                 tx.transaction.outputsData[+record.outPoint.index],
                 header.dao,
                 tipDao

--- a/packages/neuron-ui/src/containers/Main/hooks.ts
+++ b/packages/neuron-ui/src/containers/Main/hooks.ts
@@ -29,7 +29,7 @@ import {
   ShowGlobalDialog as ShowGlobalDialogSubject,
   NoDiskSpace,
 } from 'services/subjects'
-import { ckbCore, getTipHeader } from 'services/chain'
+import { rpc, getTipHeader } from 'services/chain'
 import {
   networks as networksCache,
   currentNetworkID as currentNetworkIDCache,
@@ -78,13 +78,13 @@ export const useSyncChainData = ({ chainURL, dispatch }: { chainURL: string; dis
     }
     clearInterval(timer!)
     if (chainURL) {
-      ckbCore.setNode(chainURL)
+      rpc.setNode({ url: chainURL })
       syncBlockchainInfo()
       timer = setInterval(() => {
         syncBlockchainInfo()
       }, SYNC_INTERVAL_TIME)
     } else {
-      ckbCore.setNode('')
+      rpc.setNode({ url: '' })
     }
     return () => {
       clearInterval(timer)

--- a/packages/neuron-ui/src/services/chain.ts
+++ b/packages/neuron-ui/src/services/chain.ts
@@ -1,13 +1,6 @@
-import CKBCore from '@nervosnetwork/ckb-sdk-core'
+import { CKBRPC } from '@ckb-lumos/rpc'
 
-export const ckbCore = new CKBCore('')
-export const { getHeader, getBlockchainInfo, getTipHeader, getHeaderByNumber, getFeeRateStats, getTransaction } =
-  ckbCore.rpc
+export const rpc = new CKBRPC('')
 
-export default {
-  ckbCore,
-  getHeader,
-  getTipHeader,
-  getTransaction,
-  getFeeRateStats,
-}
+export const { getHeader, getBlockchainInfo, getTipHeader, getHeaderByNumber, getFeeRateStatistics, getTransaction } =
+  rpc

--- a/packages/neuron-ui/src/utils/hooks/useGetCountDownAndFeeRateStats.ts
+++ b/packages/neuron-ui/src/utils/hooks/useGetCountDownAndFeeRateStats.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { getFeeRateStats } from 'services/chain'
+import { getFeeRateStatistics } from 'services/chain'
 import { MEDIUM_FEE_RATE, METHOD_NOT_FOUND } from 'utils/const'
 
 type CountdownOptions = {
@@ -16,7 +16,7 @@ const useGetCountDownAndFeeRateStats = ({ seconds = 30, interval = 1000 }: Count
   }>({ suggestFeeRate: MEDIUM_FEE_RATE })
 
   const handleGetFeeRateStatis = useCallback(() => {
-    getFeeRateStats()
+    getFeeRateStatistics()
       .then(res => {
         const { mean, median } = res ?? {}
         const suggested = mean && median ? Math.max(1000, Number(mean), Number(median)) : MEDIUM_FEE_RATE

--- a/yarn.lock
+++ b/yarn.lock
@@ -3401,25 +3401,6 @@
     pump "^3.0.0"
     tar-fs "^2.1.1"
 
-"@nervosnetwork/ckb-sdk-core@0.109.0":
-  version "0.109.0"
-  resolved "https://registry.yarnpkg.com/@nervosnetwork/ckb-sdk-core/-/ckb-sdk-core-0.109.0.tgz#9ac514e119c3fb2e1cde28437351b06e92700a06"
-  integrity sha512-c0pMKrZxVG0zRaPOMY+sV7CubW+Fr1YGEj/c3iEZadlXQPeeZ7wdhblG/F4oEtGebRv2lO+F8gTL9FwQlHAXRw==
-  dependencies:
-    "@nervosnetwork/ckb-sdk-rpc" "0.109.0"
-    "@nervosnetwork/ckb-sdk-utils" "0.109.0"
-    "@nervosnetwork/ckb-types" "0.109.0"
-    tslib "2.3.1"
-
-"@nervosnetwork/ckb-sdk-rpc@0.109.0":
-  version "0.109.0"
-  resolved "https://registry.yarnpkg.com/@nervosnetwork/ckb-sdk-rpc/-/ckb-sdk-rpc-0.109.0.tgz#89a46227c22a56820260d5d72e976b6b4420d650"
-  integrity sha512-qkb2TBMb/gqECNqzVlrx9p6V4TdyYcGlN4sOgjVrrDQw7wVcezZFMjj6usNZZLxzbyEmjksTxbAucUnbftumxA==
-  dependencies:
-    "@nervosnetwork/ckb-sdk-utils" "0.109.0"
-    axios "0.21.4"
-    tslib "2.3.1"
-
 "@nervosnetwork/ckb-sdk-utils@0.109.0":
   version "0.109.0"
   resolved "https://registry.yarnpkg.com/@nervosnetwork/ckb-sdk-utils/-/ckb-sdk-utils-0.109.0.tgz#4ac4b70f5649bd641c6cc35c70e0130f043cc98f"
@@ -7160,13 +7141,6 @@ axe-core@^4.6.2:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.2.tgz#040a7342b20765cb18bb50b628394c21bccc17a0"
   integrity sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==
-
-axios@0.21.4:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
-  dependencies:
-    follow-redirects "^1.14.0"
 
 axios@^0.27.2:
   version "0.27.2"
@@ -10950,7 +10924,7 @@ flow-parser@0.*:
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.210.1.tgz#6e04775dc2ebd5bde6a37de38532836678a5ac3e"
   integrity sha512-M0SdOwD0wZHhk6K/AOaPReBnw2vB7p9KUFUFZHJRsU3ZMl/+WVrMpmb8AfEM6GXZ5mEssCx9vHugxxJg1ieoew==
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.9, follow-redirects@^1.15.0:
+follow-redirects@^1.0.0, follow-redirects@^1.14.9, follow-redirects@^1.15.0:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==


### PR DESCRIPTION
1. `CKBRPC.createBatchRequest()` in Lumos currently has limited typing info: `any`
```ts
createBatchRequest: <N extends keyof Base, P extends (string | number | object)[], R = any[]>(params?: any) => any;
```

So in this PR I manually added response types in `then` blocks for `CKBRPC.createBatchRequest` calls, e.g. 
```ts
rpc
  .createBatchRequest<'getTransaction', string[], CKBComponents.TransactionWithStatus[]>(
    depositOutPointHashes.map(v => ['getTransaction', v])
  )
  .exec()
  .then((txs: CKBComponents.TransactionWithStatus[]) => {
```

**I'm working on another PR for Lumos to bring back the right types for `CKBRPC.createBatchRequest()`**

2. In `packages/neuron-ui/src/components/WithdrawDialog/index.tsx`
```ts
  calculateMaximumWithdraw(
    tx.transaction.outputs[+record.outPoint.index] as CKBComponents.CellOutput,
    tx.transaction.outputsData[+record.outPoint.index],
    header.dao,
    tipDao
  )
```
`as CKBComponents.CellOutput` is added because

`calculateMaximumWithdraw` expects `CKBComponents.CellOutput` whose `script.hashType` is `'data' | 'type' | 'data1'`

`tx.transaction.outputs` member has type `Output` whose `script.hashType` is `"type" | "data" | "data1" | "data2"`

`as CKBComponents.CellOutput` will be removed in next PR, which I will replace `@nervosnetwork/ckb-sdk-utils` methods with Lumos methods.

3. `@nervosnetwork/ckb-sdk-core` is removed from `dependencies` of `neurons-ui` .
