### PR TITLE
ci: fix ci build error (treat warnings as errors)

### DIFF
--- a/packages/neuron-ui/package.json
+++ b/packages/neuron-ui/package.json
@@ -18,7 +18,7 @@
     "start": "cross-env DISABLE_ESLINT_PLUGIN=true GENERATE_SOURCEMAP=false react-app-rewired start",
     "lint": "eslint --fix --ext .tsx,.ts,.js src",
     "test": "react-app-rewired test --env=jsdom --watchAll=false",
-    "build": "cross-env DISABLE_ESLINT_PLUGIN=true GENERATE_SOURCEMAP=false react-app-rewired build",
+    "build": "cross-env CI=false DISABLE_ESLINT_PLUGIN=true GENERATE_SOURCEMAP=false react-app-rewired build",
     "clean": "npx rimraf build",
     "precommit": "lint-staged",
     "storybook": "storybook dev -p 9009 -s public",


### PR DESCRIPTION
`procoss.env.CI` is set to `true` in CI, causing a build error when building `neuron:ui`

This PR aims to fix this.

The warning
```sh
[Module not found: Error: Can't resolve 'fs' in '/home/runner/work/neuron/neuron/node_modules/@ckb-lumos/config-manager/lib'](neuron-ui: Module not found: Error: Can't resolve 'fs' in '/home/runner/work/neuron/neuron/node_modules/@ckb-lumos/config-manager/lib')
```
is caused by
https://github.com/ckb-js/lumos/blob/develop/packages/config-manager/src/manager.ts#L107

But we don't call that deprecated function in `neuron-ui`


https://github.com/nervosnetwork/neuron/actions/runs/9022501373/job/24792170701

<img width="1025" alt="image" src="https://github.com/nervosnetwork/neuron/assets/7459812/9b6582fc-a093-47e1-8cf4-b6b2eb97afed">

## Reference
* https://github.com/facebook/create-react-app/issues/3657
* https://github.com/facebook/create-react-app/blob/main/packages/react-scripts/scripts/build.js#L182
