### PR TITLE
test: correct SUDT parser test description

### DIFF
--- a/packages/neuron-wallet/tests/utils/parse_sudt_token_info/index.test.ts
+++ b/packages/neuron-wallet/tests/utils/parse_sudt_token_info/index.test.ts
@@ -1,7 +1,7 @@
 import parseSUDTTokenInfo from '../../../src/utils/parse_sudt_token_info'
 
 describe('parseSUDTTokenInfo', () => {
-  it('parse sudt token info should success', function () {
+  it('parse sudt token info should succeed', function () {
     const hexData = '0x080a456972632d320a455432'
     const { decimal, name, symbol } = parseSUDTTokenInfo(hexData)
     expect(decimal).toEqual('8')


### PR DESCRIPTION
Change the SUDT parser test description to “should succeed” so the expected outcome is explicit.