### PR TITLE
fix: retry full synchronization after polling errors

### DIFF
--- a/packages/neuron-wallet/src/block-sync-renderer/sync/full-synchronizer.ts
+++ b/packages/neuron-wallet/src/block-sync-renderer/sync/full-synchronizer.ts
@@ -30,12 +30,16 @@ export default class FullSynchronizer extends Synchronizer {
       await this.processNextBlockNumber()
 
       while (this.pollingIndexer) {
-        const indexerTipBlock = await this.indexer.tip()
-        await this.synchronize(indexerTipBlock)
+        try {
+          const indexerTipBlock = await this.indexer.tip()
+          await this.synchronize(indexerTipBlock)
+        } catch (error) {
+          logger.error(`Full synchronization iteration failed; retrying in 5 seconds: ${error.message}`)
+        }
         await CommonUtils.sleep(5000)
       }
     } catch (error) {
-      logger.error(`Error connecting to Indexer: ${error.message}`)
+      logger.error(`Failed to initialize full synchronization: ${error.message}`)
     }
   }
 

--- a/packages/neuron-wallet/tests/block-sync-renderer/full-synchronizer.test.ts
+++ b/packages/neuron-wallet/tests/block-sync-renderer/full-synchronizer.test.ts
@@ -338,10 +338,13 @@ describe('unit tests for IndexerConnector', () => {
             await connectIndexer(indexerConnector)
             await flushPromises()
           })
-          it('throws error', async () => {
+          it('logs the queue worker error', () => {
             expect(stubbedLoggerErrorFn).toHaveBeenCalledWith(
               'Connector: \tError in processing next block number queue: Error: exception'
             )
+          })
+          it('starts polling after the queue worker error', () => {
+            expect(stubbedTipFn).toHaveBeenCalledTimes(1)
           })
         })
       })
@@ -395,6 +398,46 @@ describe('unit tests for IndexerConnector', () => {
                 cacheTipNumber: parseInt(fakeBlock3.number),
                 indexerTipNumber: parseInt(fakeTip2.blockNumber),
               })
+            })
+          })
+        })
+      })
+      describe('when a polling iteration fails', () => {
+        const sqliteBusyError = new Error('SQLITE_BUSY: database is locked')
+        let tipObserver: any
+
+        beforeEach(async () => {
+          tipObserver = jest.fn()
+          indexerConnector.blockTipsSubject.subscribe(tip => {
+            tipObserver(tip)
+          })
+          stubbedTipFn.mockResolvedValue(fakeTip1)
+          stubbedUpsertTxHashesFn.mockRejectedValueOnce(sqliteBusyError).mockResolvedValue([])
+          stubbedNextUnprocessedTxsGroupedByBlockNumberFn.mockResolvedValue([])
+          stubbedNextUnprocessedBlock.mockResolvedValue(undefined)
+
+          await connectIndexer(indexerConnector)
+        })
+
+        it('logs the error without emitting a block tip', () => {
+          expect(stubbedLoggerErrorFn).toHaveBeenCalledWith(
+            'Full synchronization iteration failed; retrying in 5 seconds: SQLITE_BUSY: database is locked'
+          )
+          expect(tipObserver).toHaveBeenCalledTimes(0)
+        })
+
+        describe('after the polling interval', () => {
+          beforeEach(async () => {
+            jest.advanceTimersByTime(5000)
+            await flushPromises()
+          })
+
+          it('continues polling and emits the recovered block tip', () => {
+            expect(stubbedTipFn).toHaveBeenCalledTimes(2)
+            expect(tipObserver).toHaveBeenCalledTimes(1)
+            expect(tipObserver).toHaveBeenCalledWith({
+              cacheTipNumber: parseInt(fakeTip1.blockNumber),
+              indexerTipNumber: parseInt(fakeTip1.blockNumber),
             })
           })
         })


### PR DESCRIPTION
## Summary

- keep the full-node wallet synchronizer (`FullSynchronizer`) alive when one polling iteration fails
- wait for the existing five-second polling interval before retrying
- report the failure as a full-synchronization iteration error instead of an indexer connection error
- add a regression test covering recovery from a transient `SQLITE_BUSY` failure

Fixes #3508.

## Root cause

`FullSynchronizer.initSync()` previously wrapped the lifetime polling loop in a single `try/catch`. If `indexer.tip()` or the wallet-cache work in `synchronize()` threw, including a transient `SQLITE_BUSY` failure, control left the loop and the catch only logged the error. Because `connect()` starts `initSync()` in the background, the queue had already considered startup successful, so the existing `indexer-error` restart path was not reached.

This change catches errors around one polling iteration. A failed iteration is logged, the synchronizer waits five seconds, and the next iteration can continue. `connect()` remains non-blocking, so the queue can still install its block-tip and transaction subscriptions.

## Scope

This is a recovery fix for the permanently stopped polling loop. It does not remove the underlying SQLite contention, enable WAL, change `busy_timeout`, serialize database writers, or implement bounded/exponential retry. Persistent failures are not escalated to `indexer-error` or surfaced as an actionable UI error by this change. Those can be evaluated separately.

This change only affects `FullSynchronizer`. Transaction-status tracking and `LightSynchronizer` are unchanged, so `SQLITE_BUSY` warnings or pop-ups may still occur. The fix specifically prevents a transient error in the full-node polling path from leaving wallet synchronization permanently stopped.

## Testing

- `yarn workspace neuron-wallet test --runTestsByPath tests/block-sync-renderer/full-synchronizer.test.ts tests/block-sync-renderer/queue.test.ts --coverage=false` — 28 passed
- `yarn workspace neuron-wallet test --coverage=false` — 1,070 passed, 1 skipped
- `yarn workspace neuron-wallet build`
- Prettier and ESLint on both changed files
- Windows A/B regression check of the original recovery test, before the additional queue-start assertion:
  - previous loop implementation: 2 failed, 15 passed
  - this change: 17 passed
