### PR TITLE
ci: migrate GitHub Actions to Node.js 24 runtimes

### DIFF
--- a/.github/workflows/add-replied-label.yml
+++ b/.github/workflows/add-replied-label.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - id: check-access
         name: Check if the commenter is a collaborator
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             try{
@@ -30,7 +30,7 @@ jobs:
 
       - id: check-issue
         name: Check if the comment is replied in an issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const response = await github.rest.issues.get({
@@ -45,7 +45,7 @@ jobs:
       - id: add-label
         name: Add 'replied' label
         if: ${{ steps.check-access.outputs.result == 'true' && steps.check-issue.outputs.result == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.issues.addLabels({

--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -10,16 +10,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "yarn"
 
       - name: Restore
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -37,7 +37,7 @@ jobs:
 
       - name: Changed Files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           files: "packages/**/*.{js,cjs,mjs,jsx,ts,tsx,css,scss}"
 

--- a/.github/workflows/check-spell.yml
+++ b/.github/workflows/check-spell.yml
@@ -8,5 +8,5 @@ jobs:
     name: Check spell
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: crate-ci/typos@master

--- a/.github/workflows/check_checksums.yml
+++ b/.github/workflows/check_checksums.yml
@@ -14,7 +14,7 @@ jobs:
       actions: read # to read artifacts
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Generate checksums from artifacts
         run: ruby ./scripts/release-checksums.rb ${{ github.event.release.tag_name }} | tee generated_checksums.txt
@@ -36,6 +36,6 @@ jobs:
           body="${body//$'\r'/'%0D'}"
           echo "body=$body" >> $GITHUB_OUTPUT
 
-      - uses: peter-evans/commit-comment@v3
+      - uses: peter-evans/commit-comment@v4
         with:
           body: ${{ steps.comment_body.outputs.body }}

--- a/.github/workflows/check_storybook.yml
+++ b/.github/workflows/check_storybook.yml
@@ -26,16 +26,16 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: "yarn"
 
       - name: Restore
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules

--- a/.github/workflows/checksums-of-release-draft.yml
+++ b/.github/workflows/checksums-of-release-draft.yml
@@ -16,10 +16,10 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 'latest'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,4 +69,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,16 +17,16 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "yarn"
 
       - name: Restore
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report
           path: playwright-report
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload Playwright test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-test-results
           path: test-results/e2e

--- a/.github/workflows/merge_released_into_develop.yml
+++ b/.github/workflows/merge_released_into_develop.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Request
         uses: repo-sync/pull-request@v2
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -32,16 +32,16 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: "yarn"
 
       - name: Restore
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -50,7 +50,7 @@ jobs:
 
       - name: Add msbuild to PATH
         if: runner.os == 'Windows'
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
 
@@ -94,7 +94,7 @@ jobs:
       # Visual Studio detection when native modules (node-hid, etc.) are compiled.
       - name: Setup Java (required by CodeSignTool)
         if: runner.os == 'Windows'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "11"
@@ -206,42 +206,42 @@ jobs:
 
       - name: Upload Neuron App Zip
         if: runner.os == 'macOS'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Neuron-Mac-x64
           path: release/Neuron-*-mac-x64.zip
 
       - name: Upload Neuron App Zip(arm64)
         if: runner.os == 'macOS'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Neuron-Mac-arm64
           path: release/Neuron-*-mac-arm64.zip
 
       - name: Upload Neuron Dmg
         if: runner.os == 'macOS'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Neuron-Dmg-x64
           path: release/Neuron-*-x64.dmg
 
       - name: Upload Neuron Dmg(arm64)
         if: runner.os == 'macOS'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Neuron-Dmg-arm64
           path: release/Neuron-*-arm64.dmg
 
       - name: Upload Neuron Win
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Neuron-Win
           path: release/Neuron-*-setup.exe
 
       - name: Upload Neuron Linux
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Neuron-Linux
           path: release/Neuron-*.AppImage

--- a/.github/workflows/package_for_test.yml
+++ b/.github/workflows/package_for_test.yml
@@ -32,17 +32,17 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout for push
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         if: ${{ github.event_name == 'push' }}
 
       - name: Checkout for PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         if: ${{ github.event_name == 'issue_comment' }}
         with:
           ref: refs/pull/${{ github.event.issue.number }}/merge
 
       - name: Ensure no more commits after the triggering comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         if: ${{ github.event_name == 'issue_comment' }}
         env:
           ISSUE_NUMBER: ${{github.event.issue.number}}
@@ -73,13 +73,13 @@ jobs:
             }
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: "yarn"
 
       - name: Restore
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -88,7 +88,7 @@ jobs:
 
       - name: Add msbuild to PATH
         if: runner.os == 'Windows'
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
 
@@ -108,7 +108,7 @@ jobs:
           CI: false
 
       - name: Write electron-build Test yml
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('node:fs')
@@ -147,42 +147,42 @@ jobs:
 
       - name: Upload Neuron App Zip
         if: runner.os == 'macOS'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Neuron-Mac-x64
           path: release/Neuron-*-mac-x64.zip
 
       - name: Upload Neuron App Zip(arm64)
         if: runner.os == 'macOS'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Neuron-Mac-arm64
           path: release/Neuron-*-mac-arm64.zip
 
       - name: Upload Neuron Dmg
         if: runner.os == 'macOS'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Neuron-Dmg-x64
           path: release/Neuron-*-x64.dmg
 
       - name: Upload Neuron Dmg(arm64)
         if: runner.os == 'macOS'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Neuron-Dmg-arm64
           path: release/Neuron-*-arm64.dmg
 
       - name: Upload Neuron Win
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Neuron-Win
           path: release/Neuron-*-setup.exe
 
       - name: Upload Neuron Linux
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Neuron-Linux
           path: release/Neuron-*.AppImage
@@ -197,14 +197,14 @@ jobs:
     steps:
       - name: Comment by push event
         if: ${{ github.event_name == 'push' }}
-        uses: peter-evans/commit-comment@v3
+        uses: peter-evans/commit-comment@v4
         with:
           body: |
             Packaging for test is done in [${{ github.run_id }}](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
 
       - name: Comment by pull request comment event
         if: ${{ github.event_name == 'issue_comment' }}
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ github.event.comment.id }}
           body: |
@@ -221,7 +221,7 @@ jobs:
     steps:
       - name: Comment by pull request comment event when package failed
         if: ${{ github.event_name == 'issue_comment' }}
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ github.event.comment.id }}
           body: Packageing failed in [${{ github.run_id }}](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}). @${{ github.event.comment.user.login }}

--- a/.github/workflows/spam-comment-detection.yaml
+++ b/.github/workflows/spam-comment-detection.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Node.js
-        uses: actions/setup-node@main
+        uses: actions/setup-node@v6
 
       - name: Check for Spam
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const comment = process.env.COMMENT_BODY.toLowerCase()

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,16 +25,16 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: "yarn"
 
       - name: Restore
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules

--- a/.github/workflows/update-issue-status.yml
+++ b/.github/workflows/update-issue-status.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update stale issues
-        uses: actions/stale@v9
+        uses: actions/stale@v10
         with:
           any-of-issue-labels: replied
           stale-issue-label: stale

--- a/.github/workflows/update_ckb_client_versions.yml
+++ b/.github/workflows/update_ckb_client_versions.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 
@@ -29,7 +29,7 @@ jobs:
           git add .ckb-version .ckb-light-version compatible.json
 
       - name: Set GPG
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@v7
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -37,7 +37,7 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Open PR to develop branch
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           title: Update ckb client versions
           commit-message: 'feat: update ckb client versions'

--- a/.github/workflows/update_neuron_compatible.yml
+++ b/.github/workflows/update_neuron_compatible.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 
@@ -32,7 +32,7 @@ jobs:
           git add compatible.json
 
       - name: Set GPG
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@v7
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -40,7 +40,7 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Open PR to RC branch
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           title: Update Neuron compatibility table
           commit-message: 'feat: Update Neuron compatibility table'

--- a/.github/workflows/update_wallet_env.yml
+++ b/.github/workflows/update_wallet_env.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ startsWith(github.ref_name, 'rc/') }}
     steps:
       - name: Create Branch
-        uses: peterjgrainger/action-create-branch@v3.0.0
+        uses: peterjgrainger/action-create-branch@v4.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -22,12 +22,12 @@ jobs:
           sha: '${{ github.sha }}'
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: 'chore-update-wallet-env/${{github.ref_name}}'
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 
@@ -36,7 +36,7 @@ jobs:
           npm run update:wallet-env
 
       - name: Commit env file
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE: ${{ github.ref_name }}
@@ -63,7 +63,7 @@ jobs:
             })
 
       - name: Create PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE: ${{github.ref}}


### PR DESCRIPTION
GitHub Actions now warns that the Node.js 20 runtime used by our actions is deprecated and is being forced to Node.js 24. Upgrade the affected action references to versions whose manifests declare `runs.using: node24`, including the packaging, artifact upload, and comment steps shown in the warnings.

This updates 71 action references across 17 workflows. The Node.js 22 build/test matrix, explicit Yarn caching, action inputs, permissions, and triggers are unchanged. The Docker-based `repo-sync/pull-request` and composite `crate-ci/typos` actions do not require a Node runtime migration. The selected versions support the inputs and outputs used here and require Actions runner v2.327.1 or newer; these workflows use GitHub-hosted runners.

Validation:
- Verified the selected action manifests and checked relevant major-version migration notes.
- Verified that every changed line is an action reference; all other workflow lines are unchanged.
- `actionlint` reports no new issues. Its existing error about a `branches` filter on the `release` event in `merge_released_into_develop.yml` is also present on the base branch; validation passes with that diagnostic filtered.
- typos v1.50.1 and `git diff --check` pass.

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
