### PR TITLE
fix: fix ci build error

### DIFF
--- a/packages/neuron-ui/config-overrides.js
+++ b/packages/neuron-ui/config-overrides.js
@@ -4,5 +4,6 @@ const path = require('path')
 module.exports = function override(config) {
   const webpackConfig = { ...config }
   webpackConfig.resolve.alias.electron = path.join(__dirname, 'src/electron-modules')
+  webpackConfig.resolve.fallback = { fs: false }
   return webpackConfig
 }


### PR DESCRIPTION
This PR aims to fix a build error in CI caused by require `fs` in lumos config manager.
This is usually a warning, but in CI, it becomes an error.
```sh
neuron-ui: Module not found: Error: Can't resolve 'fs' in '/home/runner/work/neuron/neuron/node_modules/@ckb-lumos/config-manager/lib'
```
**With this PR, there will be no such warning or error.**

**Code in lumos**
https://github.com/ckb-js/lumos/blob/develop/packages/config-manager/src/manager.ts#L107


**Code in bundle.js WITHOUT this PR**, hence the warning in dev and error in CI

<img width="1192" alt="image" src="https://github.com/nervosnetwork/neuron/assets/7459812/c0b754d9-ec2e-45f0-9881-c5fcdea9df0c">

------

**Code in bundle.js WITH this PR**.  We don't call `initializeConfigLegacy()` in `neuron-ui` so it's not a problem.

<img width="795" alt="image" src="https://github.com/nervosnetwork/neuron/assets/7459812/6a23ec3f-ef08-4b71-a397-6fb396d6f795">



**Job**
https://github.com/nervosnetwork/neuron/actions/runs/9022501373/job/24792170701

<img width="1057" alt="image" src="https://github.com/nervosnetwork/neuron/assets/7459812/e46d22a1-9d77-4d08-b207-787ff0d9c048">