### PR TITLE
feat: Add UI crash logs

### DIFF
--- a/packages/neuron-ui/src/components/ErrorBoundary/index.tsx
+++ b/packages/neuron-ui/src/components/ErrorBoundary/index.tsx
@@ -1,10 +1,18 @@
-import React, { Component } from 'react'
+import React, { Component, ErrorInfo } from 'react'
 import { Stack } from 'office-ui-fabric-react'
 import Spinner from 'widgets/Spinner'
 import { handleViewError } from 'services/remote'
 
-const handleError = (error: Error) => {
-  handleViewError(error.toString())
+const handleError = (error: Error, errorInfo?: ErrorInfo) => {
+  handleViewError(
+    JSON.stringify([
+      `UI crash: ${error.message}`,
+      {
+        stack: error.stack,
+        componentStack: errorInfo?.componentStack || 'N/A',
+      },
+    ])
+  )
   if (import.meta.env.MODE !== 'development') {
     window.location.reload()
   }
@@ -23,8 +31,8 @@ class ErrorBoundary extends Component<{ children: React.ReactChild }, { hasError
     return handleError(error)
   }
 
-  public componentDidCatch(error: Error) {
-    this.setState(handleError(error))
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    this.setState(handleError(error, errorInfo))
   }
 
   render() {

--- a/packages/neuron-ui/src/components/ErrorBoundary/index.tsx
+++ b/packages/neuron-ui/src/components/ErrorBoundary/index.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ErrorInfo } from 'react'
+import React, { Component, ErrorInfo, ReactNode } from 'react'
 import { Stack } from 'office-ui-fabric-react'
 import Spinner from 'widgets/Spinner'
 import { handleViewError } from 'services/remote'
@@ -16,11 +16,10 @@ const handleError = (error: Error, errorInfo?: ErrorInfo) => {
   if (import.meta.env.MODE !== 'development') {
     window.location.reload()
   }
-  return { hasError: true }
 }
 
-class ErrorBoundary extends Component<{ children: React.ReactChild }, { hasError: boolean }> {
-  constructor(props: { children: React.ReactChild }) {
+class ErrorBoundary extends Component<{ children: ReactNode }, { hasError: boolean }> {
+  constructor(props: { children: ReactNode }) {
     super(props)
     this.state = {
       hasError: false,
@@ -32,7 +31,8 @@ class ErrorBoundary extends Component<{ children: React.ReactChild }, { hasError
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    this.setState(handleError(error, errorInfo))
+    handleError(error, errorInfo)
+    this.setState({ hasError: true })
   }
 
   render() {

--- a/packages/neuron-wallet/src/controllers/api.ts
+++ b/packages/neuron-wallet/src/controllers/api.ts
@@ -284,7 +284,11 @@ export default class ApiController {
       if (env.isDevMode) {
         console.error(error)
       }
-      logger.error(JSON.parse(error))
+      try {
+        logger.error(JSON.parse(error))
+      } catch (e) {
+        logger.error(error)
+      }
     })
 
     handle('set-locale', async (_, locale: Locale) => {

--- a/packages/neuron-wallet/src/controllers/api.ts
+++ b/packages/neuron-wallet/src/controllers/api.ts
@@ -284,6 +284,7 @@ export default class ApiController {
       if (env.isDevMode) {
         console.error(error)
       }
+      logger.error(JSON.parse(error))
     })
 
     handle('set-locale', async (_, locale: Locale) => {


### PR DESCRIPTION
issue:

- https://github.com/Magickbase/neuron-public-issues/issues/436

```
[2025-03-12T05:22:49.106Z] [error] [
  "UI crash: Cannot destructure property 'status' of 'item' as it is null.",
  {
    stack: "TypeError: Cannot destructure property 'status' of 'item' as it is null.\n" +
      '    at TransactionType (http://localhost:3000/src/components/TransactionType/index.tsx:62:9)\n' +
      '    at renderWithHooks (http://localhost:3000/node_modules/.vite/deps/chunk-XKMW3FHY.js?v=249d37e2:19079:26)\n' +
      '    at mountIndeterminateComponent (http://localhost:3000/node_modules/.vite/deps/chunk-XKMW3FHY.js?v=249d37e2:21829:21)\n' +
      '    at beginWork (http://localhost:3000/node_modules/.vite/deps/chunk-XKMW3FHY.js?v=249d37e2:22810:22)\n' +
      '    at beginWork$1 (http://localhost:3000/node_modules/.vite/deps/chunk-XKMW3FHY.js?v=249d37e2:26654:22)\n' +
      '    at performUnitOfWork (http://localhost:3000/node_modules/.vite/deps/chunk-XKMW3FHY.js?v=249d37e2:26099:20)\n' +
      '    at workLoopSync (http://localhost:3000/node_modules/.vite/deps/chunk-XKMW3FHY.js?v=249d37e2:26038:13)\n' +
      '    at renderRootSync (http://localhost:3000/node_modules/.vite/deps/chunk-XKMW3FHY.js?v=249d37e2:26017:15)\n' +
      '    at recoverFromConcurrentError (http://localhost:3000/node_modules/.vite/deps/chunk-XKMW3FHY.js?v=249d37e2:25634:28)\n' +
      '    at performConcurrentWorkOnRoot (http://localhost:3000/node_modules/.vite/deps/chunk-XKMW3FHY.js?v=249d37e2:25582:30)',
    componentStack: '\n' +
      '    at TransactionType (http://localhost:3000/src/components/TransactionType/index.tsx:54:3)\n' +
      '    at td\n' +
      '    at tr\n' +
      '    at tbody\n' +
      '    at table\n' +
      '    at div\n' +
      '    at Table (http://localhost:3000/src/widgets/Table/index.tsx:39:5)\n' +
      '    at div\n' +
      '    at div\n' +
      '    at div\n' +
      '    at PageContainer (http://localhost:3000/src/components/PageContainer/index.tsx:72:7)\n' +
      '    at History (http://localhost:3000/src/components/History/index.tsx?t=1741756769124:60:7)\n' +
      '    at RenderedRoute (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=249d37e2:3537:5)\n' +
      '    at RenderedRoute (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=249d37e2:3537:5)\n' +
      '    at Outlet (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=249d37e2:3907:26)\n' +
      '    at div\n' +
      '    at MainContent (http://localhost:3000/src/containers/Main/index.tsx:46:20)\n' +
      '    at LockWindow (http://localhost:3000/src/containers/LockWindow/index.tsx:55:23)\n' +
      '    at RenderedRoute (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=249d37e2:3537:5)\n' +
      '    at RouterRender (http://localhost:3000/src/index.tsx?t=1741756961145:40:10)\n' +
      '    at Router (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=249d37e2:3914:15)\n' +
      '    at HashRouter (http://localhost:3000/node_modules/.vite/deps/react-router-dom.js?v=249d37e2:4677:5)\n' +
      '    at Suspense\n' +
      '    at ErrorBoundary (http://localhost:3000/src/components/ErrorBoundary/index.tsx?t=1741756961145:35:5)\n' +
      '    at ComponentWithNeuronWallet\n' +
      '    at http://localhost:3000/src/states/stateProvider/provider.tsx:38:35'
  }
]
```