### PR TITLE
perf: set groupByTransaction to true in fetchTxMapping()

### DIFF
--- a/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-cache-service.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/indexer-cache-service.ts
@@ -84,6 +84,7 @@ export default class IndexerCacheService {
             lock: lockScript,
             fromBlock: lastCacheBlockNumber.value,
             toBlock: currentHeaderBlockNumber,
+            groupByTransaction: true,
           },
           this.rpcService.url,
           {


### PR DESCRIPTION
https://github.com/nervosnetwork/ckb-indexer?tab=readme-ov-file#get_transactions

This is a minor improvement on transaction hash fetching.

`groupByTransaction: true` makes sure that every item in `response.result.objects` has unique `tx_hash`

```ts
// IndexerCacheService.fetchTxMapping()

for (const lockScript of lockScripts) {
  const transactionCollector = new TransactionCollector(
    this.indexer,
    {
      lock: lockScript,
      fromBlock: lastCacheBlockNumber.value,
      toBlock: currentHeaderBlockNumber,
      groupByTransaction: true,
    },
    this.rpcService.url,
    {
      includeStatus: false,
    }
  )

  const fetchedTxHashes = await transactionCollector.getTransactionHashes()
  if (!fetchedTxHashes.length) {
    continue
  }

  for (const txHash of fetchedTxHashes) {
    mappingsByTxHash.set(txHash, [
      {
        address: addressMeta.address,
        lockHash: lockScript.computeHash(),
      },
    ])
  }
}
```