### PR TITLE
Release v0.116.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# 0.116.2 (2024-05-29)
+
+### CKB Node & Light Client
+
+- [CKB@v0.116.1](https://github.com/nervosnetwork/ckb/releases/tag/v0.116.1) was released on May. 11st, 2024. This version of CKB node is now bundled and preconfigured in Neuron.
+- [CKB Light Client@v0.3.7](https://github.com/nervosnetwork/ckb-light-client/releases/tag/v0.3.7) was released on Apr. 13th, 2024. This version of CKB Light Client is now bundled and preconfigured in Neuron
+
+### Assumed valid target
+
+Block before `0x6dd077b407d019a0bce0cbad8c34e69a524ae4b2599b9feda2c7491f3559d32c`(at height `13,007,704`) will be skipped in validation.(https://github.com/nervosnetwork/neuron/pull/3157)
+
+---
+
+## Bug fixes
+
+- 3179: Remove the display of the ledger firmware version because it causes the Nervos app to crash on the ledger device.(@yanguoyu)
+
+**Full Changelog**: https://github.com/nervosnetwork/neuron/compare/v0.116.1...v0.116.2
+
 # 0.116.1 (2024-05-28)
 
 ### CKB Node & Light Client

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/*"],
-  "version": "0.116.1",
+  "version": "0.116.2",
   "npmClient": "yarn",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "neuron",
   "productName": "Neuron",
   "description": "CKB Neuron Wallet",
-  "version": "0.116.1",
+  "version": "0.116.2",
   "private": true,
   "author": {
     "name": "Nervos Core Dev",

--- a/packages/neuron-ui/package.json
+++ b/packages/neuron-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neuron-ui",
-  "version": "0.116.1",
+  "version": "0.116.2",
   "private": true,
   "author": {
     "name": "Nervos Core Dev",

--- a/packages/neuron-ui/src/components/ImportHardware/detect-device.tsx
+++ b/packages/neuron-ui/src/components/ImportHardware/detect-device.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from 'widgets/Button'
-import { getDevices, getDeviceFirmwareVersion, getDeviceCkbAppVersion, connectDevice } from 'services/remote'
+import { getDevices, getDeviceCkbAppVersion, connectDevice } from 'services/remote'
 import { isSuccessResponse, errorFormatter, useDidMount } from 'utils'
 import { ReactComponent as SuccessInfo } from 'widgets/Icons/SuccessInfo.svg'
 import { Error as ErrorIcon } from 'widgets/Icons/icon'
@@ -50,7 +50,6 @@ const DetectDevice = ({ dispatch, model }: { dispatch: React.Dispatch<ActionType
   const [scanning, setScanning] = useState(true)
   const [error, setError] = useState('')
   const [appVersion, setAppVersion] = useState('')
-  const [firmwareVersion, setFirmwareVersion] = useState('')
 
   const findDevice = useCallback(async () => {
     setError('')
@@ -75,10 +74,6 @@ const DetectDevice = ({ dispatch, model }: { dispatch: React.Dispatch<ActionType
         if (!isSuccessResponse(connectionRes)) {
           setScanning(false)
           throw new ConnectFailedException(errorFormatter(connectionRes.message, t))
-        }
-        const firmwareVersionRes = await getDeviceFirmwareVersion(device.descriptor)
-        if (isSuccessResponse(firmwareVersionRes)) {
-          setFirmwareVersion(firmwareVersionRes.result!)
         }
         const ckbVersionRes = await getDeviceCkbAppVersion(device.descriptor)
         if (isSuccessResponse(ckbVersionRes)) {
@@ -117,9 +112,6 @@ const DetectDevice = ({ dispatch, model }: { dispatch: React.Dispatch<ActionType
         <h3 className={styles.model}>{productName}</h3>
         {errorMsg ? <Info isError msg={errorMsg} /> : null}
         {scanning ? <Info isWaiting={scanning} msg={t('import-hardware.waiting')} /> : null}
-        {firmwareVersion && !errorMsg && !scanning ? (
-          <Info msg={t('import-hardware.firmware-version', { version: firmwareVersion })} />
-        ) : null}
         {appVersion ? <Info msg={t('import-hardware.app-version', { version: appVersion })} /> : null}
       </section>
       <footer className={styles.dialogFooter}>

--- a/packages/neuron-ui/src/services/remote/hardware.ts
+++ b/packages/neuron-ui/src/services/remote/hardware.ts
@@ -32,7 +32,6 @@ export type Version = string
 
 export const getDevices = remoteApi<Model | null, DeviceInfo[]>('detect-device')
 export const getDeviceCkbAppVersion = remoteApi<Descriptor, Version>('get-device-ckb-app-version')
-export const getDeviceFirmwareVersion = remoteApi<Descriptor, Version>('get-device-firmware-version')
 export const getDeviceExtendedPublickey = remoteApi<void, ExtendedPublicKey>('get-device-extended-public-key')
 export const getDevicePublicKey = remoteApi<void, PublicKey>('get-device-public-key')
 export const connectDevice = remoteApi<DeviceInfo, void>('connect-device')

--- a/packages/neuron-ui/src/services/remote/remoteApiWrapper.ts
+++ b/packages/neuron-ui/src/services/remote/remoteApiWrapper.ts
@@ -132,7 +132,6 @@ type Action =
   // Hardware Wallet
   | 'detect-device'
   | 'get-device-ckb-app-version'
-  | 'get-device-firmware-version'
   | 'get-device-public-key'
   | 'get-device-extended-public-key'
   | 'connect-device'

--- a/packages/neuron-wallet/package.json
+++ b/packages/neuron-wallet/package.json
@@ -3,7 +3,7 @@
   "productName": "Neuron",
   "description": "CKB Neuron Wallet",
   "homepage": "https://www.nervos.org/",
-  "version": "0.116.1",
+  "version": "0.116.2",
   "private": true,
   "author": {
     "name": "Nervos Core Dev",
@@ -97,7 +97,7 @@
     "electron-builder": "24.9.1",
     "electron-devtools-installer": "3.2.0",
     "jest-when": "3.6.0",
-    "neuron-ui": "0.116.1",
+    "neuron-ui": "0.116.2",
     "typescript": "5.3.3"
   }
 }

--- a/packages/neuron-wallet/src/controllers/api.ts
+++ b/packages/neuron-wallet/src/controllers/api.ts
@@ -836,10 +836,6 @@ export default class ApiController {
       return this.#hardwareController.getCkbAppVersion()
     })
 
-    handle('get-device-firmware-version', async () => {
-      return this.#hardwareController.getFirmwareVersion()
-    })
-
     handle('get-device-extended-public-key', async () => {
       return this.#hardwareController.getExtendedPublicKey()
     })

--- a/packages/neuron-wallet/src/controllers/hardware.ts
+++ b/packages/neuron-wallet/src/controllers/hardware.ts
@@ -38,16 +38,6 @@ export default class HardwareController {
     }
   }
 
-  public async getFirmwareVersion(): Promise<Controller.Response<string>> {
-    const device = HardwareWalletService.getInstance().getCurrent()!
-    const version = await device.getFirmwareVersion?.()
-
-    return {
-      status: ResponseCode.Success,
-      result: version,
-    }
-  }
-
   public async getExtendedPublicKey(): Promise<Controller.Response<ExtendedPublicKey>> {
     const device = HardwareWalletService.getInstance().getCurrent()!
     const pubkey = await device.getExtendedPublicKey()

--- a/packages/neuron-wallet/src/services/hardware/hardware.ts
+++ b/packages/neuron-wallet/src/services/hardware/hardware.ts
@@ -140,7 +140,6 @@ export abstract class Hardware {
   public abstract signMessage(path: string, messageHex: string): Promise<string>
   public abstract disconnect(): Promise<void>
   public abstract getAppVersion(): Promise<string>
-  public abstract getFirmwareVersion?(): Promise<string>
   public abstract signTransaction(
     walletID: string,
     tx: Transaction,

--- a/packages/neuron-wallet/src/services/hardware/ledger.ts
+++ b/packages/neuron-wallet/src/services/hardware/ledger.ts
@@ -104,16 +104,6 @@ export default class Ledger extends Hardware {
     return conf!.version
   }
 
-  async getFirmwareVersion(): Promise<string> {
-    const res: Buffer = await this.transport!.send(0xe0, 0x01, 0x00, 0x00)!
-    const byteArray = [...res]
-    const data = byteArray.slice(0, byteArray.length - 2)
-    const versionLength = data[4]
-    const version = Buffer.from(data.slice(5, 5 + versionLength)).toString()
-
-    return version
-  }
-
   async getPublicKey(path: string) {
     const networkService = NetworksService.getInstance()
     const isTestnet = !networkService.isMainnet()


### PR DESCRIPTION
# 0.116.2 (2024-05-29)

### CKB Node & Light Client

- [CKB@v0.116.1](https://github.com/nervosnetwork/ckb/releases/tag/v0.116.1) was released on May. 11st, 2024. This version of CKB node is now bundled and preconfigured in Neuron.
- [CKB Light Client@v0.3.7](https://github.com/nervosnetwork/ckb-light-client/releases/tag/v0.3.7) was released on Apr. 13th, 2024. This version of CKB Light Client is now bundled and preconfigured in Neuron

### Assumed valid target

Block before `0x6dd077b407d019a0bce0cbad8c34e69a524ae4b2599b9feda2c7491f3559d32c`(at height `13,007,704`) will be skipped in validation.(https://github.com/nervosnetwork/neuron/pull/3157)

---

## Bug fixes

- 3179: Remove the display of the ledger firmware version because it causes the Nervos app to crash on the ledger device.(@yanguoyu)

**Full Changelog**: https://github.com/nervosnetwork/neuron/compare/v0.116.1...v0.116.2
…mware version (#3179)