### PR TITLE
fix: Replace `Asset` to `Amount` and better 'Asset' data format

### DIFF
--- a/packages/neuron-ui/src/components/FormattedTokenAmount/index.tsx
+++ b/packages/neuron-ui/src/components/FormattedTokenAmount/index.tsx
@@ -12,7 +12,7 @@ type FormattedTokenAmountProps = { item: State.Transaction; show: boolean; symbo
 type AmountProps = Omit<FormattedTokenAmountProps, 'isNeedCopy'> & {
   sudtAmount?: string
   isReceive: boolean
-  amount: string
+  amount?: string
   symbolClassName?: string
 }
 
@@ -30,18 +30,18 @@ const Amount = ({ sudtAmount, show, item, isReceive, amount, symbolClassName, sy
     </div>
   ) : (
     <div>
-      <span className={show ? styles.amount : ''} data-direction={isReceive ? 'receive' : 'send'}>
-        {amount}
+      <span className={show ? styles.amount : ''} data-direction={amount && (isReceive ? 'receive' : 'send')}>
+        {amount ?? '--'}
       </span>
-      &nbsp;{symbol}
+      &nbsp;{amount ? symbol : ''}
     </div>
   )
 }
 
 export const FormattedTokenAmount = ({ item, show, symbolClassName }: FormattedTokenAmountProps) => {
-  let amount = '--'
+  let amount: string | undefined
   let sudtAmount = ''
-  let copyText = amount
+  let copyText: string | undefined = amount
   let isReceive = false
   let symbol = ''
 
@@ -61,16 +61,22 @@ export const FormattedTokenAmount = ({ item, show, symbolClassName }: FormattedT
         isReceive = !sudtAmount.includes('-')
       }
     } else {
-      amount = show ? `${shannonToCKBFormatter(item.value, true)}` : `${HIDE_BALANCE}`
-      isReceive = !amount.includes('-')
+      amount = show
+        ? `${shannonToCKBFormatter(item.nervosDao ? item.daoCapacity ?? '--' : item.value, true)}`
+        : `${HIDE_BALANCE}`
+      isReceive = !amount?.includes('-')
       copyText = `${amount} CKB`
       symbol = 'CKB'
+      if (item.nervosDao && item.daoCapacity === undefined) {
+        amount = undefined
+        copyText = undefined
+      }
     }
   }
 
   const props = { sudtAmount, show, item, isReceive, amount, symbolClassName, symbol }
 
-  return show ? (
+  return show && copyText ? (
     <CopyZone content={copyText}>
       <Amount {...props} />
     </CopyZone>

--- a/packages/neuron-ui/src/components/History/index.tsx
+++ b/packages/neuron-ui/src/components/History/index.tsx
@@ -126,7 +126,7 @@ const History = () => {
       sortable: true,
     },
     {
-      title: t('history.table.amount'),
+      title: t('history.table.asset'),
       dataIndex: 'amount',
       align: 'left',
       isBalance: true,

--- a/packages/neuron-ui/src/components/Overview/index.tsx
+++ b/packages/neuron-ui/src/components/Overview/index.tsx
@@ -268,7 +268,7 @@ const Overview = () => {
             },
           },
           {
-            title: t('overview.amount'),
+            title: t('overview.asset'),
             dataIndex: 'amount',
             align: 'left',
             isBalance: true,

--- a/packages/neuron-ui/src/locales/en.json
+++ b/packages/neuron-ui/src/locales/en.json
@@ -142,7 +142,7 @@
       "activity": "Activity",
       "datetime": "Date & Time",
       "status": "Status",
-      "amount": "Amount",
+      "asset": "Asset",
       "address": "Address",
       "sent": "Sent",
       "sending": "Sending",
@@ -313,7 +313,7 @@
         "name": "Wallet Name",
         "type": "Type",
         "balance": "Balance",
-        "amount": "Amount",
+        "asset": "Asset",
         "timestamp": "Time",
         "status": "Status",
         "operation": "Operation"

--- a/packages/neuron-ui/src/locales/es.json
+++ b/packages/neuron-ui/src/locales/es.json
@@ -135,7 +135,7 @@
       "activity": "Actividad",
       "datetime": "Fecha y Hora",
       "status": "Estado",
-      "amount": "Cantidad",
+      "asset": "Activos",
       "address": "Dirección",
       "sent": "Enviado",
       "sending": "Enviando",
@@ -305,7 +305,7 @@
         "name": "Nombre de la Billetera",
         "type": "Tipo",
         "balance": "Saldo",
-        "amount": "Cantidad",
+        "asset": "activos",
         "timestamp": "Tiempo",
         "status": "Estado",
         "operation": "Operación"

--- a/packages/neuron-ui/src/locales/fr.json
+++ b/packages/neuron-ui/src/locales/fr.json
@@ -142,7 +142,7 @@
       "activity": "Activité",
       "datetime": "Date et heure",
       "status": "Statut",
-      "amount": "Montant",
+      "asset": "actifs",
       "address": "Adresse",
       "sent": "Envoyé",
       "sending": "Envoi",
@@ -312,7 +312,7 @@
         "name": "Nom du Wallet",
         "type": "Type",
         "balance": "Solde",
-        "amount": "Montant",
+        "asset": "actifs",
         "timestamp": "Heure",
         "status": "Statut",
         "operation": "Opération"

--- a/packages/neuron-ui/src/locales/zh-tw.json
+++ b/packages/neuron-ui/src/locales/zh-tw.json
@@ -136,7 +136,7 @@
       "activity": "收支活動",
       "datetime": "時間",
       "status": "狀態",
-      "amount": "金額",
+      "asset": "資產",
       "address": "地址",
       "sent": "已發送",
       "sending": "正在發送",
@@ -308,7 +308,7 @@
         "name": "錢包名稱",
         "type": "類型",
         "balance": "余額",
-        "amount": "金額",
+        "asset": "資產",
         "timestamp": "時間",
         "status": "狀態",
         "operation": "操作"

--- a/packages/neuron-ui/src/locales/zh.json
+++ b/packages/neuron-ui/src/locales/zh.json
@@ -135,7 +135,7 @@
       "activity": "收支活动",
       "datetime": "时间",
       "status": "状态",
-      "amount": "金额",
+      "asset": "资产",
       "address": "地址",
       "sent": "已发送",
       "sending": "正在发送",
@@ -306,7 +306,7 @@
         "name": "钱包名称",
         "type": "类型",
         "balance": "余额",
-        "amount": "金额",
+        "asset": "资产",
         "timestamp": "时间",
         "status": "状态",
         "operation": "操作"

--- a/packages/neuron-ui/src/types/App/index.d.ts
+++ b/packages/neuron-ui/src/types/App/index.d.ts
@@ -19,6 +19,7 @@ declare namespace State {
       data: string
     }
     assetAccountType?: 'CKB' | 'sUDT' | string
+    daoCapacity?: string
   }
 
   interface DetailedInput {

--- a/packages/neuron-wallet/src/models/chain/transaction.ts
+++ b/packages/neuron-wallet/src/models/chain/transaction.ts
@@ -82,6 +82,8 @@ export default class Transaction {
   public signatures: Signatures = {}
   public assetAccountType?: AssetAccountType
 
+  public daoCapacity?: string
+
   constructor(
     version: string,
     cellDeps: CellDep[] = [],
@@ -106,7 +108,8 @@ export default class Transaction {
     sudtInfo?: SudtInfo,
     nftType?: NFTInfo,
     signatures: Signatures = {},
-    assetAccountType?: AssetAccountType
+    assetAccountType?: AssetAccountType,
+    daoCapacity?: string
   ) {
     this.cellDeps = cellDeps
     this.headerDeps = headerDeps
@@ -133,6 +136,7 @@ export default class Transaction {
     this.sudtInfo = sudtInfo
     this.nftInfo = nftType
     this.signatures = signatures
+    this.daoCapacity = daoCapacity
     TypeCheckerUtils.hashChecker(...this.headerDeps, this.blockHash)
     TypeCheckerUtils.numberChecker(
       this.version,
@@ -171,6 +175,7 @@ export default class Transaction {
     nftInfo,
     signatures = {},
     assetAccountType,
+    daoCapacity,
   }: {
     version: string
     cellDeps?: CellDep[]
@@ -196,6 +201,7 @@ export default class Transaction {
     nftInfo?: NFTInfo
     signatures?: Signatures
     assetAccountType?: AssetAccountType
+    daoCapacity?: string
   }): Transaction {
     return new Transaction(
       version,
@@ -226,7 +232,8 @@ export default class Transaction {
       sudtInfo,
       nftInfo,
       signatures,
-      assetAccountType
+      assetAccountType,
+      daoCapacity
     )
   }
 


### PR DESCRIPTION
Refer to https://github.com/Magickbase/neuron-public-issues/issues/335#issuecomment-1996306163

For [Optimize input and output storage](https://github.com/nervosnetwork/neuron/pull/2672), Neuron can not recognize whether the transaction is only sent to the current wallet. So, `For transactions sent to yourself, 'Asset' needs to be shown as '--'.` will not implement.
