### PR TITLE
fix: Dev network show mistake sync status

### DIFF
--- a/packages/neuron-wallet/src/controllers/sync-api.ts
+++ b/packages/neuron-wallet/src/controllers/sync-api.ts
@@ -108,8 +108,12 @@ export default class SyncApiController {
     const rpcService = new RpcService(network.remote, network.type)
     try {
       const syncState = await rpcService.getSyncState()
+      let bestKnownBlockNumber = parseInt(syncState.bestKnownBlockNumber, 16)
+      if (network.chain === 'ckb_dev') {
+        bestKnownBlockNumber = parseInt(await rpcService.getTipBlockNumber(), 16)
+      }
       return {
-        bestKnownBlockNumber: parseInt(syncState.bestKnownBlockNumber, 16),
+        bestKnownBlockNumber,
         bestKnownBlockTimestamp: +syncState.bestKnownBlockTimestamp,
       }
     } catch (error) {


### PR DESCRIPTION
issue: https://github.com/Magickbase/neuron-public-issues/issues/359

> https://github.com/nervosnetwork/ckb/issues/4472
> 
> `sync state` only init with local on start, and will update on sync with other node, never with self mined. dev node never has network communicate.

 If it is a devnet node, set `tip_number` to `best_known_block_number` to avoid showing sync failure.

