### PR TITLE
ci: set proper permission for spam detection action

### DIFF
--- a/.github/workflows/spam-comment-detection.yaml
+++ b/.github/workflows/spam-comment-detection.yaml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types: [created, edited]
 
+permissions:
+  issues: write
+
 jobs:
   detect-spam:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The default permission of Neuron repo is read-only so the permission write should be specify explicitly