### PR TITLE
feat: add CKB dependency check and dialog for Visual C++ Redistributable

### DIFF
--- a/packages/neuron-wallet/src/controllers/app/subscribe.ts
+++ b/packages/neuron-wallet/src/controllers/app/subscribe.ts
@@ -17,6 +17,8 @@ import startMonitor, { stopMonitor } from '../../services/monitor'
 import { clearCkbNodeCache } from '../../services/ckb-runner'
 import ShowGlobalDialogSubject from '../../models/subjects/show-global-dialog'
 import NoDiskSpaceSubject from '../../models/subjects/no-disk-space'
+import CkbDependencySubject from '../../models/subjects/ckb-dependency'
+import { showCkbDependencyDialog } from '../../utils/ckb-dependency-dialog'
 
 interface AppResponder {
   sendMessage: (channel: string, arg: any) => void
@@ -24,6 +26,8 @@ interface AppResponder {
   updateMenu: () => void
   updateWindowTitle: () => void
 }
+
+let isShowingCkbDependencyDialog = false
 
 /**
  * subscribe to events and dispatch them to the renderer process
@@ -126,5 +130,18 @@ export const subscribe = (dispatcher: AppResponder) => {
   NoDiskSpaceSubject.subscribe(params => {
     stopMonitor()
     dispatcher.sendMessage('no-disk-space', params)
+  })
+
+  CkbDependencySubject.subscribe(async () => {
+    if (isShowingCkbDependencyDialog) {
+      return
+    }
+    isShowingCkbDependencyDialog = true
+    try {
+      stopMonitor('ckb')
+      await showCkbDependencyDialog()
+    } finally {
+      isShowingCkbDependencyDialog = false
+    }
   })
 }

--- a/packages/neuron-wallet/src/locales/en.ts
+++ b/packages/neuron-wallet/src/locales/en.ts
@@ -181,7 +181,7 @@ export default {
       'ckb-dependency': {
         title: 'Bundled CKB Node',
         message: 'Dependency Required',
-        detail: `The network nodes in Neuron rely on C++ components, so please install the latest version of Microsoft Visual C++Redistributable for x64 to ensure that the software runs properly.`,
+        detail: `The bundled CKB node in Neuron requires the latest Microsoft Visual C++ Redistributable for x64. The installed version is missing or too old, so please install the latest version to ensure that the software runs properly.`,
         buttons: {
           'install-and-exit': 'Install and Exit',
         },

--- a/packages/neuron-wallet/src/locales/zh.ts
+++ b/packages/neuron-wallet/src/locales/zh.ts
@@ -170,7 +170,7 @@ export default {
         title: '内置 CKB 节点',
         message: '缺少必要的依赖',
         detail:
-          'Neuron 中的网络节点依赖C++组件,请安装 x64 最新版本的 Microsoft Visual C++Redistributable 来保证软件正常运行。',
+          'Neuron 的内置 CKB 节点需要最新 x64 版本的 Microsoft Visual C++ Redistributable。当前版本缺失或过旧，请安装最新版以保证软件正常运行。',
         buttons: {
           'install-and-exit': '安装并退出',
         },

--- a/packages/neuron-wallet/src/models/subjects/ckb-dependency.ts
+++ b/packages/neuron-wallet/src/models/subjects/ckb-dependency.ts
@@ -1,0 +1,5 @@
+import { Subject } from 'rxjs'
+
+const CkbDependencySubject = new Subject<void>()
+
+export default CkbDependencySubject

--- a/packages/neuron-wallet/src/services/ckb-runner.ts
+++ b/packages/neuron-wallet/src/services/ckb-runner.ts
@@ -12,6 +12,7 @@ import { getUsablePort } from '../utils/get-usable-port'
 import { updateToml } from '../utils/toml'
 import { BUNDLED_URL_PREFIX } from '../utils/const'
 import NoDiskSpaceSubject from '../models/subjects/no-disk-space'
+import CkbDependencySubject from '../models/subjects/ckb-dependency'
 
 const platform = (): string => {
   switch (process.platform) {
@@ -29,6 +30,10 @@ const platform = (): string => {
 enum NeedMigrateMsg {
   Wants = 'CKB wants to migrate the data into new format',
   Recommends = 'CKB recommends migrating your data into a new format',
+}
+
+export const isVcredistVersionError = (message: string) => {
+  return /(?:VC\+\+|Visual C\+\+) Redistributable/i.test(message) && /Version is below|download\/upgrade/i.test(message)
 }
 
 const { app } = env
@@ -131,6 +136,9 @@ export const startCkbNode = async () => {
     logger.error('CKB:\trun fail:', dataString)
     if (dataString.includes(NeedMigrateMsg.Wants) || dataString.includes(NeedMigrateMsg.Recommends)) {
       MigrateSubject.next({ type: 'need-migrate' })
+    }
+    if (isVcredistVersionError(dataString)) {
+      CkbDependencySubject.next()
     }
   })
   currentProcess.stdout?.on('data', data => {

--- a/packages/neuron-wallet/src/services/node.ts
+++ b/packages/neuron-wallet/src/services/node.ts
@@ -1,11 +1,9 @@
 import fs from 'fs'
 import path from 'path'
 import { BI } from '@ckb-lumos/lumos'
-import { app as electronApp, dialog, shell, app } from 'electron'
-import { t } from 'i18next'
+import { app as electronApp, app } from 'electron'
 import { interval, BehaviorSubject, merge, Subject } from 'rxjs'
 import { distinctUntilChanged, sampleTime, flatMap, delay, retry, debounceTime } from 'rxjs/operators'
-import env from '../env'
 import { ConnectionStatusSubject } from '../models/subjects/node'
 import { CurrentNetworkIDSubject } from '../models/subjects/networks'
 import { NetworkType } from '../models/network'
@@ -17,6 +15,7 @@ import logger from '../utils/logger'
 import redistCheck from '../utils/redist-check'
 import { rpcRequest } from '../utils/rpc-request'
 import { generateRPC } from '../utils/ckb-rpc'
+import { showCkbDependencyDialog } from '../utils/ckb-dependency-dialog'
 import startMonitor, { stopMonitor } from './monitor'
 import { CKBLightRunner } from './light-runner'
 import SettingsService from './settings'
@@ -211,24 +210,7 @@ class NodeService {
   }
 
   private showGuideDialog = () => {
-    const I18N_PATH = `messageBox.ckb-dependency`
-    return dialog
-      .showMessageBox({
-        type: 'info',
-        buttons: ['install-and-exit'].map(label => t(`${I18N_PATH}.buttons.${label}`)),
-        defaultId: 0,
-        title: t(`${I18N_PATH}.title`),
-        message: t(`${I18N_PATH}.message`),
-        detail: t(`${I18N_PATH}.detail`),
-        cancelId: 0,
-        noLink: true,
-      })
-      .then(() => {
-        const VC_REDIST_URL = `https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170`
-        shell.openExternal(VC_REDIST_URL)
-        env.app.quit()
-        return false
-      })
+    return showCkbDependencyDialog()
   }
 
   private getInternalNodeVersion(type: CKBNodeType) {

--- a/packages/neuron-wallet/src/utils/ckb-dependency-dialog.ts
+++ b/packages/neuron-wallet/src/utils/ckb-dependency-dialog.ts
@@ -1,0 +1,26 @@
+import { dialog, shell } from 'electron'
+import { t } from 'i18next'
+
+import env from '../env'
+
+export const VC_REDIST_URL = 'https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170'
+
+export const showCkbDependencyDialog = () => {
+  const I18N_PATH = `messageBox.ckb-dependency`
+  return dialog
+    .showMessageBox({
+      type: 'info',
+      buttons: ['install-and-exit'].map(label => t(`${I18N_PATH}.buttons.${label}`)),
+      defaultId: 0,
+      title: t(`${I18N_PATH}.title`),
+      message: t(`${I18N_PATH}.message`),
+      detail: t(`${I18N_PATH}.detail`),
+      cancelId: 0,
+      noLink: true,
+    })
+    .then(() => {
+      shell.openExternal(VC_REDIST_URL)
+      env.app.quit()
+      return false
+    })
+}

--- a/packages/neuron-wallet/src/utils/redist-check.ts
+++ b/packages/neuron-wallet/src/utils/redist-check.ts
@@ -22,7 +22,7 @@ const redistCheck = async () => {
             logger.error(`${query} stderr: ${stderr}`)
             return false
           }
-          return !!stdout
+          return isSupportedRedist(stdout)
         })
         .catch(err => {
           logger.error(err)
@@ -31,6 +31,38 @@ const redistCheck = async () => {
     )
   )
   return vcredists.includes(true)
+}
+
+export const MINIMUM_REDIST_VERSION = '14.44.0.0'
+
+export const getRedistVersion = (stdout?: string | null) => {
+  return stdout
+    ?.split(/\r?\n/)
+    .find(line => /\bVersion\b/i.test(line))
+    ?.match(/v?(\d+(?:\.\d+)+)/i)?.[1]
+}
+
+export const compareVersions = (version: string, minimumVersion: string) => {
+  const versionParts = version.split('.').map(Number)
+  const minimumVersionParts = minimumVersion.split('.').map(Number)
+  const length = Math.max(versionParts.length, minimumVersionParts.length)
+  for (let idx = 0; idx < length; idx++) {
+    const current = versionParts[idx] ?? 0
+    const minimum = minimumVersionParts[idx] ?? 0
+    if (current > minimum) {
+      return 1
+    }
+    if (current < minimum) {
+      return -1
+    }
+  }
+  return 0
+}
+
+export const isSupportedRedist = (stdout?: string | null) => {
+  const installed = !/\bInstalled\s+REG_DWORD\s+0x0\b/i.test(stdout ?? '')
+  const version = getRedistVersion(stdout)
+  return installed && !!version && compareVersions(version, MINIMUM_REDIST_VERSION) >= 0
 }
 
 export default redistCheck

--- a/packages/neuron-wallet/tests/services/ckb-runner.test.ts
+++ b/packages/neuron-wallet/tests/services/ckb-runner.test.ts
@@ -11,6 +11,7 @@ const stubbedLoggerLog = jest.fn()
 const resetSyncTaskQueueAsyncPushMock = jest.fn()
 const updateTomlMock = jest.fn()
 const getUsablePortMock = jest.fn()
+const mockCkbDependencyNext = jest.fn()
 
 const stubbedProcess: any = {}
 
@@ -24,6 +25,7 @@ const resetMocks = () => {
   resetSyncTaskQueueAsyncPushMock.mockReset()
   updateTomlMock.mockReset()
   getUsablePortMock.mockReset()
+  mockCkbDependencyNext.mockReset()
 }
 
 jest.doMock('child_process', () => {
@@ -91,7 +93,16 @@ jest.doMock('../../src/utils/toml', () => ({
 jest.doMock('../../src/utils/get-usable-port', () => ({
   getUsablePort: getUsablePortMock,
 }))
-const { startCkbNode, stopCkbNode, migrateCkbData, getNodeUrl } = require('../../src/services/ckb-runner')
+jest.mock('../../src/models/subjects/ckb-dependency', () => ({
+  next: mockCkbDependencyNext,
+}))
+const {
+  startCkbNode,
+  stopCkbNode,
+  migrateCkbData,
+  getNodeUrl,
+  isVcredistVersionError,
+} = require('../../src/services/ckb-runner')
 
 describe('ckb runner', () => {
   let stubbedCkb: any = new EventEmitter()
@@ -140,6 +151,16 @@ describe('ckb runner', () => {
             ['run', '-C', ckbDataPath, '--indexer'],
             { stdio: ['ignore', 'pipe', 'pipe'] }
           )
+        })
+
+        it('notifies when ckb reports an outdated Visual C++ Redistributable', () => {
+          stubbedCkb.stderr.emit(
+            'data',
+            Buffer.from(
+              'Detected VC++ Redistributable version (x64): v14.29.30133.00\nVersion is below 14.44.0.0. Please download/upgrade the Visual C++ Redistributable.'
+            )
+          )
+          expect(mockCkbDependencyNext).toHaveBeenCalled()
         })
       })
 
@@ -236,6 +257,19 @@ describe('ckb runner', () => {
         stubbedCkb.emit('close')
         await promise
       })
+    })
+  })
+  describe('#isVcredistVersionError', () => {
+    it('detects the bundled ckb Visual C++ Redistributable version error', () => {
+      expect(
+        isVcredistVersionError(
+          'Detected VC++ Redistributable version (x64): v14.29.30133.00\nVersion is below 14.44.0.0. Please download/upgrade the Visual C++ Redistributable.'
+        )
+      ).toBe(true)
+    })
+
+    it('ignores unrelated ckb stderr', () => {
+      expect(isVcredistVersionError('CKB wants to migrate the data into new format')).toBe(false)
     })
   })
   describe('#stopCkbNode', () => {

--- a/packages/neuron-wallet/tests/services/node.test.ts
+++ b/packages/neuron-wallet/tests/services/node.test.ts
@@ -31,6 +31,7 @@ describe('NodeService', () => {
   const pathJoinMock = jest.fn()
   const redistCheckMock = jest.fn()
   const isFirstSyncMock = jest.fn()
+  const showCkbDependencyDialogMock = jest.fn()
 
   const fakeHTTPUrl = 'http://fakeurl'
 
@@ -59,6 +60,7 @@ describe('NodeService', () => {
     pathJoinMock.mockReset()
     redistCheckMock.mockReset()
     isFirstSyncMock.mockReset()
+    showCkbDependencyDialogMock.mockReset()
   }
 
   beforeEach(() => {
@@ -183,6 +185,10 @@ describe('NodeService', () => {
     }))
 
     jest.doMock('utils/redist-check', () => redistCheckMock)
+
+    jest.doMock('utils/ckb-dependency-dialog', () => ({
+      showCkbDependencyDialog: showCkbDependencyDialogMock,
+    }))
 
     jest.doMock('services/settings', () => ({
       getInstance() {
@@ -594,6 +600,16 @@ describe('NodeService', () => {
       expect(stubbedLoggerInfo).toBeCalledWith(
         `CKB:\texternal RPC on default uri not detected, starting bundled CKB node.`
       )
+    })
+    it('shows the CKB dependency dialog when vcredist is missing or outdated', async () => {
+      isFirstSyncMock.mockReturnValue(false)
+      redistCheckMock.mockResolvedValue(false)
+      showCkbDependencyDialogMock.mockResolvedValue(false)
+
+      await nodeService.tryStartNodeOnDefaultURI()
+
+      expect(showCkbDependencyDialogMock).toHaveBeenCalled()
+      expect(stubbedStartCKBNode).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/neuron-wallet/tests/utils/redist-check/index.test.ts
+++ b/packages/neuron-wallet/tests/utils/redist-check/index.test.ts
@@ -1,59 +1,122 @@
-import redistCheck from '../../../src/utils/redist-check'
+const mockExecPromise = jest.fn()
 
-let originalPlatform: string
-
-type ExecPromiseResult = Promise<{ stdout?: null | string; stderr?: null | string }>
-type ExecFunc = () => ExecPromiseResult
 jest.mock('util', () => ({
-  promisify: jest
-    .fn<ExecFunc, any>(() => () => Promise.resolve({ stdout: 'success' }))
-    .mockImplementationOnce(() => () => Promise.resolve({ stdout: 'success' }))
-    .mockImplementationOnce(() => () => Promise.resolve({ stdout: null, stderr: 'err' }))
-    .mockImplementationOnce(() => () => Promise.reject({ stdout: null, stderr: 'err' })),
+  promisify: jest.fn(() => mockExecPromise),
 }))
 jest.mock('utils/logger', () => console)
 
+import redistCheck, {
+  compareVersions,
+  getRedistVersion,
+  isSupportedRedist,
+  MINIMUM_REDIST_VERSION,
+} from '../../../src/utils/redist-check'
+
+let originalPlatform: string
+
+const setPlatform = (platform: string) => {
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+  })
+}
+
+const registryOutput = (version: string, installed = '0x1') => `
+HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\VisualStudio\\14.0\\VC\\Runtimes\\x64
+    Installed    REG_DWORD    ${installed}
+    Version      REG_SZ       v${version}
+`
+
 describe('redist check', () => {
-  describe('win32', () => {
-    beforeAll(function () {
-      originalPlatform = process.platform
-      Object.defineProperty(process, 'platform', {
-        value: 'win32',
-      })
+  beforeAll(() => {
+    originalPlatform = process.platform
+  })
+
+  afterAll(() => {
+    setPlatform(originalPlatform)
+  })
+
+  beforeEach(() => {
+    mockExecPromise.mockReset()
+  })
+
+  describe('version helpers', () => {
+    it('parses the redist version from registry output', () => {
+      expect(getRedistVersion(registryOutput('14.44.35208.0'))).toBe('14.44.35208.0')
     })
-    it('true', async () => {
-      const redistStatus = await redistCheck()
-      expect(redistStatus).toBe(true)
+
+    it('compares version parts numerically', () => {
+      expect(compareVersions('14.44.0.0', MINIMUM_REDIST_VERSION)).toBe(0)
+      expect(compareVersions('14.44.1.0', MINIMUM_REDIST_VERSION)).toBe(1)
+      expect(compareVersions('14.29.30133.0', MINIMUM_REDIST_VERSION)).toBe(-1)
     })
-    it('false', async () => {
-      const redistStatus = await redistCheck()
-      expect(redistStatus).toBe(false)
-    })
-    it('false with reject', async () => {
-      const redistStatus = await redistCheck()
-      expect(redistStatus).toBe(false)
-    })
-    afterAll(function () {
-      Object.defineProperty(process, 'platform', {
-        value: originalPlatform,
-      })
+
+    it('requires an installed runtime at or above the minimum version', () => {
+      expect(isSupportedRedist(registryOutput('14.44.0.0'))).toBe(true)
+      expect(isSupportedRedist(registryOutput('14.29.30133.0'))).toBe(false)
+      expect(isSupportedRedist(registryOutput('14.44.0.0', '0x0'))).toBe(false)
+      expect(isSupportedRedist('success')).toBe(false)
     })
   })
-  describe('not win32', () => {
-    beforeAll(function () {
-      originalPlatform = process.platform
-      Object.defineProperty(process, 'platform', {
-        value: 'darwin',
-      })
+
+  describe('win32', () => {
+    beforeEach(() => {
+      setPlatform('win32')
     })
-    it('true', async () => {
+
+    it('returns true when the x64 runtime is new enough', async () => {
+      mockExecPromise.mockResolvedValue({ stdout: registryOutput('14.44.0.0') })
+
       const redistStatus = await redistCheck()
+
       expect(redistStatus).toBe(true)
+      expect(mockExecPromise).toHaveBeenCalledWith(expect.stringContaining('VisualStudio'))
+      expect(mockExecPromise).toHaveBeenCalledWith(expect.stringContaining('Runtimes'))
+      expect(mockExecPromise).toHaveBeenCalledWith(expect.stringContaining('x64'))
     })
-    afterAll(function () {
-      Object.defineProperty(process, 'platform', {
-        value: originalPlatform,
-      })
+
+    it('returns false when the x64 runtime is too old', async () => {
+      mockExecPromise.mockResolvedValue({ stdout: registryOutput('14.29.30133.0') })
+
+      const redistStatus = await redistCheck()
+
+      expect(redistStatus).toBe(false)
+    })
+
+    it('returns false when the query does not include a version', async () => {
+      mockExecPromise.mockResolvedValue({ stdout: 'success' })
+
+      const redistStatus = await redistCheck()
+
+      expect(redistStatus).toBe(false)
+    })
+
+    it('returns false when the query writes to stderr', async () => {
+      mockExecPromise.mockResolvedValue({ stdout: null, stderr: 'err' })
+
+      const redistStatus = await redistCheck()
+
+      expect(redistStatus).toBe(false)
+    })
+
+    it('returns false when the query rejects', async () => {
+      mockExecPromise.mockRejectedValue({ stdout: null, stderr: 'err' })
+
+      const redistStatus = await redistCheck()
+
+      expect(redistStatus).toBe(false)
+    })
+  })
+
+  describe('not win32', () => {
+    beforeEach(() => {
+      setPlatform('darwin')
+    })
+
+    it('returns true without querying the registry', async () => {
+      const redistStatus = await redistCheck()
+
+      expect(redistStatus).toBe(true)
+      expect(mockExecPromise).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## Summary

Fix bundled CKB startup handling when Microsoft Visual C++ Redistributable is missing or outdated on Windows.

## Changes

- Check the installed x64 VC++ Redistributable version instead of only checking whether the registry key exists.
- Require VC++ Redistributable version `14.44.0.0` or newer.
- Show the existing CKB dependency dialog when bundled CKB reports a VC++ Redistributable version error at runtime.
- Update the dependency dialog copy to mention both missing and outdated runtimes.
- Add tests for version parsing, preflight checks, and runtime stderr detection.