### PR TITLE
chore(scripts): use portable Bash shebangs

### DIFF
--- a/scripts/copy-ui-files.sh
+++ b/scripts/copy-ui-files.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./node_modules/.bin/ncp ./packages/neuron-ui/build ./packages/neuron-wallet/dist/neuron-ui

--- a/scripts/download-ckb.sh
+++ b/scripts/download-ckb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CKB_VERSION=$(cat .ckb-version)
 CKB_LIGHT_VERSION=$(cat .ckb-light-version)

--- a/scripts/package-for-test.sh
+++ b/scripts/package-for-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function package() {
     case $1 in

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function release() {
     case $1 in


### PR DESCRIPTION
## Summary

- resolve Bash through `/usr/bin/env` in all executable project shell scripts
- avoid assuming Bash is installed at `/bin/bash`
- preserve existing script behavior and executable modes

## Testing

- `bash -n scripts/copy-ui-files.sh scripts/download-ckb.sh scripts/package-for-test.sh scripts/release.sh`
- verified no exact `#!/bin/bash` shebangs remain in the repository
- `git diff --check origin/develop...HEAD`
