### PR TITLE
ci: bump node and runner in ci

### DIFF
--- a/.github/workflows/check_storybook.yml
+++ b/.github/workflows/check_storybook.yml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       matrix:
         node:
-          - 20.15.1
+          - lts/*
         os:
           - macos-latest
-          - ubuntu-20.04
+          - ubuntu-latest
           - windows-latest
 
     runs-on: ${{ matrix.os }}
@@ -42,11 +42,11 @@ jobs:
             */*/node_modules
           key: 2022-10-11-${{ runner.os }}-${{ hashFiles('**/yarn.lock')}}
 
-      - name: Install libudev
-        if: matrix.os == 'ubuntu-20.04'
+      - name: Install Linux Dependencies
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libudev-dev
+          sudo apt-get install -y libudev-dev libusb-1.0-0-dev
 
       - name: Install Lerna
         run: yarn global add lerna

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,11 +12,11 @@ jobs:
     strategy:
       matrix:
         node:
-          - 20.15.1
+          - lts/*
         os:
           - macos-latest
-          - ubuntu-20.04
-          - windows-2019
+          - ubuntu-latest
+          - windows-latest
 
     runs-on: ${{ matrix.os }}
 
@@ -88,11 +88,11 @@ jobs:
           smctl windows certsync
         shell: cmd
 
-      - name: Install libudev
-        if: matrix.os == 'ubuntu-20.04'
+      - name: Install Linux Dependencies
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libudev-dev
+          sudo apt-get install -y libudev-dev libusb-1.0-0-dev
 
       - name: Install Lerna
         run: yarn global add lerna

--- a/.github/workflows/package_for_test.yml
+++ b/.github/workflows/package_for_test.yml
@@ -12,11 +12,11 @@ jobs:
     strategy:
       matrix:
         node:
-          - 20.15.1
+          - lts/*
         os:
           - macos-latest
-          - ubuntu-20.04
-          - windows-2019
+          - ubuntu-latest
+          - windows-latest
 
     runs-on: ${{ matrix.os }}
 
@@ -130,11 +130,11 @@ jobs:
           smctl windows certsync
         shell: cmd
 
-      - name: Install libudev
-        if: matrix.os == 'ubuntu-20.04'
+      - name: Install Linux Dependencies
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libudev-dev
+          sudo apt-get install -y libudev-dev libusb-1.0-0-dev
 
       - name: Install Lerna
         run: yarn global add lerna

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       matrix:
         node:
-          - 20.15.1
+          - lts/*
         os:
           - macos-latest
-          - ubuntu-20.04
+          - ubuntu-latest
           - windows-latest
 
     runs-on: ${{ matrix.os }}
@@ -42,11 +42,11 @@ jobs:
             */*/node_modules
           key: 2022-10-11-${{ runner.os }}-${{ hashFiles('**/yarn.lock')}}
 
-      - name: Install libudev
-        if: matrix.os == 'ubuntu-20.04'
+      - name: Install Linux Dependencies
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libudev-dev
+          sudo apt-get install -y libudev-dev libusb-1.0-0-dev
 
       - name: Install Lerna
         run: yarn global add lerna

--- a/.github/workflows/update_ckb_client_versions.yml
+++ b/.github/workflows/update_ckb_client_versions.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.15.1
+          node-version: lts/*
 
       - name: Update versions
         id: update_versions

--- a/.github/workflows/update_neuron_compatible.yml
+++ b/.github/workflows/update_neuron_compatible.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.15.1
+          node-version: lts/*
 
       - name: Update versions
         id: update_versions

--- a/.github/workflows/update_wallet_env.yml
+++ b/.github/workflows/update_wallet_env.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20.15.1
+          node-version: lts/*
 
       - name: Write env file
         run: |


### PR DESCRIPTION
1. use lts node.js
2. use latest ubuntu
3. use latset windows

By doing so, exceptions in the latest runtime can be handled early