### PR TITLE
fix: Fix typo check for passin

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -3,6 +3,7 @@ thur = "thur"
 numer = "numer"
 HD = "HD"
 hd = "hd"
+passin = 'passin'
 
 # defined in database schema
 lastest = "lastest"


### PR DESCRIPTION
Add `passin` to extend-words for running typo check success