### PR TITLE
ci: refine ci for spam detection

### DIFF
--- a/.github/workflows/spam-comment-detection.yaml
+++ b/.github/workflows/spam-comment-detection.yaml
@@ -24,7 +24,7 @@ jobs:
             const issue_number = process.env.ISSUE_NUMBER
             const owner = process.env.REPO_OWNER
             const repo = process.env.REPO_NAME
-            const EXTERNAL_LINK_REGEXT = /https:\/\/(?!((\w+\.)?github\.com|github\.com|(\w+\.)?magickbase\.com|(\w+\.)?nervos\.org))/gi
+            const EXTERNAL_LINK_REGEXT = /https?:\/\/(?!((\w+\.)?github\.com|github\.com|(\w+\.)?magickbase\.com|(\w+\.)?nervos\.org))/gi
             if (spam_words.some(w => comment.includes(w))) {
               console.info(`Spam comment: ${comment}`)
               github.rest.issues.deleteComment({ owner, repo, comment_id })

--- a/.github/workflows/spam-comment-detection.yaml
+++ b/.github/workflows/spam-comment-detection.yaml
@@ -46,4 +46,4 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO_OWNER: ${{github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
-          SPAM_WORDS: ${{ github.secrets.SPAM_WORDS }}
+          SPAM_WORDS: ${{ secrets.SPAM_WORDS }}


### PR DESCRIPTION
1. fix the accessibility issue of secrets, `github.secrets` doesn't work when the permissions field is set
2. fix the regexp to include `http://` when checking if a link is external