### PR TITLE
fix: remove CRs when inject environment variables 

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -106,7 +106,7 @@ jobs:
         # Inject LOG_ENCRYPTION_PUBLIC_KEY to encrypt sensitive log
       - name: Inject environment variables
         run: |
-          echo "\nLOG_ENCRYPTION_PUBLIC_KEY=${{ secrets.LOG_ENCRYPTION_PUBLIC_KEY }}\n" >> packages/neuron-wallet/.env
+          echo "LOG_ENCRYPTION_PUBLIC_KEY=${{ secrets.LOG_ENCRYPTION_PUBLIC_KEY }}" >> packages/neuron-wallet/.env
 
       - name: Package for MacOS
         if: matrix.os == 'macos-latest'


### PR DESCRIPTION
Injecting environment variables with `CR` makes the key mismatched.