### PR TITLE
fix: Skip package if the last commit is after the comment

### DIFF
--- a/.github/workflows/package_for_test.yml
+++ b/.github/workflows/package_for_test.yml
@@ -46,6 +46,37 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.issue.number }}/merge
 
+      - name: Ensure no more commits after the triggering comment
+        uses: actions/github-script@v7
+        if: ${{ github.event_name == 'issue_comment' }}
+        env:
+          ISSUE_NUMBER: ${{github.event.issue.number}}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        with:
+          script: |
+            const { ISSUE_NUMBER, COMMENT_ID } = process.env
+            let page = 1
+            let hasFoundComment = false
+            while(true) {
+              const { data: timelines } = await github.rest.issues.listEventsForTimeline({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: ISSUE_NUMBER,
+                page,
+                per_page: 100,
+              })
+              if (timelines.some(v => {
+                hasFoundComment = hasFoundComment || (v.event === 'commented' && `${v.id}` === `${COMMENT_ID}`)
+                return hasFoundComment && v.event === 'committed'
+              })) {
+                throw new Error('The last commit comes after the comment, please comment and package after last commit')
+              }
+              if (timelines.length === 0) {
+                return
+              }
+              page += 1
+            }
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
I am checking no commit after the trigger comment. If someone pushes a new commit, the package should be repacked again to include the latest commit.

https://github.com/yanguoyu/neuron/actions/runs/9484668688 is the failed example.
https://github.com/yanguoyu/neuron/actions/runs/9484691876 is the success example.