### PR TITLE
ci: use runner.os instead of matrix.os in platform conditions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -50,19 +50,19 @@ jobs:
           key: 2022-12-21-${{ runner.os }}-${{ hashFiles('**/yarn.lock')}}
 
       - name: Add msbuild to PATH
-        if: matrix.os == 'windows-2019'
+        if: runner.os == 'Windows'
         uses: microsoft/setup-msbuild@v2
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
 
       - name: Setup Certificate
-        if: matrix.os == 'windows-2019'
+        if: runner.os == 'Windows'
         run: |
           echo "${{ secrets.SM_CLIENT_CERT_FILE_BASE64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
         shell: bash
 
       - name: Set variables
-        if: matrix.os == 'windows-2019'
+        if: runner.os == 'Windows'
         run: |
           echo "SM_KEYPAIR_NAME=${{ secrets.SM_KEYPAIR_ALIAS }}" >> "$GITHUB_ENV"
           echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV"
@@ -75,7 +75,7 @@ jobs:
         shell: bash
 
       - name: Setting up the client tools
-        if: ${{ matrix.os == 'windows-2019' && env.SM_API_KEY != '' }}
+        if: ${{ runner.os == 'Windows' && env.SM_API_KEY != '' }}
         run: |
           curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
           msiexec /i smtools-windows-x64.msi /quiet /qn
@@ -83,7 +83,7 @@ jobs:
         shell: cmd
 
       - name: Certificates Sync
-        if: ${{ matrix.os == 'windows-2019' && env.SM_API_KEY != '' }}
+        if: ${{ runner.os == 'Windows' && env.SM_API_KEY != '' }}
         run: |
           smctl windows certsync
         shell: cmd
@@ -109,7 +109,7 @@ jobs:
           echo "LOG_ENCRYPTION_PUBLIC_KEY=${{ secrets.LOG_ENCRYPTION_PUBLIC_KEY }}" >> packages/neuron-wallet/.env
 
       - name: Package for MacOS
-        if: matrix.os == 'macos-latest'
+        if: runner.os == 'macOS'
         run: |
           ./scripts/download-ckb.sh mac
           yarn release mac
@@ -122,7 +122,7 @@ jobs:
           TEAM_ID: ${{ secrets.TEAM_ID }}
 
       - name: Package for Windows
-        if: matrix.os == 'windows-2019'
+        if: runner.os == 'Windows'
         run: |
           bash ./scripts/download-ckb.sh win
           yarn build
@@ -132,7 +132,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package for Linux
-        if: matrix.os == 'ubuntu-20.04'
+        if: runner.os == 'Linux'
         run: |
           ./scripts/download-ckb.sh
           yarn release linux
@@ -140,42 +140,42 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Neuron App Zip
-        if: matrix.os == 'macos-latest'
+        if: runner.os == 'macOS'
         uses: actions/upload-artifact@v4
         with:
           name: Neuron-Mac-x64
           path: release/Neuron-*-mac-x64.zip
 
       - name: Upload Neuron App Zip(arm64)
-        if: matrix.os == 'macos-latest'
+        if: runner.os == 'macOS'
         uses: actions/upload-artifact@v4
         with:
           name: Neuron-Mac-arm64
           path: release/Neuron-*-mac-arm64.zip
 
       - name: Upload Neuron Dmg
-        if: matrix.os == 'macos-latest'
+        if: runner.os == 'macOS'
         uses: actions/upload-artifact@v4
         with:
           name: Neuron-Dmg-x64
           path: release/Neuron-*-x64.dmg
 
       - name: Upload Neuron Dmg(arm64)
-        if: matrix.os == 'macos-latest'
+        if: runner.os == 'macOS'
         uses: actions/upload-artifact@v4
         with:
           name: Neuron-Dmg-arm64
           path: release/Neuron-*-arm64.dmg
 
       - name: Upload Neuron Win
-        if: matrix.os == 'windows-2019'
+        if: runner.os == 'Windows'
         uses: actions/upload-artifact@v4
         with:
           name: Neuron-Win
           path: release/Neuron-*-setup.exe
 
       - name: Upload Neuron Linux
-        if: matrix.os == 'ubuntu-20.04'
+        if: runner.os == 'Linux'
         uses: actions/upload-artifact@v4
         with:
           name: Neuron-Linux

--- a/.github/workflows/package_for_test.yml
+++ b/.github/workflows/package_for_test.yml
@@ -92,19 +92,19 @@ jobs:
           key: 2022-12-21-${{ runner.os }}-${{ hashFiles('**/yarn.lock')}}
 
       - name: Add msbuild to PATH
-        if: matrix.os == 'windows-2019'
+        if: runner.os == 'Windows'
         uses: microsoft/setup-msbuild@v2
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
 
       - name: Setup Certificate
-        if: matrix.os == 'windows-2019'
+        if: runner.os == 'Windows'
         run: |
           echo "${{ secrets.SM_CLIENT_CERT_FILE_BASE64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
         shell: bash
 
       - name: Set variables
-        if: matrix.os == 'windows-2019'
+        if: runner.os == 'Windows'
         run: |
           echo "SM_KEYPAIR_NAME=${{ secrets.SM_KEYPAIR_ALIAS }}" >> "$GITHUB_ENV"
           echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV"
@@ -117,7 +117,7 @@ jobs:
         shell: bash
 
       - name: Setting up the client tools
-        if: ${{ matrix.os == 'windows-2019' && env.SM_API_KEY != '' }}
+        if: ${{ runner.os == 'Windows' && env.SM_API_KEY != '' }}
         run: |
           curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
           msiexec /i smtools-windows-x64.msi /quiet /qn
@@ -125,7 +125,7 @@ jobs:
         shell: cmd
 
       - name: Certificates Sync
-        if: ${{ matrix.os == 'windows-2019' && env.SM_API_KEY != '' }}
+        if: ${{ runner.os == 'Windows' && env.SM_API_KEY != '' }}
         run: |
           smctl windows certsync
         shell: cmd
@@ -154,7 +154,7 @@ jobs:
             fs.writeFileSync(ympPath, fs.readFileSync(ympPath).toString().replace('asar: true', 'asar: false'))
 
       - name: Package for MacOS
-        if: ${{ matrix.os == 'macos-latest' && env.MAC_SHOULD_CODE_SIGN == 'true' }}
+        if: ${{ runner.os == 'macOS' && env.MAC_SHOULD_CODE_SIGN == 'true' }}
         run: |
           ./scripts/download-ckb.sh mac
           yarn package:test mac
@@ -168,7 +168,7 @@ jobs:
           USE_HARD_LINKS: false
 
       - name: Package for MacOS for skip code sign
-        if: ${{ matrix.os == 'macos-latest' && env.MAC_SHOULD_CODE_SIGN == 'false' }}
+        if: ${{ runner.os == 'macOS' && env.MAC_SHOULD_CODE_SIGN == 'false' }}
         run: |
           export CSC_IDENTITY_AUTO_DISCOVERY=false
           ./scripts/download-ckb.sh mac
@@ -179,7 +179,7 @@ jobs:
           USE_HARD_LINKS: false
 
       - name: Package for Windows
-        if: matrix.os == 'windows-2019'
+        if: runner.os == 'Windows'
         run: |
           bash ./scripts/download-ckb.sh win
           yarn build
@@ -189,7 +189,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package for Linux
-        if: matrix.os == 'ubuntu-20.04'
+        if: runner.os == 'Linux'
         run: |
           ./scripts/download-ckb.sh
           yarn package:test linux
@@ -198,42 +198,42 @@ jobs:
           USE_HARD_LINKS: false
 
       - name: Upload Neuron App Zip
-        if: matrix.os == 'macos-latest'
+        if: runner.os == 'macOS'
         uses: actions/upload-artifact@v4
         with:
           name: Neuron-Mac-x64
           path: release/Neuron-*-mac-x64.zip
 
       - name: Upload Neuron App Zip(arm64)
-        if: matrix.os == 'macos-latest'
+        if: runner.os == 'macOS'
         uses: actions/upload-artifact@v4
         with:
           name: Neuron-Mac-arm64
           path: release/Neuron-*-mac-arm64.zip
 
       - name: Upload Neuron Dmg
-        if: matrix.os == 'macos-latest'
+        if: runner.os == 'macOS'
         uses: actions/upload-artifact@v4
         with:
           name: Neuron-Dmg-x64
           path: release/Neuron-*-x64.dmg
 
       - name: Upload Neuron Dmg(arm64)
-        if: matrix.os == 'macos-latest'
+        if: runner.os == 'macOS'
         uses: actions/upload-artifact@v4
         with:
           name: Neuron-Dmg-arm64
           path: release/Neuron-*-arm64.dmg
 
       - name: Upload Neuron Win
-        if: matrix.os == 'windows-2019'
+        if: runner.os == 'Windows'
         uses: actions/upload-artifact@v4
         with:
           name: Neuron-Win
           path: release/Neuron-*-setup.exe
 
       - name: Upload Neuron Linux
-        if: matrix.os == 'ubuntu-20.04'
+        if: runner.os == 'Linux'
         uses: actions/upload-artifact@v4
         with:
           name: Neuron-Linux


### PR DESCRIPTION
runner.os is more general than matrix.os for platform detection