### PR TITLE
Release v0.116.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# 0.116.1 (2024-05-28)
+
+### CKB Node & Light Client
+
+- [CKB@v0.116.1](https://github.com/nervosnetwork/ckb/releases/tag/v0.116.1) was released on May. 11st, 2024. This version of CKB node is now bundled and preconfigured in Neuron.
+- [CKB Light Client@v0.3.7](https://github.com/nervosnetwork/ckb-light-client/releases/tag/v0.3.7) was released on Apr. 13th, 2024. This version of CKB Light Client is now bundled and preconfigured in Neuron
+
+### Assumed valid target
+
+Block before `0x6dd077b407d019a0bce0cbad8c34e69a524ae4b2599b9feda2c7491f3559d32c`(at height `13,007,704`) will be skipped in validation.(https://github.com/nervosnetwork/neuron/pull/3157)
+
+---
+
+## Bug fixes
+
+- 3173: Fix importing an account from a hardware wallet.(@yanguoyu)
+
+**Full Changelog**: https://github.com/nervosnetwork/neuron/compare/v0.116.0...v0.116.1
+
 # 0.116.0 (2024-05-24)
 
 ### CKB Node & Light Client

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/*"],
-  "version": "0.116.0",
+  "version": "0.116.1",
   "npmClient": "yarn",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "neuron",
   "productName": "Neuron",
   "description": "CKB Neuron Wallet",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "private": true,
   "author": {
     "name": "Nervos Core Dev",

--- a/packages/neuron-ui/package.json
+++ b/packages/neuron-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neuron-ui",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "private": true,
   "author": {
     "name": "Nervos Core Dev",

--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -3,7 +3,7 @@
   "productName": "Neuron",
   "description": "CKB Neuron Wallet",
   "homepage": "https://www.nervos.org/",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "private": true,
   "author": {
     "name": "Nervos Core Dev",
@@ -97,7 +97,7 @@
     "electron-builder": "24.9.1",
     "electron-devtools-installer": "3.2.0",
     "jest-when": "3.6.0",
-    "neuron-ui": "0.116.0",
+    "neuron-ui": "0.116.1",
     "typescript": "5.3.3"
   }
 }

--- a/packages/neuron-wallet/src/services/hardware/ledger.ts
+++ b/packages/neuron-wallet/src/services/hardware/ledger.ts
@@ -12,6 +12,20 @@ import logger from '../../utils/logger'
 import NetworksService from '../../services/networks'
 import { generateRPC } from '../../utils/ckb-rpc'
 
+const UNCOMPRESSED_KEY_LENGTH = 130
+const compressPublicKey = (key: string) => {
+  if (key.length !== UNCOMPRESSED_KEY_LENGTH) {
+    return key
+  }
+
+  const publicKey = Buffer.from(key, 'hex')
+  const compressedPublicKey = Buffer.alloc(33)
+    // '03' for odd value, '02' for even value
+    .fill(publicKey[64] & 1 ? '03' : '02', 0, 1, 'hex')
+    .fill(publicKey.subarray(1, 33), 1, 33)
+  return compressedPublicKey.toString('hex')
+}
+
 export default class Ledger extends Hardware {
   private ledgerCKB: LedgerCKB | null = null
   private transport: Transport | null = null
@@ -41,8 +55,9 @@ export default class Ledger extends Hardware {
 
   public async getExtendedPublicKey(): Promise<ExtendedPublicKey> {
     const { public_key, chain_code } = await this.ledgerCKB!.getWalletExtendedPublicKey(this.defaultPath)
+    // The ledger wallet's public key is unzipped, so zip it to 33 bytes https://en.bitcoin.it/wiki/BIP_0032 serializes the coordinate pair P
     return {
-      publicKey: public_key,
+      publicKey: compressPublicKey(public_key),
       chainCode: chain_code,
     }
   }

--- a/packages/neuron-wallet/tests/services/hardware/ledger.test.ts
+++ b/packages/neuron-wallet/tests/services/hardware/ledger.test.ts
@@ -1,0 +1,39 @@
+import Ledger from '../../../src/services/hardware/ledger'
+
+const getWalletExtendedPublicKeyMock = jest.fn()
+
+jest.mock('hw-app-ckb', () => {
+  return function () {
+    return {
+      getWalletExtendedPublicKey: getWalletExtendedPublicKeyMock,
+    }
+  }
+})
+
+jest.mock('@ledgerhq/hw-transport-node-hid', () => ({
+  open: jest.fn(),
+}))
+
+const pk =
+  '04d061e9c5891f579fd548cfd22ff29f5c642714cc7e7a9215f0071ef5a5723f691757b28e31be71f09f24673eed52348e58d53bcfd26f4d96ec6bf1489eab429d'
+const zipPk = '03d061e9c5891f579fd548cfd22ff29f5c642714cc7e7a9215f0071ef5a5723f69'
+
+describe('test for ledger', () => {
+  describe('test getExtendedPublicKey', () => {
+    it('if the return pk is unzip', async () => {
+      getWalletExtendedPublicKeyMock.mockResolvedValueOnce({ public_key: pk, chain_code: '0x' })
+      const ledger = new Ledger({} as any)
+      await ledger.connect()
+      const res = await ledger.getExtendedPublicKey()
+      expect(res.publicKey).toBe(zipPk)
+    })
+
+    it('if the return pk is zip', async () => {
+      getWalletExtendedPublicKeyMock.mockResolvedValueOnce({ public_key: zipPk, chain_code: '0x' })
+      const ledger = new Ledger({} as any)
+      await ledger.connect()
+      const res = await ledger.getExtendedPublicKey()
+      expect(res.publicKey).toBe(zipPk)
+    })
+  })
+})


### PR DESCRIPTION
# 0.116.1 (2024-05-28)

### CKB Node & Light Client

- [CKB@v0.116.1](https://github.com/nervosnetwork/ckb/releases/tag/v0.116.1) was released on May. 11st, 2024. This version of CKB node is now bundled and preconfigured in Neuron.
- [CKB Light Client@v0.3.7](https://github.com/nervosnetwork/ckb-light-client/releases/tag/v0.3.7) was released on Apr. 13th, 2024. This version of CKB Light Client is now bundled and preconfigured in Neuron

### Assumed valid target

Block before `0x6dd077b407d019a0bce0cbad8c34e69a524ae4b2599b9feda2c7491f3559d32c`(at height `13,007,704`) will be skipped in validation.(https://github.com/nervosnetwork/neuron/pull/3157)

---

## Bug fixes

- 3173: Fix importing an account from a hardware wallet.(@yanguoyu)

**Full Changelog**: https://github.com/nervosnetwork/neuron/compare/v0.116.0...v0.116.1
