### PR TITLE
fix: fix typo of February

### DIFF
--- a/packages/neuron-ui/src/locales/en.json
+++ b/packages/neuron-ui/src/locales/en.json
@@ -874,7 +874,7 @@
         "tag": "J"
       },
       "feb": {
-        "full": "Febrary",
+        "full": "February",
         "short": "Feb.",
         "tag": "F"
       },


### PR DESCRIPTION
Fix a typo that blocks other CI, e.g. https://github.com/nervosnetwork/neuron/actions/runs/11698582259/job/32579104301?pr=3250#step:3:43