### PR TITLE
ci: disable notarization of electron builder

### DIFF
--- a/packages/neuron-wallet/electron-builder.yml
+++ b/packages/neuron-wallet/electron-builder.yml
@@ -79,6 +79,7 @@ mac:
       arch:
         - arm64
         - x64
+  notarize: false # https://github.com/electron/notarize/issues/163#issuecomment-1726106735
 
 linux:
   artifactName: "${productName}-v${version}-${arch}.${ext}"


### PR DESCRIPTION
disable notarization of electron builder explicitly to
avoid unintentionally double notarization.

ref: https://github.com/electron/notarize/issues/163#issuecomment-1726106735