### PR TITLE
chore: update duration of copyright

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2024 Nervos Foundation
+Copyright (c) 2019-2025 Nervos Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/neuron-wallet/electron-builder.yml
+++ b/packages/neuron-wallet/electron-builder.yml
@@ -1,5 +1,5 @@
 appId: com.nervos.neuron
-copyright: Copyright (C) 2019-2024 Nervos Foundation.
+copyright: Copyright (C) 2019-2025 Nervos Foundation.
 productName: Neuron
 
 # This property will replace to false in package for test action


### PR DESCRIPTION
Update copyright duration from 2019-2024 to 2019-2025