### PR TITLE
fix(scripts): await release asset downloads

### DIFF
--- a/scripts/download-binaries-from-release-draft.js
+++ b/scripts/download-binaries-from-release-draft.js
@@ -25,7 +25,7 @@ const download = async (directory) => {
     .then((res) => res.json())
     .then((res) => res.map(({ name, url }) => ({ name, url })))
 
-  assetList.forEach(async ({ name, url }) => {
+  await Promise.all(assetList.map(async ({ name, url }) => {
     const path = `${directory}/${name}`
 
     await pipeline(
@@ -43,7 +43,7 @@ const download = async (directory) => {
 
       createWriteStream(path)
     )
-  })
+  }))
 }
 
 if (process.argv.length < 3) {
@@ -54,4 +54,7 @@ if (process.argv.length < 3) {
 
 const directory = process.argv[2]
 
-download(directory)
+download(directory).catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
The release-draft helper starts each asset pipeline inside `forEach(async ...)`, so `download()` resolves before the pipelines finish and download failures are detached from its promise.

This change awaits `Promise.all(assetList.map(...))` and handles the returned top-level promise by reporting the error and setting a non-zero exit code. The script now completes only after every asset has been written.

Validation: `node --check scripts/download-binaries-from-release-draft.js`.