### PR TITLE
ci: bump github actions

### DIFF
--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Changed Files
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v44
         with:
           files: "packages/**/*.{js,cjs,mjs,jsx,ts,tsx,css,scss}"
 

--- a/.github/workflows/check_storybook.yml
+++ b/.github/workflows/check_storybook.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         node:
-          - 18.12.0
+          - 20.15.1
         os:
           - macos-latest
           - ubuntu-20.04

--- a/.github/workflows/merge_released_into_develop.yml
+++ b/.github/workflows/merge_released_into_develop.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Request
         uses: repo-sync/pull-request@v2
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         node:
-          - 18.12.0
+          - 20.15.1
         os:
           - macos-latest
           - ubuntu-20.04

--- a/.github/workflows/package_for_test.yml
+++ b/.github/workflows/package_for_test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         node:
-          - 18.12.0
+          - 20.15.1
         os:
           - macos-latest
           - ubuntu-20.04

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         node:
-          - 20.11.1
+          - 20.15.1
         os:
           - macos-latest
           - ubuntu-20.04

--- a/.github/workflows/update_ckb_client_versions.yml
+++ b/.github/workflows/update_ckb_client_versions.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.15.1
 
       - name: Update versions
         id: update_versions
@@ -37,7 +37,7 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Open PR to develop branch
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           title: Update ckb client versions
           commit-message: 'feat: update ckb client versions'

--- a/.github/workflows/update_neuron_compatible.yml
+++ b/.github/workflows/update_neuron_compatible.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 20.15.1
 
       - name: Update versions
         id: update_versions
@@ -40,7 +40,7 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Open PR to RC branch
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           title: Update Neuron compatibility table
           commit-message: 'feat: Update Neuron compatibility table'

--- a/.github/workflows/update_wallet_env.yml
+++ b/.github/workflows/update_wallet_env.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ startsWith(github.ref_name, 'rc/') }}
     steps:
       - name: Create Branch
-        uses: peterjgrainger/action-create-branch@v2.4.0
+        uses: peterjgrainger/action-create-branch@v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -25,11 +25,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: 'chore-update-wallet-env/${{github.ref_name}}'
-      
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.12.0
+          node-version: 20.15.1
 
       - name: Write env file
         run: |


### PR DESCRIPTION
1. set version of node.js 20.15.1
2. bump the followings
- tj-actions/changed-files
- actions/checkout
- peter-evans/create-pull-request
- peterjgrainger/action-create-branch

Ref: https://github.com/Magickbase/neuron-public-issues/issues/366