### PR TITLE
fix: Use lumos to init Buffer

### DIFF
--- a/packages/neuron-wallet/src/controllers/wallets.ts
+++ b/packages/neuron-wallet/src/controllers/wallets.ts
@@ -168,8 +168,8 @@ export default class WalletsController {
     const keystoreObject = Keystore.fromJson(keystore)
     const masterPrivateKey = keystoreObject.extendedPrivateKey(password)
     const masterKeychain = new Keychain(
-      Buffer.from(masterPrivateKey.privateKey, 'hex'),
-      Buffer.from(masterPrivateKey.chainCode, 'hex')
+      Buffer.from(bytes.bytify(masterPrivateKey.privateKey)),
+      Buffer.from(bytes.bytify(masterPrivateKey.chainCode))
     )
     const accountKeychain = masterKeychain.derivePath(AccountExtendedPublicKey.ckbAccountPath)
     const accountExtendedPublicKey = new AccountExtendedPublicKey(

--- a/packages/neuron-wallet/src/services/sign-message.ts
+++ b/packages/neuron-wallet/src/services/sign-message.ts
@@ -6,6 +6,7 @@ import { ec as EC } from 'elliptic'
 import { AddressNotFound } from '../exceptions'
 import HardwareWalletService from './hardware'
 import AddressParser from '../models/address-parser'
+import { bytes } from '@ckb-lumos/codec'
 
 export default class SignMessage {
   static GENERATE_COUNT = 100
@@ -91,8 +92,8 @@ export default class SignMessage {
   private static getPrivateKey(wallet: Wallet, path: string, password: string): string {
     const masterPrivateKey = wallet.loadKeystore().extendedPrivateKey(password)
     const masterKeychain = new Keychain(
-      Buffer.from(masterPrivateKey.privateKey, 'hex'),
-      Buffer.from(masterPrivateKey.chainCode, 'hex')
+      Buffer.from(bytes.bytify(masterPrivateKey.privateKey)),
+      Buffer.from(bytes.bytify(masterPrivateKey.chainCode))
     )
 
     return `0x${masterKeychain.derivePath(path).privateKey.toString('hex')}`


### PR DESCRIPTION
`Buffer.from(string, 'hex')` the string value should be started without `0x`, so I use Lumos `bytes.bytify` to init Buffer.